### PR TITLE
Better failure message when arch.bin fails

### DIFF
--- a/src/deepsparse/cpu.py
+++ b/src/deepsparse/cpu.py
@@ -120,6 +120,14 @@ def _parse_arch_bin() -> architecture:
         info_str = subprocess.check_output(file_path).decode("utf-8")
         return architecture(json.loads(info_str))
 
+    except subprocess.CalledProcessError as ex:
+        error = json.loads(ex.stdout)
+        raise OSError(
+            "Neural Magic: Encountered exception while trying read arch.bin: {}".format(
+                error["error"]
+            )
+        )
+
     except Exception as ex:
         raise OSError(
             "Neural Magic: Encountered exception while trying read arch.bin: {}".format(


### PR DESCRIPTION
When arch.bin fails it will create a dummy json object with a more detailed error message.