### PR TITLE
Deprecate sockets in the API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ MDCHECKGLOBS := 'docs/**/*.md' 'docs/**/*.rst' 'examples/**/*.md' 'scripts/**/*.
 MDCHECKFILES := CODE_OF_CONDUCT.md CONTRIBUTING.md DEVELOPING.md README.md
 SPARSEZOO_TEST_MODE := "true"
 
+PYTHON := python3
+
 # run checks on all files for the repo
 quality:
 	@echo "Running copyright checks";
-	python utils/copyright.py quality $(PYCHECKGLOBS) $(MDCHECKGLOBS) $(MDCHECKFILES)
+	$(PYTHON) utils/copyright.py quality $(PYCHECKGLOBS) $(MDCHECKGLOBS) $(MDCHECKFILES)
 	@echo "Running python quality checks";
 	black --check $(CHECKDIRS);
 	isort --check-only $(CHECKDIRS);
@@ -22,7 +24,7 @@ quality:
 # style the code according to accepted standards for the repo
 style:
 	@echo "Running copyrighting";
-	python utils/copyright.py style $(PYCHECKGLOBS) $(JSCHECKGLOBS) $(MDCHECKGLOBS) $(MDCHECKFILES)
+	$(PYTHON) utils/copyright.py style $(PYCHECKGLOBS) $(JSCHECKGLOBS) $(MDCHECKGLOBS) $(MDCHECKFILES)
 	@echo "Running python styling";
 	black $(CHECKDIRS);
 	isort $(CHECKDIRS);
@@ -41,7 +43,7 @@ test-examples:
 # create docs
 docs:
 	@echo "Running docs creation";
-	python utils/docs_builder.py --src $(DOCDIR) --dest $(DOCDIR)/build/html;
+	$(PYTHON) utils/docs_builder.py --src $(DOCDIR) --dest $(DOCDIR)/build/html;
 
 docsupdate:
 	@echo "Runnning update to api docs";
@@ -50,7 +52,7 @@ docsupdate:
 
 # creates wheel file
 build:
-	python3 setup.py sdist bdist_wheel $(BUILD_ARGS)
+	$(PYTHON) setup.py sdist bdist_wheel $(BUILD_ARGS)
 
 # clean package
 clean:

--- a/docs/source/scheduler.md
+++ b/docs/source/scheduler.md
@@ -41,13 +41,13 @@ The most common use cases for the multi-stream scheduler are where parallelism i
 Depending on your engine execution strategy, enable one of these options by running:
 
 ```python
-engine = compile_model(model_path, batch_size, num_cores, num_sockets, "single_stream")
+engine = compile_model(model_path, batch_size, num_cores, "single_stream")
 ```
 
 or
 
 ```python
-engine = compile_model(model_path, batch_size, num_cores, num_sockets, "multi_stream")
+engine = compile_model(model_path, batch_size, num_cores, "multi_stream")
 ```
 
 or pass in the enum value directly, since` "multi_stream" == Scheduler.multi_stream`

--- a/examples/flask/server.py
+++ b/examples/flask/server.py
@@ -18,7 +18,7 @@ using the DeepSparse Engine as the inference backend
 
 ##########
 Command help:
-usage: server.py [-h] [-b BATCH_SIZE] [-c NUM_CORES] [-s NUM_SOCKETS]
+usage: server.py [-h] [-b BATCH_SIZE] [-c NUM_CORES]
                  [--scheduler SCHEDULER] [-a ADDRESS] [-p PORT]
                  model_path
 
@@ -35,10 +35,6 @@ optional arguments:
   -c NUM_CORES, --num-cores NUM_CORES
                         The number of physical cores to run the engine on,
                         defaults to all physical cores available on the system
-  -s NUM_SOCKETS, --num-sockets NUM_SOCKETS
-                        The number of physical sockets to run the engine on,
-                        defaults to all physical sockets available on the
-                        system
   --scheduler SCHEDULER
                         The kind of scheduler to run with. Defaults to multi_stream
   -a ADDRESS, --address ADDRESS
