### PR TITLE
Create `deepsparse.benchmark` CLI script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,7 @@ def _setup_entry_points() -> Dict:
     return {
         "console_scripts": [
             "deepsparse.check_hardware=deepsparse.cpu:print_hardware_capability",
+            "deepsparse.benchmark=deepsparse.benchmark_model.benchmark_model:main",
         ]
     }
 

--- a/src/deepsparse/benchmark_model/__init__.py
+++ b/src/deepsparse/benchmark_model/__init__.py
@@ -11,22 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import logging
-
-
-def log_init(name):
-    logger = logging.getLogger(name)
-
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    formatter = logging.Formatter(
-        "[%(levelname)6s %(filename)14s:%(lineno)4s] %(message)s"
-    )
-    ch.setFormatter(formatter)
-    logger.addHandler(ch)
-
-    logger.propagate = 0
-    logger.setLevel(logging.DEBUG)
-
-    return logger

--- a/src/deepsparse/benchmark_model/benchmark.py
+++ b/src/deepsparse/benchmark_model/benchmark.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import queue
+import threading
+import time
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from deepsparse import Engine, Scheduler, compile_model
+from deepsparse.utils import generate_random_inputs
+
+
+__all__ = ["model_stream_benchmark"]
+
+
+def verify_output(outputs: List[np.ndarray], correct_outputs: List[np.ndarray]):
+    assert len(correct_outputs) == len(outputs)
+    for i in range(len(correct_outputs)):
+        gt_output = correct_outputs[i]
+        nm_output = outputs[i]
+
+        assert gt_output.shape == nm_output.shape
+        assert type(gt_output) == type(nm_output)
+
+        max_diff = np.max(np.abs(nm_output - gt_output))
+        if not np.allclose(nm_output, gt_output, 0.0, 8.0e-4):
+            raise Exception(
+                "ERROR: output {}: {} {} MAX DIFF: {}".format(
+                    i, gt_output.shape, nm_output.shape, max_diff
+                )
+            )
+
+
+def iteration(model: Engine, input: List[np.ndarray]):
+    start = time.time()
+    output = model(input)
+    end = time.time()
+    return output, start, end
+
+
+def singlestream_benchmark(
+    model: Engine,
+    input_list: List[np.ndarray],
+    output_list: Optional[List[np.ndarray]],
+    seconds_to_run: float,
+) -> List[float]:
+    batch_times = []
+
+    stream_end_time = time.time() + seconds_to_run
+    while time.time() < stream_end_time:
+        output, start, end = iteration(model, input_list)
+        batch_times.append([start, end])
+        if output_list:
+            verify_output(output, output_list)
+
+    return batch_times
+
+
+class EngineExecutorThread(threading.Thread):
+    def __init__(
+        self,
+        model: Engine,
+        input_list: List[np.ndarray],
+        output_list: Optional[List[np.ndarray]],
+        time_queue: queue.Queue,
+        max_time: float,
+    ):
+        super(EngineExecutorThread, self).__init__()
+        self._model = model
+        self._input_list = input_list
+        self._output_list = output_list
+        self._time_queue = time_queue
+        self._max_time = max_time
+
+    def run(self):
+        while time.time() < self._max_time:
+            output, start, end = iteration(self._model, self._input_list)
+            self._time_queue.put([start, end])
+            if self._output_list:
+                verify_output(output, self._output_list)
+
+
+def multistream_benchmark(
+    model: Engine,
+    input_list: List[np.ndarray],
+    output_list: Optional[List[np.ndarray]],
+    seconds_to_run: float,
+    num_streams: int,
+) -> List[float]:
+    time_queue = queue.Queue()
+    max_time = time.time() + seconds_to_run
+    threads = []
+
+    for thread in range(num_streams):
+        threads.append(
+            EngineExecutorThread(model, input_list, output_list, time_queue, max_time)
+        )
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    return list(time_queue.queue)
+
+
+def model_stream_benchmark(
+    model: Engine,
+    input_list: List[np.ndarray],
+    output_list: Optional[List[np.ndarray]],
+    scenario: str,
+    seconds_to_run: float,
+    num_streams: int,
+) -> Dict:
+    batch_times = []
+
+    # Run the benchmark scenario and collect batch times
+    if scenario == "singlestream":
+        batch_times = singlestream_benchmark(
+            model, input_list, output_list, seconds_to_run
+        )
+    elif scenario == "multistream":
+        batch_times = multistream_benchmark(
+            model, input_list, output_list, seconds_to_run, num_streams
+        )
+    else:
+        raise Exception(f"Unknown scenario '{scenario}'")
+
+    # Convert times to milliseconds
+    batch_times_ms = [
+        (batch_time[1] - batch_time[0]) * 1000 for batch_time in batch_times
+    ]
+
+    # Calculate statistics
+    first_start_time = min([b[0] for b in batch_times])
+    last_end_time = max([b[1] for b in batch_times])
+    total_time_executing = last_end_time - first_start_time
+
+    items_per_sec = (model.batch_size * len(batch_times)) / total_time_executing
+
+    percentiles = [25.0, 50.0, 75.0, 90.0, 95.0, 99.0, 99.9]
+    buckets = np.percentile(batch_times_ms, percentiles).tolist()
+    percentiles_dict = {
+        "{:2.1f}%".format(key): value for key, value in zip(percentiles, buckets)
+    }
+    benchmark_dict = {
+        "scenario": scenario,
+        "items_per_sec": items_per_sec,
+        "seconds_ran": total_time_executing,
+        "iterations": len(batch_times_ms),
+        "median": np.median(batch_times_ms),
+        "mean": np.mean(batch_times_ms),
+        "std": np.std(batch_times_ms),
+        **percentiles_dict,
+    }
+    return benchmark_dict

