### PR TITLE
[YOLO examples] support for anchor point override

### DIFF
--- a/examples/ultralytics-yolo/annotate.py
+++ b/examples/ultralytics-yolo/annotate.py
@@ -23,6 +23,7 @@ usage: annotate.py [-h] --source SOURCE [-e {deepsparse,onnxruntime,torch}]
                    [-c NUM_CORES] [-s NUM_SOCKETS] [-q] [--fp16]
                    [--device DEVICE] [--save-dir SAVE_DIR] [--name NAME]
                    [--target-fps TARGET_FPS] [--no-save]
+                   [--model-config MODEL_CONFIG]
                    model_filepath
 
 Annotate images, videos, and streams with sparsified YOLO models
@@ -77,6 +78,10 @@ optional arguments:
                         None
   --no-save             set flag when source is from webcam to not save
                         results. not supported for non-webcam sources
+  --model-config MODEL_CONFIG
+                        YOLO config YAML file to override default anchor
+                        points when post-processing. Defaults to use standard
+                        YOLOv3/YOLOv5 anchors
 
 ##########
 Example command for running webcam annotations with pruned quantized YOLOv3:
@@ -253,6 +258,15 @@ def parse_args(arguments=None):
             "for non-webcam sources"
         ),
     )
+    parser.add_argument(
+        "--model-config",
+        type=str,
+        default=None,
+        help=(
+            "YOLO config YAML file to override default anchor points when "
+            "post-processing. Defaults to use standard YOLOv3/YOLOv5 anchors"
+        ),
+    )
 
     args = parser.parse_args(args=arguments)
     if args.engine == TORCH_ENGINE and args.device is None:
@@ -391,7 +405,7 @@ def annotate(args):
     is_webcam = args.source.isnumeric()
 
     postprocessor = (
-        YoloPostprocessor(args.image_shape)
+        YoloPostprocessor(args.image_shape, args.model_config)
         if args.engine in [DEEPSPARSE_ENGINE, ORT_ENGINE]
         else None
     )

--- a/examples/ultralytics-yolo/benchmark.py
+++ b/examples/ultralytics-yolo/benchmark.py
@@ -24,6 +24,7 @@ usage: benchmark.py [-h] [-e {deepsparse,onnxruntime,torch}]
                     [-b BATCH_SIZE] [-c NUM_CORES] [-s NUM_SOCKETS]
                     [-i NUM_ITERATIONS] [-w NUM_WARMUP_ITERATIONS] [-q]
                     [--fp16] [--device DEVICE]
+                    [--model-config MODEL_CONFIG]
                     model_filepath
 
 Benchmark sparsified YOLO models
@@ -76,6 +77,10 @@ optional arguments:
                         benchmarking. Default is 'cpu' unless running a torch
                         benchmark and cuda is available, then cuda on device
                         0. i.e. 'cuda', 'cpu', 0, 'cuda:1'
+  --model-config MODEL_CONFIG
+                        YOLO config YAML file to override default anchor
+                        points when post-processing. Defaults to use standard
+                        YOLOv3/YOLOv5 anchors
 
 ##########
 Example command for running a benchmark on a pruned quantized YOLOv3:
@@ -254,6 +259,15 @@ def parse_args(arguments=None):
             "benchmarking only supported for torch benchmarking. Default is 'cpu' "
             "unless running a torch benchmark and cuda is available, then cuda on "
             "device 0. i.e. 'cuda', 'cpu', 0, 'cuda:1'"
+        ),
+    )
+    parser.add_argument(
+        "--model-config",
+        type=str,
+        default=None,
+        help=(
+            "YOLO config YAML file to override default anchor points when "
+            "post-processing. Defaults to use standard YOLOv3/YOLOv5 anchors"
         ),
     )
 
@@ -449,7 +463,7 @@ def benchmark_yolo(args):
     )
 
     postprocessor = (
-        YoloPostprocessor(args.image_shape)
+        YoloPostprocessor(args.image_shape, args.model_config)
         if args.engine in [DEEPSPARSE_ENGINE, ORT_ENGINE]
         else None
     )

--- a/examples/ultralytics-yolo/server.py
+++ b/examples/ultralytics-yolo/server.py
@@ -19,7 +19,7 @@ using the DeepSparse Engine as the inference backend
 ##########
 Command help:
 usage: server.py [-h] [-b BATCH_SIZE] [-c NUM_CORES] [-a ADDRESS] [-p PORT]
-                 [-q]
+                 [-q] [--model-config MODEL_CONFIG]
                  onnx_filepath
 
 Host a Yolo ONNX model as a server, using the DeepSparse Engine and Flask
@@ -41,6 +41,10 @@ optional arguments:
   -q, --quantized-inputs
                         Set flag to execute inferences with int8 inputs
                         instead of float32
+  --model-config MODEL_CONFIG
+                        YOLO config YAML file to override default anchor
+                        points when post-processing. Defaults to use standard
+                        YOLOv3/YOLOv5 anchors
 
 ##########
 Example command for running:
@@ -107,8 +111,17 @@ def parse_args():
     parser.add_argument(
         "-q",
         "--quantized-inputs",
-        help=("Set flag to execute inferences with int8 inputs instead of float32"),
+        help="Set flag to execute inferences with int8 inputs instead of float32",
         action="store_true",
+    )
+    parser.add_argument(
+        "--model-config",
+        type=str,
+        default=None,
+        help=(
+            "YOLO config YAML file to override default anchor points when "
+            "post-processing. Defaults to use standard YOLOv3/YOLOv5 anchors"
+        ),
     )
 
     return parser.parse_args()
@@ -121,7 +134,7 @@ def create_and_run_model_server(
     engine = compile_model(model_path, batch_size, num_cores)
     print(engine)
 
-    postprocessor = YoloPostprocessor()
+    postprocessor = YoloPostprocessor(cfg=args.model_config)
 
     app = flask.Flask(__name__)
     CORS(app)


### PR DESCRIPTION
use non-default anchor grids for YOLO models in examples by passing in `--model-config /path/to/yolo/model/cfg.yaml`.
Standard 3 tier YOLOv3 and YOLOv5 models use the same grids which are the default if no config is provided