### PR TITLE
Restrict mistune version to fix docs build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ _dev_deps = [
     "flake8>=3.8.3",
     "isort>=5.7.0",
     "m2r2~=0.2.7",
+    "mistune==0.8.4",
     "myst-parser~=0.14.0",
     "rinohtype>=0.4.2",
     "sphinx>=3.4.0",


### PR DESCRIPTION
After starting from a fresh virtualenv, dev dependencies installation resolves to mistune version is 2.0.2. It seems that the newer version doesn't work with our docs build. We can probably use something newer than 0.8.4 but that works for now