### PR TITLE
Add onnxruntime backend to `deepsparse.benchmark`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,9 @@ _transformers_server_deps = [
     "pydantic>=1.8.2",
     "requests>=2.26.0",
 ]
+_onnxruntime_deps = [
+    "onnxruntime>=1.7.0",
+]
 
 
 class OverrideInstall(install):
@@ -168,6 +171,7 @@ def _setup_extras() -> Dict:
     return {
         "dev": _dev_deps,
         "server": _transformers_server_deps,
+        "onnxruntime": _onnxruntime_deps,
     }
 
 

--- a/src/deepsparse/benchmark_model/benchmark_model.py
+++ b/src/deepsparse/benchmark_model/benchmark_model.py
@@ -87,6 +87,7 @@ import os
 
 from deepsparse import Scheduler, compile_model
 from deepsparse.benchmark_model.stream_benchmark import model_stream_benchmark
+from deepsparse.benchmark_model.ort_engine import ORTEngine
 from deepsparse.utils import (
     generate_random_inputs,
     model_to_path,
@@ -97,6 +98,9 @@ from deepsparse.utils.log import log_init
 
 
 log = log_init(os.path.basename(__file__))
+
+DEEPSPARSE_ENGINE = "deepsparse"
+ORT_ENGINE = "onnxruntime"
 
 
 def parse_args():
@@ -177,6 +181,17 @@ def parse_args():
         ),
     )
     parser.add_argument(
+        "-e",
+        "--engine",
+        type=str,
+        default=DEEPSPARSE_ENGINE,
+        choices=[DEEPSPARSE_ENGINE, ORT_ENGINE],
+        help=(
+            "Inference engine backend to run eval on. Choices are 'deepsparse', "
+            "'onnxruntime'. Default is 'deepsparse'"
+        ),
+    )
+    parser.add_argument(
         "-q",
         "--quiet",
         help="Lower logging verbosity",
@@ -236,14 +251,22 @@ def main():
     orig_model_path = args.model_path
     args.model_path = model_to_path(args.model_path)
 
-    # Compile the ONNX into the DeepSparse Engine
-    model = compile_model(
-        model=args.model_path,
-        batch_size=args.batch_size,
-        num_cores=args.num_cores,
-        scheduler=scheduler,
-        input_shapes=input_shapes,
-    )
+    # Compile the ONNX into a runnable model
+    if args.engine == DEEPSPARSE_ENGINE:
+        model = compile_model(
+            model=args.model_path,
+            batch_size=args.batch_size,
+            num_cores=args.num_cores,
+            scheduler=scheduler,
+            input_shapes=input_shapes,
+        )
+    elif args.engine == ORT_ENGINE:
+        model = ORTEngine(
+            model=args.model_path,
+            batch_size=args.batch_size,
+            num_cores=args.num_cores,
+            input_shapes=input_shapes,
+        )
     log.info(model)
 
     # Generate random inputs to feed the model

--- a/src/deepsparse/benchmark_model/benchmark_model.py
+++ b/src/deepsparse/benchmark_model/benchmark_model.py
@@ -86,8 +86,8 @@ import logging
 import os
 
 from deepsparse import Scheduler, compile_model
-from deepsparse.benchmark_model.stream_benchmark import model_stream_benchmark
 from deepsparse.benchmark_model.ort_engine import ORTEngine
+from deepsparse.benchmark_model.stream_benchmark import model_stream_benchmark
 from deepsparse.utils import (
     generate_random_inputs,
     model_to_path,

--- a/src/deepsparse/benchmark_model/ort_engine.py
+++ b/src/deepsparse/benchmark_model/ort_engine.py
@@ -1,0 +1,171 @@
+import time
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+
+import numpy
+
+from deepsparse.benchmark import BenchmarkResults
+from deepsparse.utils import (
+    model_to_path,
+    get_input_names,
+    get_output_names,
+    override_onnx_input_shapes,
+    override_onnx_batch_size,
+)
+
+try:
+    import onnxruntime
+
+    ort_import_error = None
+except Exception as ort_import_err:
+    onnxruntime = None
+    ort_import_error = ort_import_err
+
+try:
+    from sparsezoo import Zoo
+    from sparsezoo.objects import File, Model
+
+    sparsezoo_import_error = None
+except Exception as sparsezoo_err:
+    Zoo = None
+    Model = object
+    File = object
+    sparsezoo_import_error = sparsezoo_err
+
+try:
+    # flake8: noqa
+    from deepsparse.cpu import cpu_architecture
+except ImportError:
+    raise ImportError(
+        "Unable to import deepsparse python apis. "
+        "Please contact support@neuralmagic.com"
+    )
+
+__all__ = ["ORTEngine"]
+
+ARCH = cpu_architecture()
+NUM_CORES = ARCH.num_physical_cores
+
+
+def _validate_ort_import():
+    if ort_import_error is not None:
+        raise ImportError(
+            "An exception occurred when importing onxxruntime. Please verify that "
+            "onnxruntime is installed in order to use the onnxruntime inference "
+            f"engine. \n\nException info: {ort_import_error}"
+        )
+
+
+def _validate_batch_size(batch_size: int) -> int:
+    if batch_size < 1:
+        raise ValueError("batch_size must be greater than 0")
+
+    return batch_size
+
+
+class ORTEngine(object):
+    def __init__(
+        self,
+        model: Union[str, Model, File],
+        batch_size: int,
+        num_cores: Union[None, int],
+        input_shapes: List[List[int]] = None,
+    ):
+        _validate_ort_import()
+        self._model_path = model_to_path(model)
+        self._batch_size = _validate_batch_size(batch_size)
+        self._num_cores = num_cores
+        self._input_shapes = input_shapes
+
+        self._input_names = get_input_names(self._model_path)
+        self._output_names = get_output_names(self._model_path)
+
+        sess_options = onnxruntime.SessionOptions()
+        sess_options.log_severity_level = 3
+        if num_cores is not None:
+            sess_options.intra_op_num_threads = num_cores
+
+        with override_onnx_batch_size(
+            self._model_path, batch_size
+        ) as batch_override_model_path:
+            if self._input_shapes:
+                with override_onnx_input_shapes(
+                    batch_override_model_path, self._input_shapes
+                ) as input_override_model_path:
+                    self._eng_net = onnxruntime.InferenceSession(
+                        input_override_model_path, sess_options
+                    )
+            else:
+                self._eng_net = onnxruntime.InferenceSession(
+                    batch_override_model_path, sess_options
+                )
+
+    def __call__(
+        self,
+        inp: List[numpy.ndarray],
+        val_inp: bool = True,
+    ) -> List[numpy.ndarray]:
+        return self.run(inp, val_inp)
+
+    def __repr__(self):
+        """
+        :return: Unambiguous representation of the current model instance
+        """
+        return "{}({})".format(self.__class__, self._properties_dict())
+
+    def __str__(self):
+        """
+        :return: Human readable form of the current model instance
+        """
+        formatted_props = [
+            "\t{}: {}".format(key, val) for key, val in self._properties_dict().items()
+        ]
+
+        return "{}:\n{}".format(
+            self.__class__.__name__,
+            "\n".join(formatted_props),
+        )
+
+    @property
+    def model_path(self) -> str:
+        """
+        :return: The local path to the model file the current instance was compiled from
+        """
+        return self._model_path
+
+    @property
+    def batch_size(self) -> int:
+        """
+        :return: The batch size of the inputs to be used with the model
+        """
+        return self._batch_size
+
+    @property
+    def num_cores(self) -> int:
+        """
+        :return: The number of physical cores the current instance is running on
+        """
+        return self._num_cores if self._num_cores else NUM_CORES
+
+    def run(
+        self,
+        inp: List[numpy.ndarray],
+        val_inp: bool = True,
+    ) -> List[numpy.ndarray]:
+        inputs_dict = {name: value for name, value in zip(self._input_names, inp)}
+        return self._eng_net.run(self._output_names, inputs_dict)
+
+    def timed_run(
+        self, inp: List[numpy.ndarray], val_inp: bool = False
+    ) -> Tuple[List[numpy.ndarray], float]:
+        start = time.time()
+        out = self.run(inp, val_inp)
+        end = time.time()
+
+        return out, end - start
+
+    def _properties_dict(self) -> Dict:
+        return {
+            "onnx_file_path": self._model_path,
+            "batch_size": self._batch_size,
+            "num_cores": self._num_cores,
+        }

--- a/src/deepsparse/benchmark_model/ort_engine.py
+++ b/src/deepsparse/benchmark_model/ort_engine.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import time
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
@@ -5,12 +19,13 @@ import numpy
 
 from deepsparse.benchmark import BenchmarkResults
 from deepsparse.utils import (
-    model_to_path,
     get_input_names,
     get_output_names,
-    override_onnx_input_shapes,
+    model_to_path,
     override_onnx_batch_size,
+    override_onnx_input_shapes,
 )
+
 
 try:
     import onnxruntime

--- a/src/deepsparse/benchmark_model/ort_engine.py
+++ b/src/deepsparse/benchmark_model/ort_engine.py
@@ -58,7 +58,7 @@ except ImportError:
 __all__ = ["ORTEngine"]
 
 ARCH = cpu_architecture()
-NUM_CORES = ARCH.num_physical_cores
+NUM_CORES = ARCH.num_available_physical_cores
 
 
 def _validate_ort_import():

--- a/src/deepsparse/benchmark_model/ort_engine.py
+++ b/src/deepsparse/benchmark_model/ort_engine.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 import time
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import numpy
 
-from deepsparse.benchmark import BenchmarkResults
 from deepsparse.utils import (
     get_input_names,
     get_output_names,
@@ -25,6 +24,7 @@ from deepsparse.utils import (
     override_onnx_batch_size,
     override_onnx_input_shapes,
 )
+from sparsezoo.objects import File, Model
 
 
 try:
@@ -35,16 +35,6 @@ except Exception as ort_import_err:
     onnxruntime = None
     ort_import_error = ort_import_err
 
-try:
-    from sparsezoo import Zoo
-    from sparsezoo.objects import File, Model
-
-    sparsezoo_import_error = None
-except Exception as sparsezoo_err:
-    Zoo = None
-    Model = object
-    File = object
-    sparsezoo_import_error = sparsezoo_err
 
 try:
     # flake8: noqa

--- a/src/deepsparse/benchmark_model/ort_engine.py
+++ b/src/deepsparse/benchmark_model/ort_engine.py
@@ -298,7 +298,7 @@ class ORTEngine(object):
 
     def _properties_dict(self) -> Dict:
         return {
-            "onnx_file_path": self._model_path,
-            "batch_size": self._batch_size,
-            "num_cores": self._num_cores,
+            "onnx_file_path": self.model_path,
+            "batch_size": self.batch_size,
+            "num_cores": self.num_cores,
         }

--- a/src/deepsparse/benchmark_model/stream_benchmark.py
+++ b/src/deepsparse/benchmark_model/stream_benchmark.py
@@ -27,7 +27,7 @@ __all__ = ["model_stream_benchmark"]
 
 def iteration(model: Engine, input: List[np.ndarray]):
     start = time.time()
-    output = model(input)
+    output = model.run(input, val_inp=False)
     end = time.time()
     return output, start, end
 

--- a/src/deepsparse/cpu.py
+++ b/src/deepsparse/cpu.py
@@ -99,16 +99,23 @@ class architecture(dict):
     @property
     def num_threads(self):
         """
-        :return: the total number of hyperthreads available on the current machine
+        :return: the total number of hyperthreads on the current machine
         """
         return self.threads_per_socket * self.num_sockets
 
     @property
     def num_physical_cores(self):
         """
-        :return: the total number of cores available on the current machine
+        :return: the total number of cores on the current machine
         """
         return self.cores_per_socket * self.num_sockets
+
+    @property
+    def num_available_physical_cores(self):
+        """
+        :return: the total number of cores available on the current machine
+        """
+        return self.available_cores_per_socket * self.available_sockets
 
 
 @_Memoize
@@ -224,7 +231,7 @@ def cpu_details() -> Tuple[int, str, bool]:
     """
     arch = cpu_architecture()
 
-    return arch.num_physical_cores, arch.isa, arch.vnni
+    return arch.num_available_physical_cores, arch.isa, arch.vnni
 
 
 def print_hardware_capability():
@@ -234,8 +241,8 @@ def print_hardware_capability():
     """
     arch = cpu_architecture()
     message = (
-        f"{arch.vendor} CPU detected with {arch.num_physical_cores} cores. "
-        f"({arch.num_sockets} sockets with {arch.cores_per_socket} cores each)\n"
+        f"{arch.vendor} CPU detected with {arch.num_available_physical_cores} cores. "
+        f"({arch.available_sockets} sockets with {arch.available_cores_per_socket} cores each)\n"
         "DeepSparse FP32 model performance supported: "
         f"{cpu_avx2_compatible() or cpu_avx512_compatible()}.\n"
         "DeepSparse INT8 (quantized) model performance supported: "

--- a/src/deepsparse/cpu.py
+++ b/src/deepsparse/cpu.py
@@ -242,7 +242,8 @@ def print_hardware_capability():
     arch = cpu_architecture()
     message = (
         f"{arch.vendor} CPU detected with {arch.num_available_physical_cores} cores. "
-        f"({arch.available_sockets} sockets with {arch.available_cores_per_socket} cores each)\n"
+        f"({arch.available_sockets} sockets with "
+        f"{arch.available_cores_per_socket} cores each)\n"
         "DeepSparse FP32 model performance supported: "
         f"{cpu_avx2_compatible() or cpu_avx512_compatible()}.\n"
         "DeepSparse INT8 (quantized) model performance supported: "

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -60,7 +60,7 @@ __all__ = [
 
 
 ARCH = cpu_architecture()
-NUM_CORES = ARCH.num_physical_cores
+NUM_CORES = ARCH.num_available_physical_cores
 AVX_TYPE = ARCH.isa
 VNNI = ARCH.vnni
 

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -16,7 +16,6 @@
 Code related to interfacing with a Neural Network in the DeepSparse Engine using python
 """
 
-import os
 import time
 from enum import Enum
 from typing import Dict, Iterable, List, Optional, Tuple, Union
@@ -318,7 +317,7 @@ class Engine(object):
         return self._eng_net.execute_list_out(inp)
 
     def timed_run(
-        self, inp: List[numpy.ndarray], val_inp: bool = True
+        self, inp: List[numpy.ndarray], val_inp: bool = False
     ) -> Tuple[List[numpy.ndarray], float]:
         """
         Convenience method for timing a model inference run.

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -512,12 +512,12 @@ class Engine(object):
 
     def _properties_dict(self) -> Dict:
         return {
-            "onnx_file_path": self._model_path,
-            "batch_size": self._batch_size,
-            "num_cores": self._num_cores,
-            "scheduler": self._scheduler,
-            "cpu_avx_type": self._cpu_avx_type,
-            "cpu_vnni": self._cpu_vnni,
+            "onnx_file_path": self.model_path,
+            "batch_size": self.batch_size,
+            "num_cores": self.num_cores,
+            "scheduler": self.scheduler,
+            "cpu_avx_type": self.cpu_avx_type,
+            "cpu_vnni": self.cpu_vnni,
         }
 
 

--- a/src/deepsparse/transformers/server/utils.py
+++ b/src/deepsparse/transformers/server/utils.py
@@ -90,7 +90,7 @@ def parse_api_settings() -> APIConfig:
 DEFAULT_BATCH_SIZE = 1
 DEFAULT_MAX_LENGTH = 128
 DEFAULT_SCHEDULER = "multi"
-DEFAULT_CONCURRENT_WORKERS = cpu_architecture().num_physical_cores // 2
+DEFAULT_CONCURRENT_WORKERS = cpu_architecture().num_available_physical_cores // 2
 PipelineConfigType = TypeVar(
     "PipelineEngineSettingsType",
     bound="PipelineEngineConfig",


### PR DESCRIPTION
Adds a new `--engine` argument that can select between `deepsparse` and `onnxruntime`

Running with `--engine deepsparse` (the default)
```
deepsparse.benchmark zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant_3layers-aggressive_84 -s async -t 1 -e deepsparse 
[INFO benchmark_model.py:217 ] Thread pinning to cores enabled
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 0.10.0 (434a2b34) (optimized) (system=avx512, binary=avx512)
[INFO benchmark_model.py:270 ] deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/0857c6f2-13c1-43c9-8db8-8f89a548dccd/model.onnx
        batch_size: 1
        num_cores: 18
        scheduler: Scheduler.multi_stream
        cpu_avx_type: avx512
        cpu_vnni: False
[INFO            onnx.py:176 ] Generating input 'input_ids', type = int64, shape = [1, 384]
[INFO            onnx.py:176 ] Generating input 'attention_mask', type = int64, shape = [1, 384]
[INFO            onnx.py:176 ] Generating input 'token_type_ids', type = int64, shape = [1, 384]
[INFO benchmark_model.py:287 ] num_streams default value chosen of 9. This requires tuning and may be sub-optimal
[INFO benchmark_model.py:293 ] Starting 'async' performance measurements for 1 seconds
Original Model Path: zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant_3layers-aggressive_84
Batch Size: 1
Scenario: multistream
Throughput (items/sec): 231.1491
Latency Mean (ms/batch): 37.6821
Latency Median (ms/batch): 35.7373
Latency Std (ms/batch): 17.1472
Iterations: 238
```

Running with `--engine onnxruntime`
```
deepsparse.benchmark zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant_3layers-aggressive_84 -s async -t 1 -e onnxruntime
[INFO benchmark_model.py:217 ] Thread pinning to cores enabled
[INFO benchmark_model.py:270 ] ORTEngine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/0857c6f2-13c1-43c9-8db8-8f89a548dccd/model.onnx
        batch_size: 1
        num_cores: 18
[INFO            onnx.py:176 ] Generating input 'input_ids', type = int64, shape = [1, 384]
[INFO            onnx.py:176 ] Generating input 'attention_mask', type = int64, shape = [1, 384]
[INFO            onnx.py:176 ] Generating input 'token_type_ids', type = int64, shape = [1, 384]
[INFO benchmark_model.py:287 ] num_streams default value chosen of 9. This requires tuning and may be sub-optimal
[INFO benchmark_model.py:293 ] Starting 'async' performance measurements for 1 seconds
Original Model Path: zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_quant_3layers-aggressive_84
Batch Size: 1
Scenario: multistream
Throughput (items/sec): 69.2239
Latency Mean (ms/batch): 127.1644
Latency Median (ms/batch): 122.8037
Latency Std (ms/batch): 22.4808
Iterations: 75
```