### PR TITLE
Batch splitting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ from setuptools.command.install import install
 
 
 _PACKAGE_NAME = "deepsparse"
-_VERSION = "0.1.0"
+_VERSION = "0.1.1"
+_VERSION_MAJOR, _VERSION_MINOR, _VERSION_BUG = _VERSION.split(".")
+_VERSION_MAJOR_MINOR = f"{_VERSION_MAJOR}.{_VERSION_MINOR}"
 _NIGHTLY = "nightly" in sys.argv
 
 if _NIGHTLY:
@@ -40,7 +42,9 @@ binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
 _deps = ["numpy>=1.16.3", "onnx>=1.5.0,<1.8.0", "requests>=2.0.0"]
 
-_nm_deps = [f"{'sparsezoo-nightly' if _NIGHTLY else 'sparsezoo'}~={_VERSION}"]
+_nm_deps = [
+    f"{'sparsezoo-nightly' if _NIGHTLY else 'sparsezoo'}~={_VERSION_MAJOR_MINOR}"
+]
 
 _dev_deps = [
     "black>=20.8b1",

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -21,9 +21,9 @@ import time
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy
+from tqdm.auto import tqdm
 
 from deepsparse.benchmark import BenchmarkResults
-from tqdm.auto import tqdm
 
 
 try:
@@ -142,8 +142,11 @@ class Engine(object):
     """
 
     def __init__(
-        self, model: Union[str, Model, File], batch_size: int, num_cores: int,
-        num_sockets: int = None
+        self,
+        model: Union[str, Model, File],
+        batch_size: int,
+        num_cores: int,
+        num_sockets: int = None,
     ):
         self._model_path = _model_to_path(model)
         self._batch_size = _validate_batch_size(batch_size)
@@ -490,8 +493,10 @@ class Engine(object):
 
 
 def compile_model(
-    model: Union[str, Model, File], batch_size: int = 1, num_cores: int = None,
-    num_sockets: int = None
+    model: Union[str, Model, File],
+    batch_size: int = 1,
+    num_cores: int = None,
+    num_sockets: int = None,
 ) -> Engine:
     """
     Convenience function to compile a model in the DeepSparse Engine
@@ -524,7 +529,7 @@ def benchmark_model(
     include_inputs: bool = False,
     include_outputs: bool = False,
     show_progress: bool = False,
-    num_sockets: int = None
+    num_sockets: int = None,
 ) -> BenchmarkResults:
     """
     Convenience function to benchmark a model in the DeepSparse Engine
@@ -579,7 +584,7 @@ def analyze_model(
     optimization_level: int = 1,
     imposed_as: Optional[float] = None,
     imposed_ks: Optional[float] = None,
-    num_sockets: int = None
+    num_sockets: int = None,
 ) -> dict:
     """
     Function to analyze a model's performance in the DeepSparse Engine.


### PR DESCRIPTION
This adds support for batch-splitting in the engine, i.e. if the number of the sockets on the system is > 1, then the model is split into batch_size/num_sockets smaller models which each run on their own socket.

Batch splitting will be enabled whenever num_sockets >1.