### PR TITLE
Add `deepsparse.transformers.eval_downstream` for BERT

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -173,9 +173,11 @@ def _setup_extras() -> Dict:
 
 def _setup_entry_points() -> Dict:
     data_api_entrypoint = "deepsparse.transformers.pipelines_cli:cli"
+    eval_downstream = "deepsparse.transformers.eval_downstream:main"
     return {
         "console_scripts": [
             f"deepsparse.transformers.run_inference={data_api_entrypoint}",
+            f"deepsparse.transformers.eval_downstream={eval_downstream}",
             "deepsparse.check_hardware=deepsparse.cpu:print_hardware_capability",
             "deepsparse.benchmark=deepsparse.benchmark_model.benchmark_model:main",
             "deepsparse.transformers.serve=deepsparse.transformers.server.main:main",

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -49,7 +49,7 @@ optional arguments:
 ##########
 Example command for evaluating a sparse BERT QA model from sparsezoo:
 python eval_downstream.py \
-    zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned-aggressive_98 \
+    zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/base-none \
     --dataset squad
 """
 
@@ -264,7 +264,8 @@ def main():
         sst2_eval(args)
     else:
         raise KeyError(
-            f"Unknown downstream dataset {args.dataset}, available datasets are {SUPPORTED_DATASETS}"
+            f"Unknown downstream dataset {args.dataset}, "
+            f"available datasets are {SUPPORTED_DATASETS}"
         )
 
 

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -58,11 +58,10 @@ import argparse
 
 from tqdm.auto import tqdm
 
-# isort: off
 from deepsparse.transformers import pipeline
-from datasets import load_dataset, load_metric
 
-# isort: on
+
+from datasets import load_dataset, load_metric  # isort: skip
 
 
 DEEPSPARSE_ENGINE = "deepsparse"


### PR DESCRIPTION
Allows evaluating trained BERT models on downstream datasets: squad, mnli, qqp, sst2

```
deepsparse.transformers.eval_downstream zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant_3layers-aggressive_89 --dataset squad

100%|█████████████████████████████████████████████████████████████████████| 10570/10570 [03:49<00:00, 46.02it/s]

SQuAD eval results: {'exact_match': 69.10122989593188, 'f1': 78.35950221732533}
```