### PR TITLE
[YOLO examples] detect postprocessing in ONNX graph

### DIFF
--- a/examples/ultralytics-yolo/README.md
+++ b/examples/ultralytics-yolo/README.md
@@ -54,7 +54,7 @@ run the following examples.
 to run inferences on images, videos, or webcam streams. For a full list of options
 `python annotate.py -h`.
 
-To run pruned-quantized YOLOv3 on a local webcam run:https://github.com/neuralmagic/deepsparse/pull/147
+To run pruned-quantized YOLOv3 on a local webcam run:
 ```bash
 python annotate.py \
     zoo:cv/detection/yolo_v3-spp/pytorch/ultralytics/coco/pruned_quant-aggressive_94 \

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -13,11 +13,7 @@
 # limitations under the License.
 
 """
-<<<<<<< HEAD
 Utilities for YOLO pre- and post-processing for DeepSparse pipelines
-=======
-Utilities for YOLO pre and post processing for DeepSparse pipelines
->>>>>>> moving YOLOv3 examples to unified YOLO examples
 
 Postprocessing is currently tied to yolov3-spp, modify anchor and output
 variables if using a different model.
@@ -37,10 +33,7 @@ import onnx
 import cv2
 import torch
 import torchvision
-<<<<<<< HEAD
 import yaml
-=======
->>>>>>> moving YOLOv3 examples to unified YOLO examples
 from sparseml.onnx.utils import get_tensor_dim_shape, set_tensor_dim_shape
 from sparseml.utils import create_dirs
 from sparsezoo import Zoo
@@ -56,27 +49,15 @@ __all__ = [
 ]
 
 
-<<<<<<< HEAD
-# available local YOLO configs
-
-
 # Default YOLO anchor grids
 _YOLO_DEFAULT_ANCHORS = [
-=======
-# Yolo V3 specific variables
-_YOLO_V3_ANCHORS = [
->>>>>>> moving YOLOv3 examples to unified YOLO examples
     torch.Tensor([[10, 13], [16, 30], [33, 23]]),
     torch.Tensor([[30, 61], [62, 45], [59, 119]]),
     torch.Tensor([[116, 90], [156, 198], [373, 326]]),
 ]
-<<<<<<< HEAD
 _YOLO_DEFAULT_ANCHOR_GRIDS = [
     t.clone().view(1, -1, 1, 1, 2) for t in _YOLO_DEFAULT_ANCHORS
 ]
-=======
-_YOLO_V3_ANCHOR_GRIDS = [t.clone().view(1, -1, 1, 1, 2) for t in _YOLO_V3_ANCHORS]
->>>>>>> moving YOLOv3 examples to unified YOLO examples
 
 
 def get_yolo_loader_and_saver(
@@ -378,26 +359,17 @@ def load_image(
 
 class YoloPostprocessor:
     """
-<<<<<<< HEAD
     Class for performing post-processing of YOLO model predictions
-=======
-    Class for performing postprocessing of YOLO model predictions
->>>>>>> moving YOLOv3 examples to unified YOLO examples
 
     :param image_size: size of input image to model. used to calculate stride based on
         output shapes
     """
 
-<<<<<<< HEAD
     def __init__(self, image_size: Tuple[int] = (640, 640), cfg: Optional[str] = None):
         self._image_size = image_size
         self._anchor_grids = (
             self._load_cfg_anchor_grid(cfg) if cfg else _YOLO_DEFAULT_ANCHOR_GRIDS
         )
-=======
-    def __init__(self, image_size: Tuple[int] = (640, 640)):
-        self._image_size = image_size
->>>>>>> moving YOLOv3 examples to unified YOLO examples
         self._grids = {}  # Dict[Tuple[int], torch.Tensor]
 
     def pre_nms_postprocess(self, outputs: List[numpy.ndarray]) -> torch.Tensor:
@@ -414,19 +386,11 @@ class YoloPostprocessor:
             # get grid and stride
             grid_shape = pred.shape[2:4]
             grid = self._get_grid(grid_shape)
-<<<<<<< HEAD
-=======
-            anchor_grid = _YOLO_V3_ANCHOR_GRIDS[idx]
->>>>>>> moving YOLOv3 examples to unified YOLO examples
             stride = self._image_size[0] / grid_shape[0]
 
             # decode xywh box values
             pred[..., 0:2] = (pred[..., 0:2] * 2.0 - 0.5 + grid) * stride
-<<<<<<< HEAD
             pred[..., 2:4] = (pred[..., 2:4] * 2) ** 2 * self._anchor_grids[idx]
-=======
-            pred[..., 2:4] = (pred[..., 2:4] * 2) ** 2 * anchor_grid
->>>>>>> moving YOLOv3 examples to unified YOLO examples
             # flatten anchor and grid dimensions ->
             #       (bs, num_predictions, num_classes + 5)
             processed_outputs.append(pred.view(pred.size(0), -1, pred.size(-1)))
@@ -444,7 +408,6 @@ class YoloPostprocessor:
             ).float()
         return self._grids[grid_shape]
 
-<<<<<<< HEAD
     @staticmethod
     def _load_cfg_anchor_grid(cfg: str) -> List[torch.Tensor]:
         with open(cfg) as f:
@@ -459,8 +422,6 @@ class YoloPostprocessor:
         anchors = [torch.Tensor(_split_to_coords(coords)) for coords in anchors]
         return [t.clone().view(1, -1, 1, 1, 2) for t in anchors]
 
-=======
->>>>>>> moving YOLOv3 examples to unified YOLO examples
 
 def postprocess_nms(outputs: torch.Tensor) -> List[numpy.ndarray]:
     """

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -45,6 +45,7 @@ __all__ = [
     "YoloPostprocessor",
     "postprocess_nms",
     "modify_yolo_onnx_input_shape",
+    "yolo_onnx_has_postprocessing",
     "annotate_image",
 ]
 
@@ -429,6 +430,8 @@ def postprocess_nms(outputs: torch.Tensor) -> List[numpy.ndarray]:
     :return: List of numpy arrays of NMS predictions for each image in the batch
     """
     # run nms in PyTorch, only post-process first output
+    if isinstance(outputs, numpy.ndarray):
+        outputs = torch.from_numpy(outputs)
     nms_outputs = _non_max_suppression(outputs)
     return [output.cpu().numpy() for output in nms_outputs]
 
@@ -488,6 +491,27 @@ def modify_yolo_onnx_input_shape(
     )
 
     return tmp_file.name, tmp_file
+
+
+def yolo_onnx_has_postprocessing(model_path: str) -> bool:
+    """
+    :param model_path: file path to YOLO ONNX model
+    :return: True if YOLO postprocessing (pre-nms) is included in the ONNX graph,
+        this is assumed to be when the first output of the model has fewer dimensions
+        than the other outputs as the grid dimensions have been flattened
+    """
+    model = onnx.load(model_path)
+
+    # get number of dimensions in each output
+    outputs_num_dims = [
+        len(output.type.tensor_type.shape.dim) for output in model.graph.output
+    ]
+
+    # assume if only one output, then it is post-processed
+    if len(outputs_num_dims) == 1:
+        return True
+
+    return all(num_dims > outputs_num_dims[0] for num_dims in outputs_num_dims[1:])
 
 
 _YOLO_CLASSES = [

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 """
+<<<<<<< HEAD
 Utilities for YOLO pre- and post-processing for DeepSparse pipelines
+=======
+Utilities for YOLO pre and post processing for DeepSparse pipelines
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
 
 Postprocessing is currently tied to yolov3-spp, modify anchor and output
 variables if using a different model.
@@ -33,7 +37,10 @@ import onnx
 import cv2
 import torch
 import torchvision
+<<<<<<< HEAD
 import yaml
+=======
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
 from sparseml.onnx.utils import get_tensor_dim_shape, set_tensor_dim_shape
 from sparseml.utils import create_dirs
 from sparsezoo import Zoo
@@ -49,18 +56,27 @@ __all__ = [
 ]
 
 
+<<<<<<< HEAD
 # available local YOLO configs
 
 
 # Default YOLO anchor grids
 _YOLO_DEFAULT_ANCHORS = [
+=======
+# Yolo V3 specific variables
+_YOLO_V3_ANCHORS = [
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
     torch.Tensor([[10, 13], [16, 30], [33, 23]]),
     torch.Tensor([[30, 61], [62, 45], [59, 119]]),
     torch.Tensor([[116, 90], [156, 198], [373, 326]]),
 ]
+<<<<<<< HEAD
 _YOLO_DEFAULT_ANCHOR_GRIDS = [
     t.clone().view(1, -1, 1, 1, 2) for t in _YOLO_DEFAULT_ANCHORS
 ]
+=======
+_YOLO_V3_ANCHOR_GRIDS = [t.clone().view(1, -1, 1, 1, 2) for t in _YOLO_V3_ANCHORS]
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
 
 
 def get_yolo_loader_and_saver(
@@ -362,17 +378,26 @@ def load_image(
 
 class YoloPostprocessor:
     """
+<<<<<<< HEAD
     Class for performing post-processing of YOLO model predictions
+=======
+    Class for performing postprocessing of YOLO model predictions
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
 
     :param image_size: size of input image to model. used to calculate stride based on
         output shapes
     """
 
+<<<<<<< HEAD
     def __init__(self, image_size: Tuple[int] = (640, 640), cfg: Optional[str] = None):
         self._image_size = image_size
         self._anchor_grids = (
             self._load_cfg_anchor_grid(cfg) if cfg else _YOLO_DEFAULT_ANCHOR_GRIDS
         )
+=======
+    def __init__(self, image_size: Tuple[int] = (640, 640)):
+        self._image_size = image_size
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
         self._grids = {}  # Dict[Tuple[int], torch.Tensor]
 
     def pre_nms_postprocess(self, outputs: List[numpy.ndarray]) -> torch.Tensor:
@@ -389,11 +414,19 @@ class YoloPostprocessor:
             # get grid and stride
             grid_shape = pred.shape[2:4]
             grid = self._get_grid(grid_shape)
+<<<<<<< HEAD
+=======
+            anchor_grid = _YOLO_V3_ANCHOR_GRIDS[idx]
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
             stride = self._image_size[0] / grid_shape[0]
 
             # decode xywh box values
             pred[..., 0:2] = (pred[..., 0:2] * 2.0 - 0.5 + grid) * stride
+<<<<<<< HEAD
             pred[..., 2:4] = (pred[..., 2:4] * 2) ** 2 * self._anchor_grids[idx]
+=======
+            pred[..., 2:4] = (pred[..., 2:4] * 2) ** 2 * anchor_grid
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
             # flatten anchor and grid dimensions ->
             #       (bs, num_predictions, num_classes + 5)
             processed_outputs.append(pred.view(pred.size(0), -1, pred.size(-1)))
@@ -411,6 +444,7 @@ class YoloPostprocessor:
             ).float()
         return self._grids[grid_shape]
 
+<<<<<<< HEAD
     @staticmethod
     def _load_cfg_anchor_grid(cfg: str) -> List[torch.Tensor]:
         with open(cfg) as f:
@@ -425,6 +459,8 @@ class YoloPostprocessor:
         anchors = [torch.Tensor(_split_to_coords(coords)) for coords in anchors]
         return [t.clone().view(1, -1, 1, 1, 2) for t in anchors]
 
+=======
+>>>>>>> moving YOLOv3 examples to unified YOLO examples
 
 def postprocess_nms(outputs: torch.Tensor) -> List[numpy.ndarray]:
     """


### PR DESCRIPTION
the DeepSparse engine has planned support for YOLO post-processing. This change adds a simple rule for deciding if postprocessing is included in the YOLO ONNX graph and skips additional postprocessing if it is.

This soft rule is that the first output of the model will have fewer dimensions than the other (original) outputs since the grid based dimensions will be flattened in the post-processed outputs. (e.g. the base yolov3 and yolov5 models have 5 dims in their original outputs and 3 in the postprocessed output)