@@ -68,7 +64,6 @@ def engine_flask_server(
     model_path: str,
     batch_size: int = 1,
     num_cores: int = None,
-    num_sockets: int = None,
     scheduler: Scheduler = Scheduler.multi_stream,
     address: str = "0.0.0.0",
     port: str = "5543",
@@ -82,9 +77,6 @@ def engine_flask_server(
     :param num_cores: The number of physical cores to run the model on.
         Pass None or 0 to run on the max number of cores
         in one socket for the current machine, default None
-    :param num_sockets: The number of physical sockets to run the model on.
-        Pass None or 0 to run on the max number of sockets for the
-        current machine, default None
     :param scheduler: The kind of scheduler to execute with. Defaults to multi_stream
     :param address: IP address to run on. Default is 0.0.0.0
     :param port: port to run on. Default is 5543
@@ -92,7 +84,7 @@ def engine_flask_server(
         given model on the DeepSparse engine via HTTP requests
     """
     _LOGGER.info(f"Compiling model at {model_path}")
-    engine = compile_model(model_path, batch_size, num_cores, num_sockets, scheduler)
+    engine = compile_model(model_path, batch_size, num_cores, scheduler)
     _LOGGER.info(engine)
 
     app = flask.Flask(__name__)
@@ -151,16 +143,6 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        "-s",
-        "--num-sockets",
-        type=int,
-        default=None,
-        help=(
-            "The number of physical sockets to run the engine on, "
-            "defaults to all physical sockets available on the system"
-        ),
-    )
-    parser.add_argument(
         "--scheduler",
         type=str,
         default=Scheduler.multi_stream,
@@ -191,7 +173,6 @@ def main():
         args.model_path,
         args.batch_size,
         args.num_cores,
-        args.num_sockets,
         args.scheduler,
         args.address,
         args.port,

--- a/examples/huggingface-transformers/benchmark.py
+++ b/examples/huggingface-transformers/benchmark.py
@@ -19,7 +19,7 @@ Benchmarking script for BERT ONNX models with the DeepSparse engine.
 ##########
 Command help:
 usage: benchmark.py [-h] [--data-path DATA_PATH] [-e {deepsparse,onnxruntime}]
-                    [-b BATCH_SIZE] [-c NUM_CORES] [-s NUM_SOCKETS]
+                    [-b BATCH_SIZE] [-c NUM_CORES]
                     [-i NUM_ITERATIONS] [-w NUM_WARMUP_ITERATIONS]
                     [--max-sequence-length MAX_SEQUENCE_LENGTH]
                     model_filepath
@@ -51,10 +51,6 @@ optional arguments:
                         defaults to None where it uses all physical cores
                         available on the system. For DeepSparse benchmarks,
                         this value is the number of cores per socket
-  -s NUM_SOCKETS, --num-sockets NUM_SOCKETS
-                        For DeepSparse benchmarks only. The number of physical
-                        cores to run the benchmark on. Defaults to None where
-                        is uses all sockets available on the system
   -i NUM_ITERATIONS, --num-iterations NUM_ITERATIONS
                         The number of iterations the benchmark will be run for
   -w NUM_WARMUP_ITERATIONS, --num-warmup-iterations NUM_WARMUP_ITERATIONS
@@ -162,17 +158,6 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        "-s",
-        "--num-sockets",
-        type=int,
-        default=None,
-        help=(
-            "For DeepSparse benchmarks only. The number of physical cores to run the "
-            "benchmark on. Defaults to None where is uses all sockets available on the "
-            "system"
-        ),
-    )
-    parser.add_argument(
         "-i",
         "--num-iterations",
         help="The number of iterations the benchmark will be run for",
@@ -254,8 +239,6 @@ def _load_model(args) -> Tuple[Any, List[str]]:
             "If using an older build with OpenMP, try setting the OMP_NUM_THREADS "
             "environment variable"
         )
-    if args.num_sockets is not None and args.engine != DEEPSPARSE_ENGINE:
-        raise ValueError(f"Overriding num_sockets is not supported for {args.engine}")
 
     # load model from sparsezoo if necessary
     if args.model_filepath.startswith("zoo:"):
@@ -276,9 +259,7 @@ def _load_model(args) -> Tuple[Any, List[str]]:
     # load model
     if args.engine == DEEPSPARSE_ENGINE:
         print(f"Compiling deepsparse model for {args.model_filepath}")
-        model = compile_model(
-            args.model_filepath, args.batch_size, args.num_cores, args.num_sockets
-        )
+        model = compile_model(args.model_filepath, args.batch_size, args.num_cores)
         print(f"Engine info: {model}")
     elif args.engine == ORT_ENGINE:
         print(f"loading onnxruntime model for {args.model_filepath}")

--- a/examples/huggingface-transformers/pipelines.py
+++ b/examples/huggingface-transformers/pipelines.py
@@ -834,7 +834,6 @@ def pipeline(
     tokenizer: Optional[Union[str, PreTrainedTokenizer]] = None,
     max_length: int = 128,
     num_cores: Optional[int] = None,
-    num_sockets: Optional[int] = None,
     **kwargs,
 ) -> Pipeline:
     """
@@ -850,8 +849,6 @@ def pipeline(
     :param tokenizer: huggingface tokenizer, if none provided, default will be used
     :param max_length: maximum sequence length of model inputs. default is 128
     :param num_cores: number of CPU cores to run engine with. Default is the maximum
-        available
-    :param num_sockets: number of CPU sockets to run engine with. Default is the maximum
         available
     :param kwargs: additional key word arguments for task specific pipeline constructor
     :return: Pipeline object for the given taks and model
@@ -880,9 +877,7 @@ def pipeline(
     # create model
     if model_path.startswith("zoo:"):
         model_path = _download_zoo_model(model_path)
-    model, input_names = _create_model(
-        model_path, engine_type, num_cores, num_sockets, max_length
-    )
+    model, input_names = _create_model(model_path, engine_type, num_cores, max_length)
 
     # Instantiate tokenizer if needed
     if isinstance(tokenizer, (str, tuple)):
@@ -966,7 +961,6 @@ def _create_model(
     model_path: str,
     engine_type: str,
     num_cores: Optional[int],
-    num_sockets: Optional[int],
     max_length: int = 128,
 ) -> Tuple[Union[Engine, "onnxruntime.InferenceSession"], List[str]]:
     onnx_path, input_names, _ = overwrite_transformer_onnx_model_inputs(
@@ -974,9 +968,7 @@ def _create_model(
     )
 
     if engine_type == DEEPSPARSE_ENGINE:
-        model = compile_model(
-            onnx_path, batch_size=1, num_cores=num_cores, num_sockets=num_sockets
-        )
+        model = compile_model(onnx_path, batch_size=1, num_cores=num_cores)
     elif engine_type == ORT_ENGINE:
         _validate_ort_import()
         sess_options = onnxruntime.SessionOptions()

--- a/examples/huggingface-transformers/squad_eval.py
+++ b/examples/huggingface-transformers/squad_eval.py
@@ -19,7 +19,6 @@ DeepSparse Engine or onnxruntime
 ##########
 Command help:
 usage: squad_eval.py [-h] [-c NUM_CORES] [-e {deepsparse,onnxruntime}]
-                     [-s NUM_SOCKETS]
                      [--max-sequence-length MAX_SEQUENCE_LENGTH]
                      onnx_filepath
 
@@ -37,10 +36,6 @@ optional arguments:
   -e {deepsparse,onnxruntime}, --engine {deepsparse,onnxruntime}
                         Inference engine backend to run eval on. Choices are
                         'deepsparse', 'onnxruntime'. Default is 'deepsparse'
-  -s NUM_SOCKETS, --num-sockets NUM_SOCKETS
-                        For DeepSparse only. The number of physical cores to
-                        run the eval on. Defaults to None where it uses all
-                        sockets available on the system
   --max-sequence-length MAX_SEQUENCE_LENGTH
                         the max sequence length for model inputs. Default is
                         384
@@ -96,17 +91,6 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        "-s",
-        "--num-sockets",
-        type=int,
-        default=None,
-        help=(
-            "For DeepSparse only. The number of physical sockets to run the "
-            "eval on. Defaults to None where is uses all sockets available on the "
-            "system"
-        ),
-    )
-    parser.add_argument(
         "--max-sequence-length",
         help="the max sequence length for model inputs. Default is 384",
         type=int,
@@ -127,7 +111,6 @@ def squad_eval(args):
         model_path=args.onnx_filepath,
         engine_type=args.engine,
         num_cores=args.num_cores,
-        num_sockets=args.num_sockets,
         max_length=args.max_sequence_length,
     )
     print(f"Engine info: {question_answer.model}")

--- a/examples/huggingface-transformers/squad_inference.py
+++ b/examples/huggingface-transformers/squad_inference.py
@@ -19,7 +19,6 @@ BERT-QA ONNX model and the DeepSparse engine
 ##########
 Command help:
 usage: squad_inference.py [-h] [-c NUM_CORES] [-e {deepsparse,onnxruntime}]
-                          [-s NUM_SOCKETS]
                           [--max-sequence-length MAX_SEQUENCE_LENGTH]
                           [--num-samples NUM_SAMPLES]
                           [--display-frequency DISPLAY_FREQUENCY]
@@ -41,10 +40,6 @@ optional arguments:
                         Inference engine backend to run application on.
                         Choices are 'deepsparse', 'onnxruntime'. Default is
                         'deepsparse'
-  -s NUM_SOCKETS, --num-sockets NUM_SOCKETS
-                        For DeepSparse only. The number of physical cores to
-                        run the benchmark on. Defaults to None where is uses
-                        all sockets available on the system
   --max-sequence-length MAX_SEQUENCE_LENGTH
                         the max sequence length for model inputs. Default is
                         384
@@ -110,17 +105,6 @@ def parse_args():
         ),
     )
     parser.add_argument(
-        "-s",
-        "--num-sockets",
-        type=int,
-        default=None,
-        help=(
-            "For DeepSparse only. The number of physical cores to run the "
-            "benchmark on. Defaults to None where is uses all sockets available on the "
-            "system"
-        ),
-    )
-    parser.add_argument(
         "--max-sequence-length",
         help="the max sequence length for model inputs. Default is 384",
         type=int,
@@ -167,7 +151,6 @@ def squad_inference(args):
         model_path=args.onnx_filepath,
         engine_type=args.engine,
         num_cores=args.num_cores,
-        num_sockets=args.num_sockets,
         max_length=args.max_sequence_length,
     )
 


### PR DESCRIPTION
Summary: Callers specify a core count and depend on the engine to figure out how to distribute them across sockets.