### PR TITLE
Add: Annotation support for Image classification Models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -767,3 +767,7 @@ licenses/
 engine-version.txt
 src/deepsparse/generated_version.py
 .idea/*
+
+# Annotation results
+
+examples/classification/annotation_results/

--- a/examples/classification/README.md
+++ b/examples/classification/README.md
@@ -16,7 +16,9 @@ limitations under the License.
 
 # Image Classification Example
 
-This directory holds example scripts and notebooks for benchmarking and serving image classification models using the [DeepSparse Engine](https://docs.neuralmagic.com/deepsparse/index.html).
+This directory holds example scripts and notebooks for annotating, benchmarking 
+and serving
+image classification models using the [DeepSparse Engine](https://docs.neuralmagic.com/deepsparse/index.html).
 These examples can load pre-trained, sparsified models from [SparseZoo](https://github.com/neuralmagic/sparsezoo) 
 or you can specify your own [ONNX](https://github.com/onnx/onnx) file.
 
@@ -31,7 +33,7 @@ pip3 install -r requirements.txt
 
 There is a step-by-step [classification.ipynb notebook](https://github.com/neuralmagic/deepsparse/blob/main/examples/classification/classification.ipynb) for this example.
 
-## Execution
+## Classification Example
 
 Example command for running a `mobilenet_v2` model with batch size 8 and 4 cores used:
 ```bash
@@ -101,6 +103,27 @@ for batch in batch_loader:
     print(f"outputs:{out}")
 ```
 
+## Annotation Example
+
+[annotate.py](./annotate.py) is a script for using sparsified (or 
+non-sparsified) Image classification models to run annotation on images, 
+videos, or webcam streams. For a full list of 
+options
+`python annotate.py -h`.
+
+To run pruned resnet-50 on a local webcam run:
+```bash
+python annotate.py \
+    zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned-conservative \
+    --source 0 \
+    --image-shape 224 224 \
+    --no-save  # webcam only
+```
+
+In addition to webcam, `--source` can take a path to a `.jpg` file, directory or glob path
+of `.jpg` files, or path to a `.mp4` video file.  If source is an integer and no
+corresponding webcam is available, an exception will be raised.
+ 
 ### SparseZoo Stubs
 [SparseZoo](http://sparsezoo.neuralmagic.com/) is a constantly growing repository of sparsified (pruned and 
 pruned-quantized) models with matching sparsification recipes for neural networks. It simplifies and accelerates your time to value in building performant deep learning models with a collection of inference-optimized models and recipes to prototype.

--- a/examples/classification/annotate.py
+++ b/examples/classification/annotate.py
@@ -1,0 +1,513 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Annotation script for running Image classification models using DeepSparse and
+other inference engines.
+Supports .jpg images, .mp4 movies, and webcam streaming.
+
+usage: annotate.py [-h] --source SOURCE [-e {deepsparse,onnxruntime,torch}]
+                   [-i IMAGE_SHAPE [IMAGE_SHAPE ...]] [-c NUM_CORES]
+                   [-s NUM_SOCKETS] [--fp16] [--device DEVICE]
+                   [--save-dir SAVE_DIR] [--name NAME] [--no-save]
+                   [-b BATCH_SIZE] [--target-fps TARGET_FPS]
+                   model_filepath
+
+Script for running Image classification models and annotating results using
+the DeepSparse and other runtime engines such as PyTorch and onnxruntime
+
+positional arguments:
+  model_filepath        The full file source of the ONNX model file or
+                        SparseZoo stub to the model for DeepSparse and ONNX
+                        Runtime Engine.Visit
+                        https://sparsezoo.neuralmagic.com/ to search model
+                        stubs.Path to a .pt loadable PyTorch Module for torch
+                        -Module can be the top-level object loaded or loaded
+                        into 'model'in a state dict
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --source SOURCE       File source to image or directory of .jpg files, a
+                        .mp4 video, or an integer (i.e. 0) for webcam
+  -e {deepsparse,onnxruntime,torch}, --engine {deepsparse,onnxruntime,torch}
+                        Inference engine backend to run on. Choices are
+                        ['deepsparse', 'onnxruntime', 'torch']. Default is
+                        deepsparse
+  -i IMAGE_SHAPE [IMAGE_SHAPE ...], --image-shape IMAGE_SHAPE [IMAGE_SHAPE ...]
+                        Image shape to run model with, must be two integers.
+                        Default is (224, 224)
+  -c NUM_CORES, --num-cores NUM_CORES
+                        The number of physical cores to run the annotations
+                        with, defaults to None where it uses all physical
+                        cores available on the system. For DeepSparse
+                        benchmarks, this value is the number of cores per
+                        socket.
+  -s NUM_SOCKETS, --num-sockets NUM_SOCKETS
+                        For DeepSparse Engine only. The number of physical
+                        cores to run the annotations. Defaults to None where
+                        it uses all sockets available on the system
+  --fp16                Set flag to execute with torch in half precision
+                        (fp16)
+  --device DEVICE       Torch device id to run the model with. Default is cpu.
+                        Non-cpu only supported for Torch benchmarking. Default
+                        is 'cpu' unless running with Torch and CUDA is
+                        available, then CUDA on device 0. i.e. 'cuda', 'cpu',
+                        0, 'cuda:1'
+  --save-dir SAVE_DIR   directory to save all results to. defaults to
+                        'annotation_results'
+  --name NAME           name of directory in save-dir to write results to.
+                        defaults to {engine}-annotations-{run_number}
+  --no-save             set flag when source is from webcam to not save
+                        results. not supported for non-webcam sources
+  -b BATCH_SIZE, --batch-size BATCH_SIZE
+                        The batch size to use while annotating images
+  --target-fps TARGET_FPS
+                        target FPS when writing video files. Frames will be
+                        dropped to closely match target FPS. --source must be
+                        a video file and if target-fps is greater than the
+                        source video fps then it will be ignored. Default is
+                        None
+
+##########
+Example command for running video annotations with base resnet:
+python annotate.py \
+    zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/base-none \
+    --source my_video.mp4 \
+    --image-shape 224 224
+
+##########
+Example command for running webcam annotations with base resnet:
+python annotate.py \
+    zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/base-none \
+    --source 0 \
+    --image-shape 224 224
+
+##########
+Example command for running Image annotations with base resnet:
+python annotate.py \
+    zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/base-none \
+    --source /path/to/JPEGS/ \
+    --image-shape 224 224
+"""
+import argparse
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple, Union
+
+import numpy
+import onnx
+import onnxruntime
+
+import cv2
+import torch
+import utils
+from deepsparse import compile_model
+from sparseml.onnx.utils import override_model_batch_size
+
+
+_LOGGER = logging.getLogger(__name__)
+ZOO_STUB_PREFIX = "zoo:"
+
+
+@dataclass
+class _Config:
+    model_filepath: str
+    source: Union[str, int]
+    engine: str
+    image_shape: Tuple[int, int]
+    num_cores: Optional[int]
+    num_sockets: Optional[int]
+    fp16: bool
+    device: Optional[Union[str, int]]
+    save_dir: str
+    name: str
+    no_save: bool
+    batch_size: int
+    target_fps: Optional[float]
+
+    def _validate_configuration(self):
+        if not utils.is_valid_stub_or_existing_file(self.model_filepath):
+            raise ValueError(
+                f"model-filepath:{self.model_filepath} is NOT a valid " f"stub/source"
+            )
+        if self.source.isnumeric():
+            self.source = int(self.source)
+        utils.validate_image_source(self.source)
+        self.engine = utils.Engine(self.engine)
+
+        if len(self.image_shape) != 2:
+            raise ValueError(
+                f"Image shape must be 2 integers given: {self.image_shape}"
+            )
+        if self.device not in [None, "cpu"] and self.engine != utils.Engine:
+            raise ValueError(f"device {self.device} is not supported for {self.engine}")
+        if self.fp16 and self.engine != utils.Engine.Torch:
+            raise ValueError(f"half precision is not supported for {self.engine}")
+        if self.num_cores is not None and self.engine == utils.Engine.Torch:
+            raise ValueError(
+                f"overriding default num_cores not supported for {self.engine}"
+            )
+        if (
+            self.num_cores is not None
+            and self.engine == utils.Engine.ONNXRUNTIME
+            and onnxruntime.__version__ < "1.7"
+        ):
+            raise ValueError(
+                "overriding default num_cores not supported for onnxruntime < "
+                "1.7.0. If using an older build with OpenMP, try setting the "
+                "OMP_NUM_THREADS environment variable"
+            )
+        if self.num_sockets is not None and self.engine != utils.Engine.DEEPSPARSE:
+            raise ValueError(
+                f"Overriding num_sockets is not supported for {self.engine}"
+            )
+        if (
+            self.engine == utils.Engine.DEEPSPARSE
+            or self.engine == utils.Engine.ONNXRUNTIME
+        ):
+            self.model_filepath = utils.fix_onnx_input_shape(
+                model_filepath=self.model_filepath,
+                input_shape=self.image_shape,
+            )
+        if self.engine == utils.Engine.TORCH and self.device is None:
+            self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
+        self.name = self.name or f"{self.engine.value}-annotations"
+        assert self.batch_size >= 0, "batch size should be positive"
+        self.save_dir = utils.get_save_dir_name(self.save_dir, self.name)
+
+    def __post_init__(self):
+        self._validate_configuration()
+
+
+def _parse_args(args=Optional[List[str]]):
+    parser = argparse.ArgumentParser(
+        description="Script for running Image classification models and "
+        "annotating results using the DeepSparse and other "
+        "runtime engines such as PyTorch and onnxruntime"
+    )
+
+    parser.add_argument(
+        "model_filepath",
+        type=str,
+        help=(
+            "The full file source of the ONNX model file or SparseZoo stub to "
+            "the model for DeepSparse and ONNX Runtime Engine."
+            "Visit https://sparsezoo.neuralmagic.com/ to search model stubs."
+            "Path to a .pt loadable PyTorch  Module for torch -"
+            "Module can be the top-level object loaded or loaded into 'model'"
+            "in a state dict"
+        ),
+    )
+
+    parser.add_argument(
+        "--source",
+        type=str,
+        required=True,
+        help=(
+            "File source to image or directory of .jpg files, a .mp4 video, "
+            "or an integer (i.e. 0) for webcam"
+        ),
+    )
+
+    _default_engine = utils.Engine.DEEPSPARSE.value
+    _supported_engines = utils.Engine.supported_engines()
+    parser.add_argument(
+        "-e",
+        "--engine",
+        type=str,
+        default=_default_engine,
+        choices=_supported_engines,
+        help=(
+            f"Inference engine backend to run on. Choices are "
+            f"{_supported_engines}. Default is {_default_engine}"
+        ),
+    )
+
+    _default_image_shape = (224, 224)
+    parser.add_argument(
+        "-i",
+        "--image-shape",
+        type=int,
+        default=_default_image_shape,
+        nargs="+",
+        help="Image shape to run model with, must be two integers. "
+        f"Default is {_default_image_shape}",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--num-cores",
+        type=int,
+        default=None,
+        help=(
+            "The number of physical cores to run the annotations with, "
+            "defaults to None where it uses all physical cores available on "
+            "the system. "
+            "For DeepSparse benchmarks, this value is the number of cores "
+            "per socket."
+        ),
+    )
+
+    parser.add_argument(
+        "-s",
+        "--num-sockets",
+        type=int,
+        default=None,
+        help=(
+            "For DeepSparse Engine only. The number of physical cores to run "
+            "the annotations. Defaults to None where it uses all sockets "
+            "available on the system"
+        ),
+    )
+
+    parser.add_argument(
+        "--fp16",
+        help="Set flag to execute with torch in half precision (fp16)",
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "--device",
+        type=utils.parse_device,
+        default=None,
+        help=(
+            "Torch device id to run the model with. Default is cpu. Non-cpu "
+            " only supported for Torch benchmarking. Default is 'cpu' "
+            "unless running with Torch and CUDA is available, then CUDA on "
+            "device 0. i.e. 'cuda', 'cpu', 0, 'cuda:1'"
+        ),
+    )
+    parser.add_argument(
+        "--save-dir",
+        type=str,
+        default="annotation_results",
+        help="directory to save all results to. defaults to " "'annotation_results'",
+    )
+
+    parser.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        help=(
+            "name of directory in save-dir to write results to. defaults to "
+            "{engine}-annotations-{run_number}"
+        ),
+    )
+
+    parser.add_argument(
+        "--no-save",
+        action="store_true",
+        help=(
+            "set flag when source is from webcam to not save results. not "
+            "supported for non-webcam sources"
+        ),
+    )
+    parser.add_argument(
+        "-b",
+        "--batch-size",
+        type=int,
+        default=64,
+        help="The batch size to use while annotating images",
+    )
+    parser.add_argument(
+        "--target-fps",
+        type=float,
+        default=None,
+        help=(
+            "target FPS when writing video files. Frames will be dropped to "
+            "closely match target FPS. --source must be a video file and if "
+            "target-fps "
+            "is greater than the source video fps then it will be ignored. "
+            "Default is "
+            "None"
+        ),
+    )
+    _args = parser.parse_args(args)
+    _config = _Config(
+        model_filepath=_args.model_filepath,
+        source=_args.source,
+        engine=_args.engine,
+        image_shape=tuple(_args.image_shape),
+        num_cores=_args.num_cores,
+        num_sockets=_args.num_sockets,
+        fp16=_args.fp16,
+        device=_args.device,
+        save_dir=_args.save_dir,
+        name=_args.name,
+        no_save=_args.no_save,
+        batch_size=_args.batch_size,
+        target_fps=_args.target_fps,
+    )
+    return _config
+
+
+def _load_model(config: _Config):
+    if config.engine == utils.Engine.DEEPSPARSE:
+        _LOGGER.info(f"Loading DeepSparse Engine for {config.model_filepath}")
+
+        model = compile_model(
+            config.model_filepath,
+            config.batch_size,
+            config.num_cores,
+            config.num_sockets,
+        )
+
+    elif config.engine == utils.Engine.ONNXRUNTIME:
+        _LOGGER.info(f"Loading ONNX Runtime Engine for {config.model_filepath}")
+
+        sess_options = onnxruntime.SessionOptions()
+        if config.num_cores is not None:
+            sess_options.intra_op_num_threads = config.num_cores
+
+        sess_options.log_severity_level = 3
+        sess_options.graph_optimization_level = (
+            onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
+        )
+
+        onnx_model = onnx.load(config.model_filepath)
+        override_model_batch_size(onnx_model, config.batch_size)
+        model = onnxruntime.InferenceSession(
+            onnx_model.SerializeToString(), sess_options=sess_options
+        )
+    elif config.engine == utils.Engine.TORCH:
+        _LOGGER.info(f"Loading PyTorch Engine for {config.model_filepath}")
+
+        model = torch.load(config.model_filepath)
+        if isinstance(model, dict):
+            model = model["model"]
+        model.to(config.device)
+        model.eval()
+
+        if config.fp16:
+            _LOGGER.info("Using half precision")
+            model.half()
+        else:
+            _LOGGER.info("Using full precision")
+            model.float()
+
+    return model
+
+
+def _preprocess_batch(
+    config: _Config, batch: numpy.ndarray
+) -> Union[numpy.ndarray, torch.Tensor]:
+    single_image = len(batch.shape) == 3
+    if single_image:
+        batch = batch.reshape(1, *batch.shape)
+
+    if config.engine == utils.Engine.TORCH:
+        batch = torch.from_numpy(batch.copy())
+        batch = batch.to(config.device)
+        batch = batch.half() if config.fp16 else batch.float()
+        batch /= 255.0
+    else:
+        batch = batch.astype(numpy.float32) / 255.0
+        batch = numpy.ascontiguousarray(batch)
+
+    return batch
+
+
+def _run_model(
+    config: _Config, model: Any, batch: Union[numpy.ndarray, torch.Tensor]
+) -> List[Union[numpy.ndarray, torch.Tensor]]:
+    if config.engine == utils.Engine.TORCH:
+        outputs = model(batch)
+    elif config.engine == utils.Engine.ONNXRUNTIME:
+        model_outputs = [out.name for out in model.get_outputs()]
+        model_inputs = {model.get_inputs()[0].name: batch}
+        outputs = model.run(model_outputs, model_inputs)
+    else:
+        # DeepSparse
+        outputs = model.run([batch])
+    return outputs
+
+
+def annotate(config: _Config):
+    """
+    Method to annotate images using Image classification models according to
+    specified configuration
+
+    :param config: _Config object with info for current annotation task
+    """
+    model = _load_model(config=config)
+    _LOGGER.info(f"Loaded model: {model}")
+
+    class_labels = utils.imagenet_labels_as_list()
+
+    loader, saver, is_video = utils.get_loader_and_saver(
+        config.source, config.save_dir, config.image_shape, config
+    )
+    is_webcam = isinstance(config.source, int)
+
+    for batch_idx, (current_batch, source_images) in enumerate(loader):
+        if config.device not in ["cpu", None]:
+            torch.cuda.synchronize()
+
+        batch = _preprocess_batch(config, current_batch)
+
+        iter_start = time.time()
+
+        # inference
+        predictions = _run_model(config, model, batch)
+        predictions = predictions[-1]
+
+        elapsed_time = time.time() - iter_start
+        measured_fps = config.batch_size / elapsed_time
+
+        print("fps: ", measured_fps)
+
+        predicted_labels = [
+            class_labels[index]
+            for index in numpy.argmax(numpy.asarray(predictions), axis=-1)
+        ]
+
+        for image, label in zip(source_images, predicted_labels):
+            annotated_image = utils.annotate_image(
+                image=image,
+                annotation_text=f"class: {label} images/sec: {measured_fps}",
+            )
+
+            # display
+            if is_webcam:
+                cv2.imshow("annotations", annotated_image)
+                cv2.waitKey(1)
+
+            if saver:
+                saver.save_frame(annotated_image)
+                _LOGGER.info(f"Results saved to {config.save_dir}")
+
+    if saver:
+        saver.close()
+
+
+def main(args=Optional[List[str]]):
+    """
+    Driver function
+
+    :param args: Command line arguments to parse and drive annotation
+    """
+    _config = _parse_args(args=args)
+    annotate(_config)
+    _cleanup(filepath=_config.model_filepath)
+
+
+def _cleanup(filepath):
+    os.unlink(filepath)
+
+
+if __name__ == "__main__":
+    main(args=sys.argv[1:])

--- a/examples/classification/requirements.txt
+++ b/examples/classification/requirements.txt
@@ -1,5 +1,11 @@
-deepsparse
-sparseml
+# pip install -r requirements.txt
+
+# NM Deps
+deepsparse>=0.3.1
+sparseml[torchvision]>=0.3.1
+
+# Example Deps
+opencv-python
 Flask_Cors==3.0.10
 Flask==2.0.1
 onnxruntime

--- a/examples/classification/utils.py
+++ b/examples/classification/utils.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helper methods and utilities
+"""
+import glob
+import json
+import logging
+import os
+import shutil
+from enum import Enum, unique
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any, Iterable, Iterator, List, Optional, Tuple, Union
+
+import numpy
+import numpy as np
+import onnx
+
+import cv2
+from sparseml.onnx.utils import get_tensor_dim_shape, set_tensor_dim_shape
+from sparseml.utils import create_dirs
+from sparsezoo import Zoo
+
+
+ZOO_STUB_PREFIX = "zoo:"
+
+
+@unique
+class Engine(Enum):
+    DEEPSPARSE = "deepsparse"
+    ONNXRUNTIME = "onnxruntime"
+    TORCH = "torch"
+
+    @classmethod
+    def supported_engines(cls):
+        return [_engine.value for _engine in cls]
+
+
+# helpers
+
+
+def annotate_image(image: numpy.ndarray, annotation_text: str) -> numpy.ndarray:
+    """
+    Returns a new copy of image annotated with the given text, in the top
+    left corner.
+
+    :param image: A numpy array representing the image
+    :param annotation_text: The text to annotate the image with
+    :return: A copy of the image annotated with the given annotation text
+    """
+    image_copy = numpy.copy(image)
+
+    (w, h), _ = cv2.getTextSize(annotation_text, cv2.FONT_HERSHEY_SIMPLEX, 0.6, 1)
+
+    x1, y1 = 10, 50
+    image_copy = cv2.rectangle(image_copy, (x1, y1 - 20), (x1 + w, y1), (0, 0, 0), -1)
+    image_copy = cv2.putText(
+        image_copy,
+        annotation_text,
+        (x1, y1 - 5),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.6,
+        (255, 255, 255),
+        1,
+    )
+    return image_copy
+
+
+def parse_device(device: Union[str, int]) -> Union[str, int]:
+    """
+    :param device: The device id to use for inference
+    :return: An integer representing the device to run inference on or the
+        string id if device id is not an integer value
+    """
+    try:
+        return int(device)
+    except Exception:
+        return device
+
+
+def get_save_dir_name(*args) -> str:
+    """
+    Returns a non-existing directory name from the given arguments
+
+    :param args: directories to join together
+    :return:
+    """
+    save_directory_name = joined_directory_name = os.path.join(*args)
+    index = 2
+
+    while Path(save_directory_name).exists():
+        save_directory_name = os.path.join(f"{joined_directory_name}-{index}")
+        index += 1
+    print(f"Results will be saved to {save_directory_name}")
+    return save_directory_name
+
+
+def fix_onnx_input_shape(model_file_or_stub: str, input_shape: Tuple[int, int]) -> str:
+    """
+    Creates a new ONNX model from given model file or SparseZoo stub that
+    accepts the input shape. If the given model already has the given input
+    shape no modifications are made. Uses a tempfile to store the
+    modified model file.
+
+    :param model_file_or_stub: str SparseZoo stub or source to ONNX model file
+    :param input_shape: Tuple of two integers representing the image shape to
+        override ONNX model file with.
+    :return: filepath to an onnx model with input reshaped to the
+        given input_shape, will be the original source if the shape is the same.
+    """
+    given_model_path = model_path = model_file_or_stub
+    if given_model_path.startswith("zoo:"):
+        model = Zoo.load_model_from_stub(given_model_path)
+        model_path = model.onnx_file.downloaded_path()
+        logging.info(f"Downloaded {given_model_path} to {model_path}")
+
+    model = onnx.load(model_path)
+    model_input = model.graph.input[0]
+
+    model_input_indexes = [2, 3]
+    model_input_shape = tuple(
+        get_tensor_dim_shape(model_input, index) for index in model_input_indexes
+    )
+
+    if model_input_shape == input_shape:
+        return model_path  # No shape modification needed
+
+    for input_index, dim_shape in zip(model_input_indexes, input_shape):
+        set_tensor_dim_shape(model_input, input_index, dim_shape)
+
+    tmp_file = NamedTemporaryFile(delete=False)
+    onnx.save(model, tmp_file.name)
+
+    logging.info(
+        f"Overwrote original model input shape {model_input_shape} to "
+        f"{input_shape}\n"
+        f"Original model source: {given_model_path}, new temporary "
+        f"model saved to {tmp_file.name}"
+    )
+    return tmp_file.name
+
+
+# validators
+def is_valid_stub_or_existing_file(stub_or_path: str) -> bool:
+    """
+    Utility method to test if given argument is either a valid SparseZoo stub
+    or an existing file on the filesystem
+
+    :param stub_or_path: string to test for validity
+    :return: True if valid stub or existing file
+    """
+    is_valid_stub = (
+        stub_or_path.startswith(ZOO_STUB_PREFIX) and stub_or_path.count("?") < 2
+    )
+    return is_valid_stub or Path(stub_or_path).is_file()
+
+
+def is_valid_string_source(source: str) -> bool:
+    """
+    Utility function to test if string source is a valid image/video file or
+    a non-empty directory of images directory
+
+    :param source: str source to directory of images or a valid image/video file
+    :return: bool True if valid string source else False
+    """
+    is_valid_file = Path(source).is_file() and (
+        source.endswith(".jpeg") or source.endswith(".jpg") or source.endswith(".mp4")
+    )
+    is_valid_not_empty_dir = Path(source).is_dir() and (
+        glob.glob(os.path.join(source, "*.jpeg"))
+        or glob.glob(os.path.join(source, "*.jpg"))
+    )
+    return is_valid_file or is_valid_not_empty_dir
+
+
+def is_valid_webcam(source: int) -> bool:
+    """
+    Utility function to test if webcam device is available and open
+    follows “it's easier to ask for forgiveness than permission” idiom
+    inspired from https://tinyurl.com/valid-webcam
+
+    :param source: int representing the video camera device
+    :return: bool True if valid video capture device else False
+    """
+    capture = cv2.VideoCapture(source)
+    return capture is not None and capture.isOpened()
+
+
+def validate_image_source(source: Union[str, int]) -> None:
+    """
+    Utility function to check if given source is either a valid file source,
+    or a valid webcam
+
+    :param source: String source to a valid file source, or an Integer
+        representing a valid webcam
+    """
+    if isinstance(source, str) and not is_valid_string_source(source=source):
+        raise ValueError(f"source:{source} is NOT a valid image source")
+    if isinstance(source, int) and not is_valid_webcam(source=source):
+        raise AssertionError(f"Unable to open video source:{source}")
+
+
+def imagenet_labels_as_list() -> List[str]:
+    """
+    :return: ImageNet labels as a list
+    """
+    imagenet_json = "imagenet.json"
+    with open(imagenet_json) as f:
+        imagenet_data = json.load(f)
+    return list(imagenet_data["label_mappings"].values())
+
+
+def get_loader_and_saver(
+    source: Union[str, int],
+    save_dir: str,
+    image_size: Tuple[int] = (224, 224),
+    config: Any = None,
+) -> Union[Iterable, Any, bool]:
+    """
+    :param source: file path to image or directory of .jpg files, a .mp4
+    video, or an integer (i.e. 0) for web-cam
+    :param save_dir: path of directory to save to
+    :param image_size: size of input images to model
+    :param config: configuration for annotation task
+    :return: image loader iterable, result saver objects
+        images, video, or web-cam based on path given, and a boolean value
+        that is True is the returned objects load videos
+    """
+
+    source_is_webcam = isinstance(source, int)
+    source_is_video = source.endswith(".mp4")
+    is_video = source_is_webcam or source_is_video
+
+    if source_is_webcam:
+        loader = WebcamLoader(
+            camera=source, image_size=image_size, batch_size=config.batch_size
+        )
+        saver = (
+            None
+            if config.no_save
+            else VideoSaver(
+                save_dir=save_dir,
+                original_fps=30,
+                output_frame_size=loader.original_frame_size,
+                target_fps=config.target_fps,
+            )
+        )
+
+    elif source_is_video:
+        loader = VideoBatchLoader(
+            path=source, image_size=image_size, batch_size=config.batch_size
+        )
+        saver = VideoSaver(
+            save_dir=save_dir,
+            original_fps=loader.original_fps,
+            output_frame_size=loader.original_frame_size,
+            target_fps=config.target_fps,
+        )
+
+    else:
+        loader = ImageBatchLoader(
+            path=source, image_size=image_size, batch_size=config.batch_size
+        )
+        saver = ImagesSaver(save_dir=save_dir)
+
+    return loader, saver, is_video
+
+
+# Loaders
+
+
+def load_image(
+    image: Union[str, numpy.ndarray], image_size: Tuple[int] = (224, 224)
+) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    """
+    :param image: file source to image or raw image array
+    :param image_size: target shape for image
+    :return: Image loaded into numpy and reshaped to the given shape and the
+    original image
+    """
+    image = cv2.imread(image) if isinstance(image, str) else image
+    img_resized = cv2.resize(image, image_size)
+    img_transposed = img_resized[:, :, ::-1].transpose(2, 0, 1)
+    return img_transposed, image
+
+
+class ImageBatchLoader:
+    """
+    Class for pre-processing and iterating over images to be used as input
+    for image classification models
+
+    :param path: Filepath to single image file or directory of image files to
+        load, glob paths also valid
+    :param image_size: size of input images to model
+    """
+
+    def __init__(
+        self, path: str, image_size: Tuple[int] = (224, 224), batch_size: int = 1
+    ):
+        self._path = path
+        self._image_size = image_size
+        self._batch_size = batch_size
+
+        if Path(path).is_dir():
+            self._image_file_paths = [
+                os.path.join(path, file_name) for file_name in os.listdir(path)
+            ]
+        elif "*" in path:
+            self._image_file_paths = glob.glob(path)
+        elif Path(path).is_file():
+            # single file
+            self._image_file_paths = [path]
+        else:
+            raise ValueError(f"{path} is not a file, glob, or directory")
+
+    def __iter__(self) -> Iterator[Tuple[numpy.ndarray, numpy.ndarray]]:
+        current_batch, images = [], []
+
+        for image_path in self._image_file_paths:
+            batch_image, image = load_image(
+                image=image_path, image_size=self._image_size
+            )
+            current_batch.append(batch_image)
+            images.append(image)
+
+            if len(current_batch) == self._batch_size:
+                yield np.asarray(current_batch), np.asarray(images)
+                current_batch, images = [], []
+
+
+class VideoBatchLoader:
+    """
+    Class for pre-processing and iterating over video frames to be used as
+    input for Image classification models
+
+    :param path: Filepath to single video file
+    :param image_size: size of input images to model
+    """
+
+    def __init__(self, path: str, image_size: Tuple[int] = (224, 224), batch_size=1):
+        self._path = path
+        self._image_size = image_size
+        self._vid = cv2.VideoCapture(self._path)
+        self._total_frames = int(self._vid.get(cv2.CAP_PROP_FRAME_COUNT))
+        self._fps = self._vid.get(cv2.CAP_PROP_FPS)
+        self._batch_size = batch_size
+
+    def __iter__(self) -> Iterator[Tuple[numpy.ndarray, numpy.ndarray]]:
+        current_batch, images = [], []
+
+        for _ in range(self._total_frames):
+            loaded, frame = self._vid.read()
+            if not loaded:
+                break
+            batch_image, image = load_image(image=frame, image_size=self._image_size)
+            current_batch.append(batch_image)
+            images.append(image)
+
+            if len(current_batch) == self._batch_size:
+                yield np.asarray(current_batch), np.asarray(images)
+                current_batch, images = [], []
+        self._vid.release()
+
+    @property
+    def original_fps(self) -> float:
+        """
+        :return: the frames per second of the video this object reads
+        """
+        return self._fps
+
+    @property
+    def original_frame_size(self) -> Tuple[int, int]:
+        """
+        :return: the original size of frames in the video this object reads
+        """
+        return (
+            int(self._vid.get(cv2.CAP_PROP_FRAME_WIDTH)),
+            int(self._vid.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+        )
+
+    @property
+    def total_frames(self) -> int:
+        """
+        :return: the total number of frames this object may laod from the video
+        """
+        return self._total_frames
+
+
+class WebcamLoader:
+    """
+    Class for pre-processing and iterating over webcam frames to be used as
+    input for Image classification models.
+
+    Adapted from:
+        https://github.com/ultralytics/yolov5/blob/master/utils/datasets.py
+
+    :param camera: Webcam index
+    :param image_size: size of input images to model
+    """
+
+    def __init__(
+        self, camera: int, image_size: Tuple[int, int] = (224, 224), batch_size: int = 1
+    ):
+
+        self._camera = camera
+        self._image_size = image_size
+        self._stream = cv2.VideoCapture(self._camera)
+        self._stream.set(cv2.CAP_PROP_BUFFERSIZE, 3)
+        self._batch_size = batch_size
+
+    def __iter__(self) -> Iterator[Tuple[numpy.ndarray, numpy.ndarray]]:
+        current_batch, images = [], []
+
+        while True:
+            if cv2.waitKey(1) == ord("q"):  # q to quit
+                self._stream.release()
+                cv2.destroyAllWindows()
+                break
+
+            loaded, frame = self._stream.read()
+
+            assert loaded, f"Could not load image from webcam {self._camera}"
+
+            frame = cv2.flip(frame, 1)  # flip left-right
+            batch_image, image = load_image(image=frame, image_size=self._image_size)
+            current_batch.append(batch_image)
+            images.append(image)
+
+            if len(current_batch) == self._batch_size:
+                yield np.asarray(current_batch), np.asarray(images)
+                current_batch, images = [], []
+
+    @property
+    def original_frame_size(self) -> Tuple[int, int]:
+        """
+        :return: the original size of frames in the stream this object reads
+        """
+        return (
+            int(self._stream.get(cv2.CAP_PROP_FRAME_WIDTH)),
+            int(self._stream.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+        )
+
+
+# Savers
+
+
+class ImagesSaver:
+    """
+    Base class for saving model outputs. Saves each image as an
+    individual file in the given directory
+
+    :param save_dir: source to directory to write to
+    """
+
+    def __init__(self, save_dir: str):
+        self._save_dir = save_dir
+        self._idx = 0
+        create_dirs(save_dir)
+
+    def save_frame(self, image: numpy.ndarray):
+        """
+        :param image: numpy array of image to save
+        """
+        output_path = os.path.join(self._save_dir, f"result-{self._idx}.jpg")
+        cv2.imwrite(output_path, image)
+        self._idx += 1
+
+    def close(self):
+        """
+        perform any clean-up tasks
+        """
+        pass
+
+
+class VideoSaver(ImagesSaver):
+    """
+    Class for saving model outputs as a VideoFile
+
+    :param save_dir: source to directory to write to
+    :param original_fps: frames per second to save video with
+    :param output_frame_size: size of frames to write
+    :param target_fps: fps target for output video. if present, video
+        will be written with a certain number of the original frames
+        evenly dropped to match the target FPS.
+    """
+
+    def __init__(
+        self,
+        save_dir: str,
+        original_fps: float,
+        output_frame_size: Tuple[int, int],
+        target_fps: Optional[float] = None,
+    ):
+        super().__init__(save_dir)
+
+        self._output_frame_size = output_frame_size
+        self._original_fps = original_fps
+
+        if target_fps is not None and target_fps >= original_fps:
+            print(
+                f"target_fps {target_fps} is greater than source_fps "
+                f"{original_fps}. target fps file will not be invoked"
+            )
+        self._target_fps = target_fps
+
+        self._file_path = os.path.join(self._save_dir, "results.mp4")
+        self._writer = cv2.VideoWriter(
+            self._file_path,
+            cv2.VideoWriter_fourcc(*"mp4v"),
+            original_fps,
+            self._output_frame_size,
+        )
+        self._n_frames = 0
+
+    def save_frame(self, image: numpy.ndarray):
+        """
+        :param image: numpy array of image to save
+        """
+        self._writer.write(image)
+        self._n_frames += 1
+
+    def close(self):
+        """
+        perform any clean-up tasks
+        """
+        self._writer.release()
+        if self._target_fps is not None and self._target_fps < self._original_fps:
+            self._write_target_fps_video()
+
+    def _write_target_fps_video(self):
+        assert self._target_fps is not None
+        num_frames_to_keep = int(
+            self._n_frames * (self._target_fps / self._original_fps)
+        )
+        # adjust target fps so we can keep the same video duration
+        adjusted_target_fps = num_frames_to_keep * (self._original_fps / self._n_frames)
+
+        # select num_frames_to_keep evenly spaced frame idxs
+        frame_indexes_to_keep = set(
+            numpy.round(numpy.linspace(0, self._n_frames, num_frames_to_keep))
+            .astype(int)
+            .tolist()
+        )
+
+        # create new video writer for adjusted video
+        vid_path = os.path.join(
+            self._save_dir, f"_results-{adjusted_target_fps:.2f}fps.mp4"
+        )
+        fps_writer = cv2.VideoWriter(
+            vid_path,
+            cv2.VideoWriter_fourcc(*"mp4v"),
+            adjusted_target_fps,
+            self._output_frame_size,
+        )
+
+        # read from original video and write to FPS adjusted video
+        saved_vid = cv2.VideoCapture(self._file_path)
+        for idx in range(self._n_frames):
+            _, frame = saved_vid.read()
+            if idx in frame_indexes_to_keep:
+                fps_writer.write(frame)
+
+        saved_vid.release()
+        fps_writer.release()
+        shutil.move(vid_path, self._file_path)  # overwrite original file


### PR DESCRIPTION
Add:
* annotate.py for running annotation on Images/Videos/Webcam-Stream using Image classification models with a variety of Inference Engines
* utils.py containing helper methods and utilities

Update:
* .gitignore to avoid showing examples/classification/annotation-results in git
* README.md with example usage for examples/classification/annotate.py
* examples/classification/requirements.txt