### PR TITLE
Ignore failed import for sparsezoo in engine

### DIFF
--- a/src/deepsparse/benchmark.py
+++ b/src/deepsparse/benchmark.py
@@ -280,5 +280,7 @@ class BenchmarkResults(Iterable):
         :param extras: Optional batch extras to store any other data for the run
         """
         self._results.append(
-            BatchBenchmarkResult(time_start, time_end, batch_size, inputs, outputs, extras)
+            BatchBenchmarkResult(
+                time_start, time_end, batch_size, inputs, outputs, extras
+            )
         )

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -12,7 +12,7 @@ from deepsparse.benchmark import BenchmarkResults
 
 try:
     from sparsezoo import Model, File
-except ImportError:
+except Exception as err:
     Model = object
     File = object
 

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -60,15 +60,15 @@ def _model_to_path(model: Union[str, Model, File]) -> str:
     if not model:
         raise ValueError("model must be a path, sparsezoo.Model, or sparsezoo.File")
 
-    if isinstance(model, Model):
+    if isinstance(model, str):
+        pass
+    elif isinstance(model, Model):
         # default to the main onnx file for the model
-        model = model.onnx_file
-
-    if isinstance(model, File):
+        model = model.onnx_file.downloaded_path()
+    elif isinstance(model, File):
         # get the downloaded_path -- will auto download if not on local system
         model = model.downloaded_path()
-
-    if not isinstance(model, str):
+    else:
         raise ValueError("unsupported type for model: {}".format(type(model)))
 
     if not os.path.exists(model):

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -62,13 +62,14 @@ def _model_to_path(model: Union[str, Model, File]) -> str:
 
     if isinstance(model, str):
         pass
-    elif isinstance(model, Model):
+    elif Model is not object and isinstance(model, Model):
         # default to the main onnx file for the model
         model = model.onnx_file.downloaded_path()
-    elif isinstance(model, File):
+    elif File is not object and isinstance(model, File):
         # get the downloaded_path -- will auto download if not on local system
         model = model.downloaded_path()
-    else:
+
+    if not isinstance(model, str):
         raise ValueError("unsupported type for model: {}".format(type(model)))
 
     if not os.path.exists(model):

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -9,7 +9,6 @@ import importlib
 import time
 
 from deepsparse.benchmark import BenchmarkResults
-from sparsezoo import Model, File
 
 try:
     from deepsparse.cpu import cpu_details
@@ -51,18 +50,7 @@ def _import_ort_nm():
 ENGINE_ORT = _import_ort_nm()
 
 
-def _model_to_path(model: Union[str, Model, File]) -> str:
-    if not model:
-        raise ValueError("model must be a path, sparsezoo.Model, or sparsezoo.File")
-
-    if isinstance(model, Model):
-        # default to the main onnx file for the model
-        model = model.onnx_file
-
-    if isinstance(model, File):
-        # get the downloaded_path -- will auto download if not on local system
-        model = model.downloaded_path()
-
+def _model_to_path(model: str) -> str:
     if not isinstance(model, str):
         raise ValueError("unsupported type for model: {}".format(type(model)))
 
@@ -104,8 +92,7 @@ class Engine(object):
     |    # create an engine for batch size 1 on all available cores
     |    engine = Engine("path/to/onnx", batch_size=1, num_cores=None)
 
-    :param model: Either a path to the model's onnx file, a sparsezoo Model object,
-        or a sparsezoo ONNX File object that defines the neural network
+    :param model: Either a path to the model's onnx file that defines the neural network
         graph definition to compile
     :param batch_size: The batch size of the inputs to be used with the engine
     :param num_cores: The number of physical cores to run the model on.
@@ -113,7 +100,7 @@ class Engine(object):
         in one socket for the current machine, default None
     """
 
-    def __init__(self, model: Union[str, Model, File], batch_size: int, num_cores: int):
+    def __init__(self, model: str, batch_size: int, num_cores: int):
         self._model_path = _model_to_path(model)
         self._batch_size = _validate_batch_size(batch_size)
         self._num_cores = _validate_num_cores(num_cores)
@@ -461,17 +448,14 @@ class Engine(object):
         }
 
 
-def compile_model(
-    model: Union[str, Model, File], batch_size: int = 1, num_cores: int = None
-) -> Engine:
+def compile_model(model: str, batch_size: int = 1, num_cores: int = None) -> Engine:
     """
     Convenience function to compile a model in the DeepSparse Engine
     from an ONNX file for inference.
     Gives defaults of batch_size == 1 and num_cores == None
     (will use all physical cores available on a single socket).
 
-    :param model: Either a path to the model's onnx file, a sparsezoo Model object,
-        or a sparsezoo ONNX File object that defines the neural network
+    :param model: Path to the model's onnx file that defines the neural network
         graph definition to compile
     :param batch_size: The batch size of the inputs to be used with the model
     :param num_cores: The number of physical cores to run the model on.
@@ -483,7 +467,7 @@ def compile_model(
 
 
 def analyze_model(
-    model: Union[str, Model, File],
+    model: str,
     inp: List[numpy.ndarray],
     batch_size: int = 1,
     num_cores: int = None,
@@ -499,9 +483,8 @@ def analyze_model(
     Gives defaults of batch_size == 1 and num_cores == None
     (will use all physical cores available on a single socket).
 
-    :param model: Either a path to the model's onnx file, a sparsezoo Model object,
-        or a sparsezoo ONNX File object that defines the neural network
-        graph definition to analyze
+    :param model: Path to the model's onnx file that defines the neural network
+        graph definition to compile
     :param inp: The list of inputs to pass to the engine for analyzing inference.
         The expected order is the inputs order as defined in the ONNX graph.
     :param batch_size: The batch size of the inputs to be used with the model


### PR DESCRIPTION
The engine doesn't have a way to install sparsezoo so we're removing it from engine.py for the moment