### PR TITLE
Allow input shape override to broadcast across all inputs

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -232,7 +232,8 @@ def override_onnx_input_shapes(
     # Input shapes should be a list of lists, even if there is only one input
     assert all(isinstance(inp, list) for inp in input_shapes)
 
-    # If there is a single input shape given and multiple inputs, duplicate for all inputs
+    # If there is a single input shape given and multiple inputs,
+    # duplicate for all inputs to apply the same shape
     if len(input_shapes) == 1 and len(external_inputs) > 1:
         for i in range(len(external_inputs) - 1):
             input_shapes.append(input_shapes[0])

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -235,7 +235,7 @@ def override_onnx_input_shapes(
     # If there is a single input shape given and multiple inputs,
     # duplicate for all inputs to apply the same shape
     if len(input_shapes) == 1 and len(external_inputs) > 1:
-        for i in range(len(external_inputs) - 1):
+        for _ in range(len(external_inputs) - 1):
             input_shapes.append(input_shapes[0])
 
     # Make sure that input shapes can map to the ONNX model

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -235,8 +235,7 @@ def override_onnx_input_shapes(
     # If there is a single input shape given and multiple inputs,
     # duplicate for all inputs to apply the same shape
     if len(input_shapes) == 1 and len(external_inputs) > 1:
-        for _ in range(len(external_inputs) - 1):
-            input_shapes.append(input_shapes[0])
+        input_shapes.extend([input_shapes[0] for _ in range(1, len(external_inputs))])
 
     # Make sure that input shapes can map to the ONNX model
     assert len(external_inputs) == len(

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -229,14 +229,30 @@ def override_onnx_input_shapes(
         input for input in all_inputs if input.name not in initializer_input_names
     ]
 
-    # Make sure that given input shapes can map to the ONNX model
-    assert len(external_inputs) == len(input_shapes)
-
     # Input shapes should be a list of lists, even if there is only one input
     assert all(isinstance(inp, list) for inp in input_shapes)
 
-    # Overwrite the shapes
+    # If there is a single input shape given and multiple inputs, duplicate for all inputs
+    if len(input_shapes) == 1 and len(external_inputs) > 1:
+        for i in range(len(external_inputs) - 1):
+            input_shapes.append(input_shapes[0])
+
+    # Make sure that input shapes can map to the ONNX model
+    assert len(external_inputs) == len(
+        input_shapes
+    ), "Mismatch of number of model inputs ({}) and override shapes ({})".format(
+        len(external_inputs), len(input_shapes)
+    )
+
+    # Overwrite the input shapes of the model
     for input_idx, external_input in enumerate(external_inputs):
+        assert len(external_input.type.tensor_type.shape.dim) == len(
+            input_shapes[input_idx]
+        ), "Input '{}' shape doesn't match shape override: {} vs {}".format(
+            external_input.name,
+            external_input.type.tensor_type.shape.dim,
+            input_shapes[input_idx],
+        )
         for dim_idx, dim in enumerate(external_input.type.tensor_type.shape.dim):
             dim.dim_value = input_shapes[input_idx][dim_idx]
 


### PR DESCRIPTION
For example, many BERT models have 3 inputs with exactly the same shape.
So instead of writing 
`deepsparse.benchmark bert.onnx --input_shapes [1,128],[1,128],[1,128]`
you can now write
`deepsparse.benchmark bert.onnx --input_shapes [1,128]`
and it will try to apply the shape to all inputs.