### PR TITLE
Add documentation for num_threads in engine config struct

### DIFF
--- a/docs/source/c++api-overview.md
+++ b/docs/source/c++api-overview.md
@@ -99,6 +99,8 @@ This file contains a structure that is used in the call to create the engine. Th
 
 **batch_size** - The batch size refers to the process of concatenating input and output tensors into a contiguous batched tensor. See [DeepSparse Engine documentation](https://docs.neuralmagic.com/deepsparse/) about the performance trade-offs of batching.
 
+**num_threads** - The number of worker threads for the engine to use while executing a model.  If left as 0, the engine will select a default number of worker threads.
+
 
 ### Dimensions
 


### PR DESCRIPTION
I've added a num_threads field to the engine's config structure.  It can be used to select the number of worker threads in the engine.