### PR TITLE
Add version.py and exec in setup.py and docs conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,11 +29,13 @@ copyright = (
 author = "Neural Magic"
 
 # The full version, including alpha/beta/rc tags
-ver_major, ver_minor, ver_bug, ver_build = __version__.split(".") + (
-    [None] if len(__version__.split(".")) < 4 else []
-)
-version = f"{ver_major}.{ver_minor}"
-release = __version__
+version = "unknown"
+version_major_minor = version
+# load and overwrite version info from sparseml package
+exec(open(os.path.join(os.pardir, os.pardir, "src", "deepsparse", "version.py")).read())
+release = version
+version = version_major_minor
+print(f"loaded versions from src/deepsparse/version.py and set to {release}, {version}")
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,7 @@ author = "Neural Magic"
 # The full version, including alpha/beta/rc tags
 version = "unknown"
 version_major_minor = version
-# load and overwrite version info from sparseml package
+# load and overwrite version info from deepsparse package
 exec(open(os.path.join(os.pardir, os.pardir, "src", "deepsparse", "version.py")).read())
 release = version
 version = version_major_minor

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,6 @@
 import os
 import sys
 
-from deepsparse import __version__
-
 sys.path.insert(0, os.path.abspath("../.."))
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools.command.install import install
 
 version = "unknown"
 version_major_minor = version
-# load and overwrite version info from sparseml package
+# load and overwrite version info from deepsparse package
 exec(open(os.path.join("src", "deepsparse", "version.py")).read())
 print(f"loaded version {version} from src/deepsparse/version.py")
 

--- a/setup.py
+++ b/setup.py
@@ -21,15 +21,14 @@ from typing import Dict, List, Tuple
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-from deepsparse import __version__
 
+version = "unknown"
+version_major_minor = version
+# load and overwrite version info from sparseml package
+exec(open(os.path.join("src", "deepsparse", "version.py")).read())
+print(f"loaded version {version} from src/deepsparse/version.py")
 
 _PACKAGE_NAME = "deepsparse"
-_VERSION = __version__
-_VERSION_MAJOR, _VERSION_MINOR, _VERSION_BUG, _VERSION_BUILD = _VERSION.split(".") + (
-    [None] if len(_VERSION.split(".")) < 4 else []
-)
-_VERSION_MAJOR_MINOR = f"{_VERSION_MAJOR}.{_VERSION_MINOR}"
 _NIGHTLY = "nightly" in sys.argv
 
 if _NIGHTLY:
@@ -45,7 +44,7 @@ binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 _deps = ["numpy>=1.16.3", "onnx>=1.5.0,<1.8.0", "requests>=2.0.0", "tqdm>=4.0.0"]
 
 _nm_deps = [
-    f"{'sparsezoo-nightly' if _NIGHTLY else 'sparsezoo'}~={_VERSION_MAJOR_MINOR}"
+    f"{'sparsezoo-nightly' if _NIGHTLY else 'sparsezoo'}~={version_major_minor}"
 ]
 
 _dev_deps = [
@@ -113,7 +112,7 @@ def _setup_long_description() -> Tuple[str, str]:
 
 setup(
     name=_PACKAGE_NAME,
-    version=_VERSION,
+    version=version,
     author="Neuralmagic, Inc.",
     author_email="support@neuralmagic.com",
     description=(

--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -21,5 +21,7 @@ __all__ = ["__version__"]
 __version__ = "0.0.0"
 
 version = __version__
-version_major, version_minor, version_bug = version.split(".")
+version_major, version_minor, version_bug, version_build = version.split(".") + (
+    [None] if len(version.split(".")) < 4 else []
+) # handle conditional for version being 3 parts or 4 (4 containing build date)
 version_major_minor = f"{version_major}.{version_minor}"

--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Placeholder file, will be overwritten by the backend on build.
+Functionality for storing and setting the version info for DeepSparse
+"""
+
+__all__ = ["__version__"]
+__version__ = "0.0.0"
+
+version = __version__
+version_major, version_minor, version_bug = version.split(".")
+version_major_minor = f"{version_major}.{version_minor}"

--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -17,7 +17,14 @@ Placeholder file, will be overwritten by the backend on build.
 Functionality for storing and setting the version info for DeepSparse
 """
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "version",
+    "version_major",
+    "version_minor",
+    "version_bug",
+    "version_major_minor",
+]
 __version__ = "0.0.0"
 
 version = __version__

--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -23,6 +23,7 @@ __all__ = [
     "version_major",
     "version_minor",
     "version_bug",
+    "version_build",
     "version_major_minor",
 ]
 __version__ = "0.0.0"


### PR DESCRIPTION
Changing so that we don't have a requirement of the user setting the pythonpath for builds and docs to work with new version