### PR TITLE
[cherry-pick] numpy float32 object not JSON Serializable (#240)

### DIFF
--- a/src/deepsparse/transformers/__init__.py
+++ b/src/deepsparse/transformers/__init__.py
@@ -41,5 +41,6 @@ _check_transformers_install()
 
 
 from .helpers import *
+from .loaders import *
 from .pipelines import *
 from .server import *

--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Optional, Tuple
 
+import numpy
 import onnx
 
 from sparsezoo import Zoo
@@ -30,6 +31,7 @@ from sparsezoo import Zoo
 __all__ = [
     "get_onnx_path_and_configs",
     "overwrite_transformer_onnx_model_inputs",
+    "fix_numpy_types",
 ]
 
 
@@ -134,3 +136,34 @@ def overwrite_transformer_onnx_model_inputs(
 
 def _get_file_parent(file_path: str) -> str:
     return str(Path(file_path).parent.absolute())
+
+
+def fix_numpy_types(func):
+    """
+    Decorator to fix numpy types in Dicts, List[Dicts], List[List[Dicts]]
+    Because `orjson` does not support serializing individual numpy data types
+    yet
+    """
+
+    def _wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+
+        def _normalize_fields(_dict):
+            if isinstance(_dict, dict):
+                for field in _dict:
+                    if isinstance(_dict[field], numpy.generic):
+                        _dict[field] = _dict[field].item()
+
+        if isinstance(result, dict):
+            _normalize_fields(result)
+        elif result and isinstance(result, list):
+            for element in result:
+                if isinstance(element, list):
+                    for _result in element:
+                        _normalize_fields(_result)
+                else:
+                    _normalize_fields(element)
+
+        return result
+
+    return _wrapper

--- a/src/deepsparse/transformers/pipelines.py
+++ b/src/deepsparse/transformers/pipelines.py
@@ -42,6 +42,7 @@ from transformers.utils import logging
 
 from deepsparse import Engine, compile_model, cpu
 from deepsparse.transformers.helpers import (
+    fix_numpy_types,
     get_onnx_path_and_configs,
     overwrite_transformer_onnx_model_inputs,
 )
@@ -1404,7 +1405,8 @@ def process_dataset(
         batch_size=batch_size,
         task=task,
     )
-
+    # Wraps pipeline object to make numpy types serializable
+    pipeline_object = fix_numpy_types(pipeline_object)
     with open(output_path, "a") as output_file:
         for batch in batch_loader:
             batch_output = pipeline_object(**batch)

--- a/src/deepsparse/transformers/server/main.py
+++ b/src/deepsparse/transformers/server/main.py
@@ -48,6 +48,8 @@ except Exception:
         "installing them is to use deepsparse[transformers,server]"
     )
 
+from deepsparse.transformers.helpers import fix_numpy_types
+
 from .schemas import TaskRequestModel, TaskResponseModel
 from .throttled_engine import (
     ThrottleWrapper,
@@ -55,7 +57,7 @@ from .throttled_engine import (
     get_response_model,
     get_throttled_engine_pipeline,
 )
-from .utils import fix_numpy_types, parse_api_settings
+from .utils import parse_api_settings
 
 
 app = FastAPI(


### PR DESCRIPTION
* Bugfix: float32 object not JSON Serializable for `deepsparse.transformers.run_inference`

* Move `fix_numpy_types` functions from server.utils to deepsparse.transformers.helpers module

* Update usages accordingly

* Bugfix: Address review Comments

* Removed `numpy` alias
* Added a comment before wrapping `pipeline_object` in `process_dataset`