### PR TITLE
Pipelines raw data api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ def _setup_entry_points() -> Dict:
         "console_scripts": [
             "deepsparse.check_hardware=deepsparse.cpu:print_hardware_capability",
             "deepsparse.benchmark=deepsparse.benchmark_model.benchmark_model:main",
+            "deepsparse.pipeline=deepsparse.transformers.pipelines_cli:cli",
         ]
     }
 

--- a/setup.py
+++ b/setup.py
@@ -160,11 +160,12 @@ def _setup_extras() -> Dict:
 
 
 def _setup_entry_points() -> Dict:
+    data_api_entrypoint = "deepsparse.transformers.pipelines_cli:cli"
     return {
         "console_scripts": [
+            f"deepsparse.transformers.pipeline={data_api_entrypoint}",
             "deepsparse.check_hardware=deepsparse.cpu:print_hardware_capability",
             "deepsparse.benchmark=deepsparse.benchmark_model.benchmark_model:main",
-            "deepsparse.pipeline=deepsparse.transformers.pipelines_cli:cli",
         ]
     }
 

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ def _setup_entry_points() -> Dict:
     data_api_entrypoint = "deepsparse.transformers.pipelines_cli:cli"
     return {
         "console_scripts": [
-            f"deepsparse.transformers.pipeline={data_api_entrypoint}",
+            f"deepsparse.transformers.run_inference={data_api_entrypoint}",
             "deepsparse.check_hardware=deepsparse.cpu:print_hardware_capability",
             "deepsparse.benchmark=deepsparse.benchmark_model.benchmark_model:main",
         ]

--- a/src/deepsparse/transformers/loaders.py
+++ b/src/deepsparse/transformers/loaders.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utilities for loading batches from files for pipelines
+"""
+
+import json
+from abc import ABC, abstractmethod
+from csv import DictReader
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+__all__ = [
+    "get_batch_loader",
+]
+
+
+class _BatchLoader(ABC):
+    # Base class for all BatchLoaders
+    def __init__(self, data_file: str, batch_size: int = 1):
+        self.data_file = data_file
+        self.batch_size = batch_size
+        self.header = None
+
+    @abstractmethod
+    def __iter__(self) -> Optional[Dict[str, Any]]:
+        raise NotImplementedError
+
+
+class _DictBatchLoader(_BatchLoader):
+    def add_to_batch(
+        self,
+        input_sample: Dict[str, Any],
+        batch: Optional[Dict[str, List[Any]]],
+    ) -> Dict[str, List[Any]]:
+        """
+        Add dict type input to batch
+        Note: Updates the header with keys of input_sample, if batch evaluates
+        to False.
+
+        :param input_sample: A dict representing one sample
+        :param batch: A dict with same keys as input
+        :return: items of input_sample appended to the right keys
+        """
+        if not batch:
+            self.header = list(input_sample.keys())
+            batch = {key: [input_sample[key]] for key in self.header}
+        else:
+            for key in self.header:
+                batch[key].append(input_sample[key])
+        return batch
+
+    def pad_last_batch(self, batch):
+        """
+        Pads the batch with last added value
+        Batch must have at-least one value
+
+        :param batch: The batch to be padded to batch_size
+        :return: The padded batch
+        """
+        if self.header and 0 < len(batch[self.header[0]]) < self.batch_size:
+            for key in self.header:
+                repeat_element = batch[key][-1]
+                copies_needed = self.batch_size - len(batch[key])
+                extra_elements = [repeat_element] * copies_needed
+                batch[key].extend(extra_elements)
+
+            yield batch
+
+    def __iter__(self) -> Optional[Dict[str, Any]]:
+        raise NotImplementedError
+
+
+class _JSONBatchLoader(_DictBatchLoader):
+    # Convenience class to read batches from JSON files
+
+    def __iter__(self) -> Optional[Dict[str, Any]]:
+        # Note: json file should contain one json object per line
+        batch = None
+        with open(self.data_file) as f:
+            for line in f:
+                _input = json.loads(line)
+                batch = self.add_to_batch(_input, batch)
+                if len(batch[self.header[0]]) == self.batch_size:
+                    yield batch
+                    batch = {key: [] for key in batch}
+        yield from self.pad_last_batch(batch)
+
+
+class _CSVBatchLoader(_DictBatchLoader):
+    # Convenience class to read batches from CSV files
+
+    def __iter__(self) -> Optional[Dict[str, Any]]:
+        batch = None
+        with open(self.data_file) as f:
+            reader = DictReader(f)
+            for _input in reader:
+                batch = self.add_to_batch(_input, batch)
+                if len(batch[self.header[0]]) == self.batch_size:
+                    yield batch
+                    batch = {key: [] for key in batch}
+        yield from self.pad_last_batch(batch)
+
+
+class _TextBatchLoader(_BatchLoader):
+    # Convenience class to read batches from TEXT files
+    # Note: Does not support Question-Answering task
+
+    def __init__(self, data_file: str, batch_size: int = 1, task: str = None):
+        super().__init__(data_file=data_file, batch_size=batch_size)
+        if task in ["ner", "token-classification"]:
+            self.header = "inputs"
+        elif task in ["sentiment-analysis", "text-classification"]:
+            self.header = "sequences"
+        else:
+            raise ValueError(f"{task} does not support text file as input")
+
+    def __iter__(self) -> Optional[Dict[str, Any]]:
+        batch = []
+        with open(self.data_file) as f:
+            for line in f:
+                batch.append(line.strip())
+                if len(batch) == self.batch_size:
+                    yield {self.header: batch}
+                    batch = []
+        if 0 < len(batch) < self.batch_size:
+            batch.extend([batch[-1]] * (self.batch_size - len(batch)))
+            yield {self.header: batch}
+
+
+def get_batch_loader(
+    data_file: str, batch_size: int = 1, task: str = None
+) -> _BatchLoader:
+    """
+    Returns the corresponding BatchLoader based on filetype
+
+    :param data_file: The file to read data from, can be json, csv, or txt
+    :param batch_size: The batch size to use for creating batches
+    :param task: The task, batches are to be generated for
+    :return: Respective _BatchLoader object based on filetype
+    """
+
+    data_file_obj = Path(data_file)
+    file_type = data_file_obj.suffix
+
+    if file_type == ".json":
+        return _JSONBatchLoader(data_file=data_file, batch_size=batch_size)
+
+    if file_type == ".csv":
+        return _CSVBatchLoader(data_file=data_file, batch_size=batch_size)
+
+    if file_type == ".txt":
+        return _TextBatchLoader(data_file=data_file, batch_size=batch_size, task=task)
+
+    raise ValueError(f"input file type {file_type} not supported")

--- a/src/deepsparse/transformers/loaders.py
+++ b/src/deepsparse/transformers/loaders.py
@@ -39,7 +39,7 @@ class _BatchLoader(ABC):
         self.header = None
 
     @abstractmethod
-    def _get_reader(self) -> List[Dict[str, str]]:
+    def _get_reader(self, filename) -> List[Dict[str, str]]:
         raise NotImplementedError
 
     def add_to_batch(
@@ -96,14 +96,14 @@ class _BatchLoader(ABC):
 class _JSONBatchLoader(_BatchLoader):
     # Convenience class to read batches from JSON files
 
-    def _get_reader(self, filename):
+    def _get_reader(self, filename) -> List[Dict[str, str]]:
         return (json.loads(line) for line in filename)
 
 
 class _CSVBatchLoader(_BatchLoader):
     # Convenience class to read batches from CSV files
 
-    def _get_reader(self, filename):
+    def _get_reader(self, filename) -> List[Dict[str, str]]:
         return DictReader(filename)
 
 
@@ -120,7 +120,7 @@ class _TextBatchLoader(_BatchLoader):
         else:
             raise ValueError(f"{task} does not support text file as input")
 
-    def _get_reader(self, filename):
+    def _get_reader(self, filename) -> List[Dict[str, str]]:
         return ({self.header[0]: line.strip()} for line in filename)
 
 

--- a/src/deepsparse/transformers/loaders.py
+++ b/src/deepsparse/transformers/loaders.py
@@ -39,7 +39,7 @@ class _BatchLoader(ABC):
         self.header = None
 
     @abstractmethod
-    def _get_reader(self):
+    def _get_reader(self) -> List[Dict[str, str]]:
         raise NotImplementedError
 
     def add_to_batch(
@@ -84,8 +84,8 @@ class _BatchLoader(ABC):
     def __iter__(self) -> Optional[Dict[str, Any]]:
         # Note: json file should contain one json object per line
         batch = None
-        with open(self.data_file) as f:
-            for _input in self._get_reader(f):
+        with open(self.data_file) as _input_file:
+            for _input in self._get_reader(_input_file):
                 batch = self.add_to_batch(_input, batch)
                 if len(batch[self.header[0]]) == self.batch_size:
                     yield batch
@@ -96,15 +96,15 @@ class _BatchLoader(ABC):
 class _JSONBatchLoader(_BatchLoader):
     # Convenience class to read batches from JSON files
 
-    def _get_reader(self, f):
-        return (json.loads(line) for line in f)
+    def _get_reader(self, filename):
+        return (json.loads(line) for line in filename)
 
 
 class _CSVBatchLoader(_BatchLoader):
     # Convenience class to read batches from CSV files
 
-    def _get_reader(self, f):
-        return DictReader(f)
+    def _get_reader(self, filename):
+        return DictReader(filename)
 
 
 class _TextBatchLoader(_BatchLoader):
@@ -120,8 +120,8 @@ class _TextBatchLoader(_BatchLoader):
         else:
             raise ValueError(f"{task} does not support text file as input")
 
-    def _get_reader(self, f):
-        return ({self.header[0]: line.strip()} for line in f)
+    def _get_reader(self, filename):
+        return ({self.header[0]: line.strip()} for line in filename)
 
 
 def get_batch_loader(
@@ -148,4 +148,4 @@ def get_batch_loader(
     if file_type == ".txt":
         return _TextBatchLoader(data_file=data_file, batch_size=batch_size, task=task)
 
-    raise ValueError(f"input file type {file_type} not supported")
+    raise ValueError(f"input file {data_file} not supported")

--- a/src/deepsparse/transformers/pipelines.py
+++ b/src/deepsparse/transformers/pipelines.py
@@ -63,6 +63,8 @@ __all__ = [
     "QuestionAnsweringPipeline",
     "pipeline",
     "overwrite_transformer_onnx_model_inputs",
+    "SUPPORTED_ENGINES",
+    "SUPPORTED_TASKS",
 ]
 
 logger = logging.get_logger(__name__) if logging else None

--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -103,9 +103,7 @@ __all__ = [
     "cli",
 ]
 
-MODEL_DIR = os.getenv("MODEL_DIR")
-if MODEL_DIR is None:
-    MODEL_DIR = "MODEL"
+MODEL_DIR = os.getenv("MODEL_DIR") or ""
 
 
 def _parse_args() -> argparse.Namespace:

--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -36,9 +36,9 @@ optional arguments:
   --task {ner,question-answering,sentiment-analysis,text-classification,
   token-classification}
                         Name of the task to define which pipeline to
-                        create.Currently supported tasks dict_keys(['ner',
+                        create.Currently supported tasks ['ner',
                         'question-answering', 'sentiment-analysis', 'text-
-                        classification', 'token-classification'])
+                        classification', 'token-classification']
   -d DATA, --data DATA  Path to file containing data for inferences, inputs
                         should be separated via newline
   --model-name MODEL_NAME, --model_name MODEL_NAME
@@ -91,11 +91,10 @@ Example commands:
 """
 
 import argparse
-import json
 from typing import Optional
 
-from .loaders import SUPPORTED_EXTENSIONS, get_batch_loader
-from .pipelines import SUPPORTED_ENGINES, SUPPORTED_TASKS, pipeline
+from .loaders import SUPPORTED_EXTENSIONS
+from .pipelines import SUPPORTED_ENGINES, SUPPORTED_TASKS, pipeline, process_dataset
 
 
 __all__ = [
@@ -112,7 +111,7 @@ def _parse_args() -> argparse.Namespace:
         "-t",
         "--task",
         help="Name of the task to define which pipeline to create."
-        f"Currently supported tasks {SUPPORTED_TASKS.keys()}",
+        f" Currently supported tasks {list(SUPPORTED_TASKS.keys())}",
         choices=SUPPORTED_TASKS.keys(),
         type=str,
         default="sentiment-analysis",
@@ -219,25 +218,6 @@ def _parse_args() -> argparse.Namespace:
     return _args
 
 
-def _pipeline_inference(
-    pipeline_object,
-    data_path: str,
-    batch_size: int,
-    task: str,
-    output_path: str,
-):
-    batch_loader = get_batch_loader(
-        data_file=data_path,
-        batch_size=batch_size,
-        task=task,
-    )
-
-    with open(output_path, "a") as output_file:
-        for batch in batch_loader:
-            batch_output = pipeline_object(**batch)
-            json.dump(batch_output, output_file)
-
-
 def cli():
     """
     Cli entrypoint for one-shot inference using pipelines
@@ -256,7 +236,7 @@ def cli():
         batch_size=_args.batch_size,
         scheduler=_args.scheduler,
     )
-    _pipeline_inference(
+    process_dataset(
         pipeline_object=pipe,
         data_path=_args.data,
         output_path=_args.output_file,

--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -1,0 +1,323 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+deepsparse.pipelines entrypoint cli script for one shot inference using
+pipelines
+
+####################
+usage: deepsparse.pipeline [-h]
+                           [-t {ner,question-answering,sentiment-analysis,
+                           text-classification,token-classification}]
+                           -d DATA [--model-name MODEL_NAME] --model-path
+                           MODEL_PATH [--engine-type {deepsparse,onnxruntime}]
+                           [--config CONFIG] [--tokenizer TOKENIZER]
+                           [--max-length MAX_LENGTH] [--num-cores NUM_CORES]
+                           [-b BATCH_SIZE] [--scheduler {multi,single}]
+                           [-o OUTPUT_FILE]
+
+Cli utility for one shot inference using pipelines
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -t {ner,question-answering,sentiment-analysis,text-classification,
+  token-classification},
+  --task {ner,question-answering,sentiment-analysis,text-classification,
+  token-classification}
+                        Name of the task to define which pipeline to
+                        create.Currently supported tasks dict_keys(['ner',
+                        'question-answering', 'sentiment-analysis', 'text-
+                        classification', 'token-classification'])
+  -d DATA, --data DATA  Path to file containing data for inferences, inputs
+                        should be separated via newline
+  --model-name MODEL_NAME, --model_name MODEL_NAME
+                        Canonical name of the hugging face model this model is
+                        based on
+  --model-path MODEL_PATH, --model_path MODEL_PATH
+                        path to (ONNX) model file to run
+  --engine-type {deepsparse,onnxruntime}, --engine_type {deepsparse,onnxruntime}
+                        inference engine name to use. Supported options are
+                        'deepsparse'and 'onnxruntime'
+  --config CONFIG       huggingface model config, if none provided, default
+                        will be usedwhich will be from the model name or
+                        sparsezoo stub if given for model path
+  --tokenizer TOKENIZER
+                        huggingface tokenizer, if none provided, default will
+                        be used
+  --max-length MAX_LENGTH, --max_length MAX_LENGTH
+                        maximum sequence length of model inputs. default is
+                        128
+  --num-cores NUM_CORES, --num_cores NUM_CORES
+                        number of CPU cores to run engine with. Default is the
+                        maximum available
+  -b BATCH_SIZE, --batch-size BATCH_SIZE, --batch_size BATCH_SIZE
+                        The batch size to use for pipelines
+  --scheduler {multi,single}
+                        The scheduler to use for the engine. Can be None,
+                        single or multi
+  -o OUTPUT_FILE, --output-file OUTPUT_FILE, --output_file OUTPUT_FILE
+                        Directs the output to a name of your choice
+####################
+Example commands:
+1) deepsparse.pipeline --task ner \
+    --model-path bert-ner-test.onnx \
+    --data input.txt
+
+2) deepsparse.pipeline --task ner \
+    --model-path models/bert-ner-test.onnx \
+    --data input.txt \
+    --config ner-config.json \
+    --output-file out.txt \
+    --batch_size 2
+
+3) deepsparse.pipeline --task sentiment-analysis \
+    --model_path models/bert-sst-test.onnx \
+    --data models/input.txt \
+    --batch_size 2 \
+    --output_file out.txt
+
+"""
+
+import argparse
+import json
+from csv import reader
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Union
+
+from transformers import PretrainedConfig, PreTrainedTokenizer
+
+from .pipelines import SUPPORTED_ENGINES, SUPPORTED_TASKS, pipeline
+
+
+__all__ = [
+    "cli",
+]
+
+
+@dataclass
+class _PipelineCliArgs:
+    """
+    :param task: name of the task to define which pipeline to create. Currently
+        supported task - ['ner', 'question-answering', 'sentiment-analysis',
+        'text-classification', 'token-classification']
+    :param data: str, List[str], file containing List of strings representing input
+    :param model_name: canonical name of the hugging face model this model is based on
+    :param model_path: path to (ONNX) model file to run
+    :param engine_type: inference engine name to use. Supported options are 'deepsparse'
+        and 'onnxruntime'
+    :param config: huggingface model config, if none provided, default will be used
+        which will be from the model name or sparsezoo stub if given for model path
+    :param tokenizer: huggingface tokenizer, if none provided, default will be used
+    :param max_length: maximum sequence length of model inputs. default is 128
+    :param num_cores: number of CPU cores to run engine with. Default is the maximum
+        available
+    :param batch_size: The batch size to use for pipelines. Defaults to 1.
+    :param scheduler: The scheduler to use for the engine. Can be None, single or multi.
+    :param output_file: File to write output to, omit to print output to stdout
+    :return: Inference results  for each input
+    """
+
+    task: str
+    data: Union[List, str]
+    model_name: Optional[str] = None
+    model_path: Optional[str] = None
+    engine_type: str = SUPPORTED_ENGINES[0]
+    config: Optional[Union[str, PretrainedConfig]] = None
+    tokenizer: Optional[Union[str, PreTrainedTokenizer]] = None
+    max_length: int = 128
+    num_cores: Optional[int] = None
+    batch_size: int = 1
+    scheduler: Optional[str] = None
+    output_file: Optional[argparse.FileType] = None
+
+    def __post_init__(self):
+        data_file = Path(self.data)
+        assert data_file.exists(), f"The input data file must exist, {data_file}"
+        assert data_file.is_file(), f"The input data file must be a file, {data_file}"
+        supported_extensions = [".json", ".csv", ".txt"]
+        assert data_file.suffix in supported_extensions, (
+            f"The input data file must be one of {supported_extensions}, "
+            f"found {data_file.suffix}"
+        )
+
+    @property
+    def data_loader(self):
+        data_file = Path(self.data)
+        extension = data_file.suffix
+        with open(data_file) as f:
+            if extension == ".json":
+                data = json.load(f)
+                gen = data.values()
+
+            elif extension == ".csv":
+                gen = reader(f)
+
+            elif extension == ".txt":
+                gen = (line.strip() for line in f)
+
+            for _input in gen:
+                yield _input
+
+    @property
+    def batch_loader(self):
+        batch = []
+
+        for _ in self.data_loader:
+            batch.append(_)
+            if len(batch) == self.batch_size:
+                yield batch
+                batch = []
+
+
+def _parse_args() -> _PipelineCliArgs:
+    parser = argparse.ArgumentParser(
+        description="Cli utility for one shot inference using pipelines"
+    )
+
+    parser.add_argument(
+        "-t",
+        "--task",
+        help="Name of the task to define which pipeline to create."
+        f"Currently supported tasks {SUPPORTED_TASKS.keys()}",
+        choices=SUPPORTED_TASKS.keys(),
+        type=str,
+        default="sentiment-analysis",
+    )
+
+    parser.add_argument(
+        "-d",
+        "--data",
+        help="Path to file containing data for inferences, "
+        "inputs should be separated via newline",
+        required=True,
+        type=str,
+    )
+
+    parser.add_argument(
+        "--model-name",
+        "--model_name",
+        help="Canonical name of the hugging face model this model is based on",
+        default=None,
+        type=Optional[str],
+    )
+
+    parser.add_argument(
+        "--model-path",
+        "--model_path",
+        help="path to (ONNX) model file to run",
+        required=True,
+        type=str,
+    )
+
+    parser.add_argument(
+        "--engine-type",
+        "--engine_type",
+        help="inference engine name to use. Supported options are 'deepsparse'"
+        "and 'onnxruntime'",
+        type=str,
+        choices=SUPPORTED_ENGINES,
+        default=SUPPORTED_ENGINES[0],
+    )
+
+    parser.add_argument(
+        "--config",
+        help="huggingface model config, if none provided, default will be used"
+        "which will be from the model name or sparsezoo stub if given for "
+        "model path",
+        type=str,
+        default=None,
+    )
+
+    parser.add_argument(
+        "--tokenizer",
+        help="huggingface tokenizer, if none provided, default will be used",
+        type=str,
+        default=None,
+    )
+
+    parser.add_argument(
+        "--max-length",
+        "--max_length",
+        help="maximum sequence length of model inputs. default is 128",
+        type=int,
+        default=128,
+    )
+
+    parser.add_argument(
+        "--num-cores",
+        "--num_cores",
+        help="number of CPU cores to run engine with. Default is the maximum "
+        "available",
+        type=int,
+        default=None,
+    )
+    parser.add_argument(
+        "-b",
+        "--batch-size",
+        "--batch_size",
+        help="The batch size to use for pipelines",
+        type=int,
+        default=1,
+    )
+
+    scheduler_choices = ["multi", "single"]
+    parser.add_argument(
+        "--scheduler",
+        choices=scheduler_choices,
+        help="The scheduler to use for the engine. Can be None, single or multi",
+        default=scheduler_choices[0],
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        "--output_file",
+        action="store",
+        dest="output_file",
+        type=argparse.FileType("w"),
+        help="Directs the output to a name of your choice",
+        default="-",
+    )
+
+    _args = parser.parse_args()
+    return _PipelineCliArgs(**vars(_args))
+
+
+def cli():
+    """
+    Cli entrypoint for one-shot inference using pipelines
+    """
+    _args = _parse_args()
+
+    pipe = pipeline(
+        task=_args.task,
+        model_name=_args.model_name,
+        model_path=_args.model_path,
+        engine_type=_args.engine_type,
+        config=_args.config,
+        tokenizer=_args.tokenizer,
+        max_length=_args.max_length,
+        num_cores=_args.num_cores,
+        batch_size=_args.batch_size,
+        scheduler=_args.scheduler,
+    )
+
+    for batch in _args.batch_loader:
+        batch_output = pipe(batch)
+        _args.output_file.write(str(batch_output))
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
This pull request adds in a cli entrypoint for deepsparse pipeline integration,

The intended usage is as follows:

```bash
$deepsparse.pipeline --task sentiment-analysis \
    --model_path models/bert-sst-test.onnx \
    --data models/input.txt \
    --batch_size 2 \
    --output_file out.txt
```

Where the `input.txt` file contains a single input per line, example contents:
```
Person and Building
Person and Building
```

The cli creates batches and calls the respective pipeline, The `out.txt` should look like
```
[{'label': 'O', 'score': 0.9988996982574463}, {'label': 'O', 'score': 0.9988996982574463}]
```

~Note: This pull request depends on #228~ Landed
~TODOs:~ Completed
 -  [X]  TEST support for JSON input
 -  [X]  TEST support for CSV input
 -  [X]  TEST support for TXT input
 
 Example of JSON and CSV files(for `question-answering` task) is as follows
 
 JSON
 ```
{"question":"What's my name", "context":"My name is Snorlax"}
{"question":"What's my name", "context":"My name is Snorlax"}
{"question":"What's my name", "context":"My name is Snorlax"}
```
CSV
```
question,context
What's my name,My name is Snorlax
What's my name,My name is Snorlax
What's my name,My name is Snorlax
```