--- a/src/deepsparse/benchmark_model/benchmark.py
+++ b/src/deepsparse/benchmark_model/benchmark.py
@@ -96,7 +96,9 @@ def model_stream_benchmark(
     seconds_to_run: float,
     num_streams: int,
 ) -> Dict:
-    batch_times = []
+
+    # Warmup the engine for a second
+    singlestream_benchmark(model, input_list, 1.0)
 
     # Run the benchmark scenario and collect batch times
     if scenario == "singlestream":

--- a/src/deepsparse/benchmark_model/benchmark_model.py
+++ b/src/deepsparse/benchmark_model/benchmark_model.py
@@ -16,8 +16,6 @@ import argparse
 import json
 import logging
 import os
-import re
-from typing import List, Union
 
 from deepsparse import Scheduler, compile_model
 from deepsparse.benchmark_model.benchmark import model_stream_benchmark
@@ -56,8 +54,9 @@ def parse_args():
         "--input_shapes",
         type=str,
         default="",
-        help='Override the shapes of the inputs, i.e. -shapes "[1,2,3],[4,5,6],[7,8,9]" '
-        "results in input0=[1,2,3] input1=[4,5,6] input2=[7,8,9]",
+        help="Override the shapes of the inputs, "
+        'i.e. -shapes "[1,2,3],[4,5,6],[7,8,9]" results in '
+        "input0=[1,2,3] input1=[4,5,6] input2=[7,8,9]",
     )
     parser.add_argument(
         "-ncores",
@@ -93,8 +92,9 @@ def parse_args():
         type=int,
         default=None,
         help=(
-            "The number of streams that will execute in parallel using async scenario. "
-            "Default is automatically determined for given hardware and may be sub-optimal."
+            "The number of streams that will submit inferences in parallel using "
+            "async scenario. Default is automatically determined for given hardware "
+            "and may be sub-optimal."
         ),
     )
     parser.add_argument(
@@ -177,7 +177,7 @@ def main():
     log.info(model)
 
     # Generate random inputs to feed the model
-    # TODO(mgoin): should be able to query the Engine class instead of loading the ONNX again
+    # TODO(mgoin): should be able to query Engine class instead of loading ONNX
     if input_shapes:
         with override_onnx_input_shapes(args.model_path, input_shapes) as model_path:
             input_list = generate_random_inputs(model_path, args.batch_size)
@@ -185,12 +185,11 @@ def main():
         input_list = generate_random_inputs(args.model_path, args.batch_size)
 
     # If num_streams isn't defined, find a default
-    if not args.num_streams and scenario is not "singlestream":
+    if not args.num_streams and scenario not in "singlestream":
         args.num_streams = int(model.num_cores / 2)
         log.info(
-            "num_streams default value chosen of {}. This requires tuning and may be sub-optimal".format(
-                args.num_streams
-            )
+            "num_streams default value chosen of {}. "
+            "This requires tuning and may be sub-optimal".format(args.num_streams)
         )
 
     # Run the model once to warm up

--- a/src/deepsparse/benchmark_model/benchmark_model.py
+++ b/src/deepsparse/benchmark_model/benchmark_model.py
@@ -1,0 +1,252 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import os
+from typing import List, Union
+
+from deepsparse import Scheduler, compile_model
+from deepsparse.benchmark_model.benchmark import model_stream_benchmark
+from deepsparse.utils import generate_random_inputs, override_onnx_input_shapes
+from deepsparse.utils.log import log_init
+
+
+log = log_init(os.path.basename(__file__))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark ONNX models in the DeepSparse Engine"
+    )
+
+    parser.add_argument(
+        "model_path",
+        type=str,
+        help="Path to an ONNX model file or SparseZoo model stub",
+    )
+
+    parser.add_argument(
+        "-b",
+        "--batch_size",
+        type=int,
+        default=1,
+        help="The batch size to run the analysis for. Must be greater than 0",
+    )
+    parser.add_argument(
+        "-shapes",
+        "--input_shapes",
+        type=str,
+        default="",
+        help='Set shape for input, i.e. "input1[1 3 224 224],input2[1 4]" or "[1 3 224 224],[1 4]"',
+    )
+    parser.add_argument(
+        "-ncores",
+        "--num_cores",
+        type=int,
+        default=None,
+        help=(
+            "The number of physical cores to run the analysis on, "
+            "defaults to all physical cores available on the system"
+        ),
+    )
+    parser.add_argument(
+        "-s",
+        "--scenario",
+        type=str,
+        default="async",
+        choices=["async", "sync"],
+        help=(
+            "Choose between using a sync/async scenarios. This is similar to the "
+            "single-stream/multi-stream scenarios. Default value is async."
+        ),
+    )
+    parser.add_argument(
+        "-t",
+        "--time",
+        type=int,
+        default=10,
+        help="The number of seconds the benchmark will run. Default is 10 seconds.",
+    )
+    parser.add_argument(
+        "-nstreams",
+        "--num_streams",
+        type=int,
+        default=None,
+        help=(
+            "The number of streams that will execute in parallel using async scenario. "
+            "Default is automatically determined for given hardware and may be sub-optimal."
+        ),
+    )
+    parser.add_argument(
+        "-pin",
+        "--thread_pinning",
+        type=str,
+        default="true",
+        choices=["true", "false", "numa"],
+        help=(
+            "Enable binding threads to cores ('true' the default), "
+            "threads to cores on sockets ('numa'), or disable ('false')"
+        ),
+    )
+    parser.add_argument(
+        "-x",
+        "--export_path",
+        help="Store results into a JSON file",
+        type=str,
+        default=None,
+    )
+
+    return parser.parse_args()
+
+
+def decide_thread_pinning(pinning_mode: str):
+    pinning_mode = pinning_mode.lower()
+
+    if pinning_mode == "true":
+        os.environ["NM_BIND_THREADS_TO_CORES"] = "1"
+        print("Thread pinning to cores enabled")
+    elif pinning_mode == "false":
+        os.environ["NM_BIND_THREADS_TO_CORES"] = "0"
+        print("Thread pinning to cores disabled, performance may be sub-optimal")
+    elif pinning_mode == "numa":
+        os.environ["NM_BIND_THREADS_TO_CORES"] = "1"
+        os.environ["NM_BIND_THREADS_TO_SOCKETS"] = "1"
+        print("Thread pinning to cores and sockets enabled")
+    else:
+        print(
+            "Recieved invalid option for thread_pinning '{}', skipping".format(
+                pinning_mode
+            )
+        )
+
+
+def parse_input_shapes(shapes: str) -> List[List[int]]:
+    """
+    Reduces a string representation of a list of shapes to an actual list of shapes.
+    Examples:
+    "[[1,2,3],[4,5,6],[7,8,9]]" -> input0=[1,2,3] input1=[4,5,6] input2=[7,8,9]
+    """
+    if not shapes:
+        return None
+    shapes = shapes.replace("[", "").split("],")
+    input_shapes = [map(int, s.replace("]", "").split(",")) for s in shapes]
+    return input_shapes
+
+
+def main():
+
+    args = parse_args()
+
+    decide_thread_pinning(args.thread_pinning)
+    input_shapes = parse_input_shapes(args.input_shapes)
+
+    scheduler = (
+        Scheduler.multi_stream
+        if args.scenario.lower() == "async"
+        else Scheduler.single_stream
+    )
+    scenario = "multistream" if scheduler is Scheduler.multi_stream else "singlestream"
+
+    print("Initializing DeepSparse Engine")
+
+    # Compile the ONNX into the DeepSparse Engine
+    model = compile_model(
+        model=args.model_path,
+        batch_size=args.batch_size,
+        num_cores=args.num_cores,
+        scheduler=scheduler,
+        # input_shapes=input_shapes,
+    )
+    print(model)
+
+    # Generate random inputs to feed the model
+    # TODO(mgoin): should be able to query the Engine class instead of loading the ONNX again
+    if input_shapes:
+        with override_onnx_input_shapes(args.model_path, input_shapes) as model_path:
+            input_list = generate_random_inputs(model_path, args.batch_size)
+    else:
+        input_list = generate_random_inputs(args.model_path, args.batch_size)
+
+    # If num_streams isn't defined, find a default
+    if not args.num_streams and scenario is not "singlestream":
+        args.num_streams = int(model.num_cores / 4)
+        print(
+            "--num_streams default value chosen of {}. This requires tuning and may be sub-optimal".format(
+                args.num_streams
+            )
+        )
+
+    _, first_run_ms = model.timed_run(input_list)
+
+    print("Initial inference took {:.4f} ms".format(first_run_ms))
+
+    print(
+        "Starting '{}' performance measurements for {} seconds".format(
+            args.scenario, args.time
+        )
+    )
+
+    benchmark_result = model_stream_benchmark(
+        model,
+        input_list,
+        None,
+        scenario,
+        args.time,
+        args.num_streams,
+    )
+
+    # Print Summary
+    headers = [
+        "Scenario",
+        "Throughput",
+        "Mean (ms)",
+        "Median (ms)",
+        "Std (ms)",
+        "Iterations",
+    ]
+    header_format = " {:<13} |" * len(headers)
+    print(header_format.format(*headers))
+    row_format = " {:<13} |" + " {:<13.4f} |" * (len(headers) - 1)
+    print(
+        row_format.format(
+            scenario,
+            benchmark_result["items_per_sec"],
+            benchmark_result["mean"],
+            benchmark_result["median"],
+            benchmark_result["std"],
+            benchmark_result["iterations"],
+        )
+    )
+
+    if args.export_path:
+        export_dict = {
+            "engine": model,
+            "onnx_filename": args.model_path,
+            "batch_size": args.batch_size,
+            "num_cores": args.num_cores,
+            "scheduler": model.scheduler,
+            "seconds_to_run": args.time,
+            "num_streams": args.num_streams,
+            "benchmark_result": benchmark_result,
+        }
+        print(export_dict)
+
+        with open(args.export_path, "w") as out:
+            print(f"Saving JSON output to {args.export_path}")
+            json.dump(export_dict, out, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deepsparse/benchmark_model/benchmark_model.py
+++ b/src/deepsparse/benchmark_model/benchmark_model.py
@@ -18,7 +18,7 @@ import logging
 import os
 
 from deepsparse import Scheduler, compile_model
-from deepsparse.benchmark_model.benchmark import model_stream_benchmark
+from deepsparse.benchmark_model.stream_benchmark import model_stream_benchmark
 from deepsparse.utils import (
     generate_random_inputs,
     model_to_path,
@@ -132,12 +132,14 @@ def decide_thread_pinning(pinning_mode: str):
     if pinning_mode in "core":
         os.environ["NM_BIND_THREADS_TO_CORES"] = "1"
         log.info("Thread pinning to cores enabled")
+    elif pinning_mode in "numa":
+        os.environ["NM_BIND_THREADS_TO_CORES"] = "0"
+        os.environ["NM_BIND_THREADS_TO_SOCKETS"] = "1"
+        log.info("Thread pinning to socket/numa nodes enabled")
     elif pinning_mode in "none":
         os.environ["NM_BIND_THREADS_TO_CORES"] = "0"
-        log.info("Thread pinning to cores disabled, performance may be sub-optimal")
-    elif pinning_mode in "numa":
-        os.environ["NM_BIND_THREADS_TO_SOCKETS"] = "1"
-        log.info("Thread pinning to cores and sockets enabled")
+        os.environ["NM_BIND_THREADS_TO_SOCKETS"] = "0"
+        log.info("Thread pinning disabled, performance may be sub-optimal")
     else:
         log.info(
             "Recieved invalid option for thread_pinning '{}', skipping".format(

--- a/src/deepsparse/benchmark_model/stream_benchmark.py
+++ b/src/deepsparse/benchmark_model/stream_benchmark.py
@@ -116,6 +116,10 @@ def model_stream_benchmark(
     ]
 
     # Calculate statistics
+    # Note: We want to know all of the executions that could be performed within a
+    # given amount of wallclock time. This calculation as-is includes the test overhead
+    # such as saving timing results for each iteration so it isn't a best-case but is a
+    # realistic case.
     first_start_time = min([b[0] for b in batch_times])
     last_end_time = max([b[1] for b in batch_times])
     total_time_executing = last_end_time - first_start_time

--- a/src/deepsparse/cpu.py
+++ b/src/deepsparse/cpu.py
@@ -120,6 +120,14 @@ def _parse_arch_bin() -> architecture:
         info_str = subprocess.check_output(file_path).decode("utf-8")
         return architecture(json.loads(info_str))
 
+    except subprocess.CalledProcessError as ex:
+        error = json.loads(ex.stdout)
+        raise OSError(
+            "Neural Magic: Encountered exception while trying read arch.bin: {}".format(
+                error["error"]
+            )
+        )
+
     except Exception as ex:
         raise OSError(
             "Neural Magic: Encountered exception while trying read arch.bin: {}".format(

--- a/src/deepsparse/utils/log.py
+++ b/src/deepsparse/utils/log.py
@@ -21,7 +21,7 @@ def log_init(name):
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
-        "[%(levelname)6s %(filename)14s:%(lineno)4s] %(message)s"
+        "[%(levelname)s %(filename)18s:%(lineno)-4s] %(message)s"
     )
     ch.setFormatter(formatter)
     logger.addHandler(ch)


### PR DESCRIPTION
`deepsparse.benchmark` is meant to simplify benchmarking and be the central codepath for benchmarking the engine on ONNX or SparseZoo models, without worrying about end-to-end flows. This is to aid competitive benchmarking against other runtimes.

Example usage:
```
> deepsparse.benchmark zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned-moderate                                                      
[INFO benchmark_model.py:134 ] Thread pinning to cores enabled
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 0.10.0 (4af1c5e3) (optimized) (system=avx512, binary=avx512)
[INFO benchmark_model.py:177 ] deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/c0673523-c5fe-40e4-bfdc-f999876371ea/model.onnx
        batch_size: 1
        num_cores: 18
        num_sockets: 0
        scheduler: Scheduler.multi_stream
        cpu_avx_type: avx512
        cpu_vnni: False
[INFO            onnx.py:176 ] Generating input 'input', type = float32, shape = [1, 3, 224, 224]
[INFO benchmark_model.py:192 ] num_streams default value chosen of 9. This requires tuning and may be sub-optimal
[INFO benchmark_model.py:202 ] Starting 'async' performance measurements for 10 seconds
| Scenario      | Throughput    | Mean (ms)     | Median (ms)   | Std (ms)      | Iterations    
| multistream   | 1992.5518     | 4.4633        | 4.4053        | 0.4183        | 19929.0000 
```
```
> deepsparse.benchmark zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_3layers-aggressive_86 -s sync -shapes "[1,128],[1,128],[1,128]" -b 64
[INFO benchmark_model.py:134 ] Thread pinning to cores enabled
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 0.10.0 (4af1c5e3) (optimized) (system=avx512, binary=avx512)
[INFO benchmark_model.py:177 ] deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/124df9a3-eda9-4b62-bba9-d98c0f1dcb57/model.onnx
        batch_size: 64
        num_cores: 18
        num_sockets: 0
        scheduler: Scheduler.single_stream
        cpu_avx_type: avx512
        cpu_vnni: False
[INFO            onnx.py:176 ] Generating input 'input_ids', type = int64, shape = [64, 128]
[INFO            onnx.py:176 ] Generating input 'attention_mask', type = int64, shape = [64, 128]
[INFO            onnx.py:176 ] Generating input 'token_type_ids', type = int64, shape = [64, 128]
[INFO benchmark_model.py:202 ] Starting 'sync' performance measurements for 10 seconds
| Scenario      | Throughput    | Mean (ms)     | Median (ms)   | Std (ms)      | Iterations    
| singlestream  | 759.8180      | 84.2119       | 76.8535       | 15.9610       | 119.0000 
 ```