### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,9 +22,11 @@ CPU inference engine that delivers unprecedented performance for sparse models.
 .. raw:: html
 
     <div style="margin-bottom:16px;">
-        <a href="https://github.com/neuralmagic/deepsparse/blob/main/LICENSE">
-            <img alt="GitHub" src="https://img.shields.io/github/license/neuralmagic/deepsparse.svg?color=purple&style=for-the-badge" height=25 style="margin-bottom:4px;">
-        </a>
+    <a href="https://github.com/neuralmagic/deepsparse/blob/main/LICENSE-NEURALMAGIC"><img alt="GitHub" src="https://img.shields.io/static/v1.svg?label=LICENSE&message=neural%20magic%20engine&color=purple&style=for-the-badge" height=25>
+    </a>
+    <a href="https://github.com/neuralmagic/deepsparse/blob/main/LICENSE">
+        <img alt="GitHub" src="https://img.shields.io/github/license/neuralmagic/sparseml.svg?color=purple&style=for-the-badge" height=25>
+    </a>
         <a href="https://docs.neuralmagic.com/deepsparse/index.html">
             <img alt="Documentation" src="https://img.shields.io/website/http/docs.neuralmagic.com/deepsparse/index.html.svg?down_color=red&down_message=offline&up_message=online&style=for-the-badge" height=25 style="margin-bottom:4px;">
         </a>


### PR DESCRIPTION
adding license chip for nme; substituting in sparseml for deepsparse value in shields.io until we can debug why deepsparse won't work.