### PR TITLE
Raise minimum version of protobuf to 3.12.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,13 @@ _PACKAGE_NAME = "deepsparse" if is_release else "deepsparse-nightly"
 # File regexes for binaries to include in package_data
 binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
-_deps = ["numpy>=1.16.3", "onnx>=1.5.0,<=1.10.1", "requests>=2.0.0", "tqdm>=4.0.0", "protobuf>=3.12.2"]
+_deps = [
+    "numpy>=1.16.3",
+    "onnx>=1.5.0,<=1.10.1",
+    "requests>=2.0.0",
+    "tqdm>=4.0.0",
+    "protobuf>=3.12.2",
+]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_base}"]
 _dev_deps = [
     "beautifulsoup4==4.9.3",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ _PACKAGE_NAME = "deepsparse" if is_release else "deepsparse-nightly"
 # File regexes for binaries to include in package_data
 binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
-_deps = ["numpy>=1.16.3", "onnx>=1.5.0,<=1.10.1", "requests>=2.0.0", "tqdm>=4.0.0"]
+_deps = ["numpy>=1.16.3", "onnx>=1.5.0,<=1.10.1", "requests>=2.0.0", "tqdm>=4.0.0", "protobuf>=3.12.2"]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_base}"]
 _dev_deps = [
     "beautifulsoup4==4.9.3",


### PR DESCRIPTION
@andy-neuma found that we can install the engine without verifying we have a recent enough protobuf version

```
>>> from deepsparse.utils import generate_random_inputs
Traceback (most recent call last):
...
AttributeError: module 'google.protobuf.descriptor' has no attribute '_internal_create_key'
```

Upgrading the protobuf package manually fixed it. I picked `protobuf>=3.12.2` by looking at the latest ONNX package