### PR TITLE
[YOLO examples] torch quant CPU benchmark

### DIFF
--- a/examples/ultralytics-yolo/benchmark.py
+++ b/examples/ultralytics-yolo/benchmark.py
@@ -135,6 +135,7 @@ from deepsparse import compile_model
 from deepsparse.benchmark import BenchmarkResults
 from deepsparse_utils import (
     YoloPostprocessor,
+    download_torch_model_if_stub,
     load_image,
     modify_yolo_onnx_input_shape,
     postprocess_nms,
@@ -397,6 +398,8 @@ def _load_model(args) -> (Any, bool):
         )
     elif args.engine == TORCH_ENGINE:
         print(f"loading torch model for {args.model_filepath}")
+        args.model_filepath = download_torch_model_if_stub(args.model_filepath)
+
         model = torch.load(args.model_filepath, map_location=args.device)
 
         if isinstance(model, dict):

--- a/examples/ultralytics-yolo/benchmark.py
+++ b/examples/ultralytics-yolo/benchmark.py
@@ -408,6 +408,7 @@ def _load_model(args) -> (Any, bool):
 
         if args.recipe:
             manager = ScheduledModifierManager.from_yaml(args.recipe)
+            model.float()  # apply recipe with float32 params
             set_params_requires_grad(model, True)  # required to enable recipe hooks
             manager.apply(model)
             set_params_requires_grad(model, False)  # disable for benchmarking

--- a/examples/ultralytics-yolo/benchmark.py
+++ b/examples/ultralytics-yolo/benchmark.py
@@ -122,6 +122,7 @@ import argparse
 import glob
 import os
 import time
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Iterable, List, Optional, Tuple, Union
 
@@ -424,10 +425,8 @@ def _load_model(args) -> (Any, bool):
 
         if args.device == "cpu":
             # convert any QAT models to fully quantized for CPU execution
-            try:
+            with suppress(Exception):
                 model = torch.quantization.convert(model)
-            except Exception:
-                pass
 
         has_postprocessing = True
 

--- a/examples/ultralytics-yolo/benchmark.py
+++ b/examples/ultralytics-yolo/benchmark.py
@@ -407,6 +407,7 @@ def _load_model(args) -> (Any, bool):
 
         if args.recipe:
             manager = ScheduledModifierManager.from_yaml(args.recipe)
+            model.train()
             manager.apply(model)
 
         model.eval()

--- a/examples/ultralytics-yolo/benchmark.py
+++ b/examples/ultralytics-yolo/benchmark.py
@@ -139,6 +139,7 @@ from deepsparse_utils import (
     load_image,
     modify_yolo_onnx_input_shape,
     postprocess_nms,
+    set_params_requires_grad,
     yolo_onnx_has_postprocessing,
 )
 from sparseml.onnx.utils import override_model_batch_size
@@ -407,8 +408,9 @@ def _load_model(args) -> (Any, bool):
 
         if args.recipe:
             manager = ScheduledModifierManager.from_yaml(args.recipe)
-            model.train()
+            set_params_requires_grad(model, True)  # required to enable recipe hooks
             manager.apply(model)
+            set_params_requires_grad(model, False)  # disable for benchmarking
 
         model.eval()
         model.to(args.device)
@@ -417,7 +419,6 @@ def _load_model(args) -> (Any, bool):
             print("Using half precision")
             model.half()
         else:
-            print("Using full precision")
             model.float()
 
         if args.device == "cpu":

--- a/examples/ultralytics-yolo/benchmark.py
+++ b/examples/ultralytics-yolo/benchmark.py
@@ -405,12 +405,12 @@ def _load_model(args) -> (Any, bool):
         if isinstance(model, dict):
             model = model["model"]
 
-        model.eval()
-        model.to(args.device)
-
         if args.recipe:
             manager = ScheduledModifierManager.from_yaml(args.recipe)
             manager.apply(model)
+
+        model.eval()
+        model.to(args.device)
 
         if args.fp16:
             print("Using half precision")

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -50,6 +50,7 @@ __all__ = [
     "annotate_image",
     "download_model_if_stub",
     "download_torch_model_if_stub",
+    "set_params_requires_grad",
 ]
 
 
@@ -573,6 +574,15 @@ def download_torch_model_if_stub(path: str) -> str:
         print(f"model with stub {path} downloaded to {downloaded_path}")
         return downloaded_path
     return path
+
+
+def set_params_requires_grad(module: torch.nn.Module, requires_grad: bool):
+    """
+    :param module: module to set the requires_grad attribute of each param for
+    :param requires_grad: value to set requires_grad to
+    """
+    for param in module.parameters():
+        param.requires_grad = requires_grad
 
 
 _YOLO_CLASSES = [

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -562,7 +562,9 @@ def download_torch_model_if_stub(path: str) -> str:
         model = Zoo.load_model_from_stub(path)
 
         ckpt_file_idxs = [
-            idx for idx, file in model.framework_files if ".ckpt.pt" in file.path
+            idx
+            for idx, file in enumerate(model.framework_files)
+            if ".ckpt.pt" in file.path
         ]
 
         # return first ckpt file if it exists, otherwise, first framework file

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -49,6 +49,7 @@ __all__ = [
     "yolo_onnx_has_postprocessing",
     "annotate_image",
     "download_model_if_stub",
+    "download_torch_model_if_stub",
 ]
 
 
@@ -541,9 +542,34 @@ def download_model_if_stub(path: str) -> str:
     """
     if path.startswith("zoo"):
         model = Zoo.load_model_from_stub(path)
-        downloded_path = model.onnx_file.downloaded_path()
-        print(f"model with stub {path} downloaded to {downloded_path}")
-        return downloded_path
+        downloaded_path = model.onnx_file.downloaded_path()
+        print(f"model with stub {path} downloaded to {downloaded_path}")
+        return downloaded_path
+    return path
+
+
+def download_torch_model_if_stub(path: str) -> str:
+    """
+    Utility method to download torch model if path is a SparseZoo stub
+    If the model ckpt file exists, that checkpoint will be prefered
+
+    :param path: file path to YOLO PyTorch model or SparseZoo stub of the model
+        to be loaded
+    :return: filepath to the downloaded torch checkpoint model or
+        original path if it's not a SparseZoo Stub
+    """
+    if path.startswith("zoo"):
+        model = Zoo.load_model_from_stub(path)
+
+        ckpt_file_idxs = [
+            idx for idx, file in model.framework_files if ".ckpt.pt" in file.path
+        ]
+
+        # return first ckpt file if it exists, otherwise, first framework file
+        target_file_idx = ckpt_file_idxs[0] if ckpt_file_idxs else 0
+        downloaded_path = model.framework_files[target_file_idx].downloaded_path()
+        print(f"model with stub {path} downloaded to {downloaded_path}")
+        return downloaded_path
     return path
 
 


### PR DESCRIPTION
supports loading a recipe and model from sparsezoo, applying that recipe to the model, and then possibly converting it to a quantized torch model to run on CPU.

`torch.quantization.convert` has no affect on normal FP32 models