### PR TITLE
Update dev dependencies to have example requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ _dev_deps = [
     "wheel>=0.36.2",
     "pytest>=6.0.0",
     "sphinx-rtd-theme",
+    "onnxruntime>=1.4.0,<=1.6.0",
+    "flask>=1.0.0",
+    "flask-cors>=3.0.0",
 ]
 
 


### PR DESCRIPTION
`make test` relies on the dependencies in example folders' requirements.txt so we need to add them to dev dependencies