### PR TITLE
Fixes for build version on release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -765,4 +765,4 @@ MigrationBackup/
 
 licenses/
 engine-version.txt
-src/deepsparse/generated-version.py
+src/deepsparse/generated_version.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,11 +29,15 @@ author = "Neural Magic"
 # The full version, including alpha/beta/rc tags
 version = "unknown"
 version_major_minor = version
-# load and overwrite version info from deepsparse package
-exec(open(os.path.join(os.pardir, "src", "deepsparse", "version.py")).read())
+
+# load and overwrite version and release info from deepsparse package
+version_path = os.path.join(os.pardir, "src", "deepsparse", "generated_version.py")
+if not os.path.exists(version_path):
+    version_path = os.path.join(os.pardir, "src", "deepsparse", "version.py")
+exec(open(version_path).read())
 release = version
 version = version_major_minor
-print(f"loaded versions from src/deepsparse/version.py and set to {release}, {version}")
+print(f"loaded version {release} from {version_path}")
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,11 @@ version = "unknown"
 version_major_minor = version
 
 # load and overwrite version and release info from deepsparse package
-exec(open(os.path.join("src", "deepsparse", "version.py")).read())
-print(f"loaded version {version} from src/deepsparse/version.py")
+version_path = os.path.join("src", "deepsparse", "generated_version.py")
+if not os.path.exists(version_path):
+    version_path = os.path.join("src", "deepsparse", "version.py")
+exec(open(version_path).read())
+print(f"loaded version {version} from {version_path}")
 
 _PACKAGE_NAME = "deepsparse" if is_release else "deepsparse-nightly"
 

--- a/src/deepsparse/__init__.py
+++ b/src/deepsparse/__init__.py
@@ -19,11 +19,6 @@ for Neural Networks on commodity CPUs.
 
 # flake8: noqa
 
-try:
-    from deepsparse.version import version as __version__
-except Exception as err:
-    __version__ = "unknown"
-
 from .cpu import (
     cpu_architecture,
     cpu_avx2_compatible,
@@ -31,3 +26,4 @@ from .cpu import (
     cpu_vnni_compatible,
 )
 from .engine import *
+from .version import __version__

--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import pathlib
-
 
 """
 Functionality for storing and setting the version info for DeepSparse.  If
-a file named 'generated-version.py' exists, read version info from there, otherwise
+a file named 'generated_version.py' exists, read version info from there, otherwise
 fall back to defaults.
 """
 
@@ -36,27 +33,20 @@ __all__ = [
 ]
 
 
-# check for the backend's built version file, if it exists use that for version info
-# otherwise, fall back to version info in this file
-_deepsparse_dir = pathlib.Path(__file__).parent.absolute()
-_gen_version_file = (
-    os.path.join(_deepsparse_dir, "generated-version.py")
-    if __file__ != "<input>"
-    else os.path.join(_deepsparse_dir, "src", "deepsparse", "generated-version.py")
-)  # <input> is a special case from exec on the file done in setup.py and docs build
-
-if os.path.isfile(_gen_version_file):
-    exec(open(_gen_version_file).read())
-else:
-    __version__ = "0.2.0"
-    version = __version__
+try:
+    # check for the backend's built version file, if it exists use that for version info
+    from deepsparse.generated_version import is_release, splash, version
+except Exception:
+    # otherwise, fall back to version info in this file
+    version = "0.2.0"
+    is_release = False
     splash = (
         "DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. "
         f"version: {version} (release)"
     )
 
-is_release = len(version.split(".")) < 4  # build number not included for releases
+__version__ = version
 version_major, version_minor, version_bug, version_build = version.split(".") + (
-    [None] if is_release else []
+    [None] if len(version.split(".")) < 4 else []
 )  # handle conditional for version being 3 parts or 4 (4 containing build date)
 version_major_minor = f"{version_major}.{version_minor}"


### PR DESCRIPTION
Changing it so that docs/conf.py and setup.py conditionally load generated_version.py or version.py based on what's available.