### PR TITLE
Version fix

### DIFF
--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -26,7 +26,7 @@ __all__ = [
     "version_build",
     "version_major_minor",
 ]
-__version__ = "0.0.0"
+__version__ = "0.2.0"
 
 version = __version__
 version_major, version_minor, version_bug, version_build = version.split(".") + (


### PR DESCRIPTION
Unfortunately can't get by with loading the version from the backend and need to set version in the version.py file. If we don't, the sphinx-multiversion will not work correctly because it checkouts the repo for each version to build in a subdirectory.