### PR TITLE
add compile engine from SparseZoo stub and benchmarking progress bar

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ ensure_newline_before_comments = True
 force_grid_wrap = 0
 include_trailing_comma = True
 known_first_party = deepsparse,sparsezoo
-known_third_party = numpy,onnx,requests,onnxruntime,flask,flask_cors
+known_third_party = numpy,onnx,requests,onnxruntime,flask,flask_cors,tqdm
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 line_length = 88

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if _NIGHTLY:
 binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
 
-_deps = ["numpy>=1.16.3", "onnx>=1.5.0,<1.8.0", "requests>=2.0.0"]
+_deps = ["numpy>=1.16.3", "onnx>=1.5.0,<1.8.0", "requests>=2.0.0", "tqdm>=4.0.0"]
 
 _nm_deps = [f"{'sparsezoo-nightly' if _NIGHTLY else 'sparsezoo'}~={_VERSION}"]
 

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -62,10 +62,12 @@ def _model_to_path(model: Union[str, Model, File]) -> str:
         raise ValueError("model must be a path, sparsezoo.Model, or sparsezoo.File")
 
     if isinstance(model, str) and model.startswith("zoo:"):
+        # load SparseZoo Model from stub
         if sparsezoo_import_error is not None:
             raise sparsezoo_import_error
-        model = Zoo.load_model_from_stub(model).onnx_file.downloaded_path()
-    elif Model is not object and isinstance(model, Model):
+        model = Zoo.load_model_from_stub(model)
+
+    if Model is not object and isinstance(model, Model):
         # default to the main onnx file for the model
         model = model.onnx_file.downloaded_path()
     elif File is not object and isinstance(model, File):


### PR DESCRIPTION
* enable one line SparseZoo integrations
* added an optional progress bar for benchmarking (tqdm should be a nested dependency)

```
benchmark_model(
    "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/base-none",
    sample_input,
    show_progress=True,
)
```
