### PR TITLE
[cheery-pick] Removed: Unsupported install pathway, `deepsparse[transformers]`

### DIFF
--- a/examples/huggingface-transformers/requirements.txt
+++ b/examples/huggingface-transformers/requirements.txt
@@ -1,4 +1,4 @@
-deepsparse[transformers]
+deepsparse
 onnxruntime
 Flask_Cors==3.0.10
 Flask==2.0.1

--- a/src/deepsparse/transformers/server/main.py
+++ b/src/deepsparse/transformers/server/main.py
@@ -45,7 +45,9 @@ try:
 except Exception:
     raise ImportError(
         "Server Dependencies not found, the recommended way of"
-        "installing them is to use deepsparse[transformers,server]"
+        "installing them is to use deepsparse[server], transformers"
+        "dependency is installed automatically if "
+        "NM_NO_AUTOINSTALL_TRANSFORMERS env variable is not set."
     )
 
 from deepsparse.transformers.helpers import fix_numpy_types


### PR DESCRIPTION
Removed: Unsupported install pathway, `deepsparse[transformers]`, now dependencies are installed automatically if NM_NO_AUTOINSTALL_TRANSFORMERS env variable is not set (#247)