### PR TITLE
Add support for the elastic scheduler.

### DIFF
--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -78,11 +78,13 @@ class Scheduler(Enum):
     - default: maps to single_stream
     - single_stream: requests from separate threads execute serially
     - multi_stream: requests from separate threads execute in parallel
+    - elastic: requests from separate threads are distributed across NUMA nodes
     """
 
     default = "default"
     single_stream = "single_stream"
     multi_stream = "multi_stream"
+    elastic = "elastic"
 
     @staticmethod
     def from_str(key: str):
@@ -92,6 +94,8 @@ class Scheduler(Enum):
             return Scheduler.single_stream
         elif key in ("multi", "multi_stream"):
             return Scheduler.multi_stream
+        elif key in ("elastic"):
+            return Scheduler.elastic
         else:
             raise ValueError(f"unsupported Scheduler: {key}")
 


### PR DESCRIPTION
The elastic scheduler distributes requests across NUMA nodes rather than opportunistically multi-streaming them within a single node. This eliminates cache contention between requests which is beneficial for many workloads.