### PR TITLE
Bugfix: numpy float32 object not JSON Serializable

### DIFF
--- a/src/deepsparse/transformers/__init__.py
+++ b/src/deepsparse/transformers/__init__.py
@@ -41,5 +41,6 @@ _check_transformers_install()
 
 
 from .helpers import *
+from .loaders import *
 from .pipelines import *
 from .server import *

--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Optional, Tuple
 
-import numpy as np
+import numpy
 import onnx
 
 from sparsezoo import Zoo
@@ -151,7 +151,7 @@ def fix_numpy_types(func):
         def _normalize_fields(_dict):
             if isinstance(_dict, dict):
                 for field in _dict:
-                    if isinstance(_dict[field], np.generic):
+                    if isinstance(_dict[field], numpy.generic):
                         _dict[field] = _dict[field].item()
 
         if isinstance(result, dict):

--- a/src/deepsparse/transformers/pipelines.py
+++ b/src/deepsparse/transformers/pipelines.py
@@ -1405,6 +1405,7 @@ def process_dataset(
         batch_size=batch_size,
         task=task,
     )
+    # Wraps pipeline object to make numpy types serializable
     pipeline_object = fix_numpy_types(pipeline_object)
     with open(output_path, "a") as output_file:
         for batch in batch_loader:

--- a/src/deepsparse/transformers/pipelines.py
+++ b/src/deepsparse/transformers/pipelines.py
@@ -42,6 +42,7 @@ from transformers.utils import logging
 
 from deepsparse import Engine, compile_model, cpu
 from deepsparse.transformers.helpers import (
+    fix_numpy_types,
     get_onnx_path_and_configs,
     overwrite_transformer_onnx_model_inputs,
 )
@@ -1404,7 +1405,7 @@ def process_dataset(
         batch_size=batch_size,
         task=task,
     )
-
+    pipeline_object = fix_numpy_types(pipeline_object)
     with open(output_path, "a") as output_file:
         for batch in batch_loader:
             batch_output = pipeline_object(**batch)

--- a/src/deepsparse/transformers/server/main.py
+++ b/src/deepsparse/transformers/server/main.py
@@ -48,6 +48,8 @@ except Exception:
         "installing them is to use deepsparse[transformers,server]"
     )
 
+from deepsparse.transformers.helpers import fix_numpy_types
+
 from .schemas import TaskRequestModel, TaskResponseModel
 from .throttled_engine import (
     ThrottleWrapper,
@@ -55,7 +57,7 @@ from .throttled_engine import (
     get_response_model,
     get_throttled_engine_pipeline,
 )
-from .utils import fix_numpy_types, parse_api_settings
+from .utils import parse_api_settings
 
 
 app = FastAPI(


### PR DESCRIPTION
Bugfix: float32 object not JSON Serializable for `deepsparse.transformers.run_inference`

* Move `fix_numpy_types` functions from server.utils to deepsparse.transformers.helpers module

* Update usages accordingly