### PR TITLE
Only generate default splash message if generated-version.py does not exist

### DIFF
--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -45,12 +45,12 @@ if os.path.isfile(_gen_version_file):
 else:
     __version__ = "0.2.0"
     version = __version__
+    splash = (
+        "DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. "
+        f"version: {version} (release)"
+    )
 
 version_major, version_minor, version_bug, version_build = version.split(".") + (
     [None] if len(version.split(".")) < 4 else []
 )  # handle conditional for version being 3 parts or 4 (4 containing build date)
 version_major_minor = f"{version_major}.{version_minor}"
-splash = (
-    "DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. "
-    f"version: {version} (release)"
-)


### PR DESCRIPTION
I didn't look at the last pull request closely enough.  The default splash message should only be generated if generated-version.py is not present.  Otherwise it will be provided by generated-version.py.
