### PR TITLE
Add validation script for Image Classification pipeline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ _onnxruntime_deps = [
 ]
 
 _ic_integration_deps = [
+    "click<8.1",
     "opencv-python",
 ]
 

--- a/src/deepsparse/image_classification/schemas.py
+++ b/src/deepsparse/image_classification/schemas.py
@@ -27,7 +27,7 @@ class ImageClassificationInput(BaseModel):
     Input model for image classification
     """
 
-    images: Union[str, List[numpy.ndarray], List[str]]
+    images: Union[str, numpy.ndarray, List[str]]
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -25,8 +25,8 @@ Options:
                                   Classification model to be evaluated.
                                   Defaults to resnet50 trained on
                                   Imagenette  [default: zoo:cv/classification/
-                                  resnet_v1-50/pytorch/sparseml/imagenette/pru
-                                  ned-conservative]
+                                  resnet_v1-50/pytorch/sparseml/imagenette/
+                                  base-none]
   --batch-size, --batch_size INTEGER
                                   Test batch size, must divide the dataset
                                   evenly  [default: 1]

--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -23,7 +23,7 @@ Options:
   --model-path, --model_path TEXT
                                   Path/SparseZoo stub for the Image
                                   Classification model to be evaluated.
-                                  Defaults to pruned resnet50 trained on
+                                  Defaults to resnet50 trained on
                                   Imagenette  [default: zoo:cv/classification/
                                   resnet_v1-50/pytorch/sparseml/imagenette/pru
                                   ned-conservative]
@@ -63,8 +63,7 @@ import click
 
 
 resnet50_imagenet_pruned = (
-    "zoo:cv/classification/resnet_v1-50/pytorch/"
-    "sparseml/imagenette/pruned-conservative"
+    "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenette/base-none"
 )
 
 
@@ -82,7 +81,7 @@ resnet50_imagenet_pruned = (
     type=str,
     default=resnet50_imagenet_pruned,
     help="Path/SparseZoo stub for the Image Classification model to be "
-    "evaluated. Defaults to pruned resnet50 trained on Imagenette",
+    "evaluated. Defaults to resnet50 trained on Imagenette",
     show_default=True,
 )
 @click.option(
@@ -93,13 +92,13 @@ resnet50_imagenet_pruned = (
     show_default=True,
     help="Test batch size, must divide the dataset evenly",
 )
-def main(dataset_root: str, model_path: str, batch_size: int):
+def main(dataset_path: str, model_path: str, batch_size: int):
     """
     Validation Script for Image Classification Models
     """
 
     dataset = torchvision.datasets.ImageFolder(
-        root=dataset_root,
+        root=dataset_path,
         transform=transforms.Compose(
             [
                 transforms.ToTensor(),
@@ -129,7 +128,8 @@ def main(dataset_root: str, model_path: str, batch_size: int):
 
         for actual, predicted in zip(actual_labels, predicted_labels):
             total += 1
-
+            if isinstance(predicted, str):
+                predicted = int(predicted)
             if actual.item() == predicted:
                 correct += 1
 

--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Usage: validation_script.py [OPTIONS]
+
+  Validation Script for Image Classification Models
+
+Options:
+  --dataset-path, --dataset_path DIRECTORY
+                                  Path to the validation dataset  [required]
+  --model-path, --model_path TEXT
+                                  Path/SparseZoo stub for the Image
+                                  Classification model to be evaluated.
+                                  Defaults to pruned resnet50 trained on
+                                  Imagenette  [default: zoo:cv/classification/
+                                  resnet_v1-50/pytorch/sparseml/imagenette/pru
+                                  ned-conservative]
+  --batch-size, --batch_size INTEGER
+                                  Test batch size, must divide the dataset
+                                  evenly  [default: 1]
+  --help                          Show this message and exit.
+
+#########
+EXAMPLES
+#########
+
+##########
+Example command for validating pruned resnet50 on imagenette dataset:
+python validation_script.py \
+  --dataset-path /path/to/imagenette/
+
+"""
+from tqdm import tqdm
+
+from deepsparse.pipeline import Pipeline
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+
+try:
+    import torchvision
+
+except ModuleNotFoundError as torchvision_error:  # noqa: F841
+    print(
+        "Torchvision not installed. Please install it using the command:"
+        "pip install torchvision>=0.3.0,<=0.10.1"
+    )
+    exit(1)
+
+import click
+
+
+resnet50_imagenet_pruned = (
+    "zoo:cv/classification/resnet_v1-50/pytorch/"
+    "sparseml/imagenette/pruned-conservative"
+)
+
+
+@click.command()
+@click.option(
+    "--dataset-path",
+    "--dataset_path",
+    required=True,
+    type=click.Path(dir_okay=True, file_okay=False),
+    help="Path to the validation dataset",
+)
+@click.option(
+    "--model-path",
+    "--model_path",
+    type=str,
+    default=resnet50_imagenet_pruned,
+    help="Path/SparseZoo stub for the Image Classification model to be "
+    "evaluated. Defaults to pruned resnet50 trained on Imagenette",
+    show_default=True,
+)
+@click.option(
+    "--batch-size",
+    "--batch_size",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Test batch size, must divide the dataset evenly",
+)
+def main(dataset_root: str, model_path: str, batch_size: int):
+    """
+    Validation Script for Image Classification Models
+    """
+
+    dataset = torchvision.datasets.ImageFolder(
+        root=dataset_root,
+        transform=transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Resize(size=(224, 224)),
+            ]
+        ),
+    )
+
+    data_loader = DataLoader(
+        dataset=dataset,
+        batch_size=batch_size,
+    )
+
+    pipeline = Pipeline.create(
+        task="image_classification",
+        model_path=model_path,
+        batch_size=batch_size,
+    )
+    correct = total = 0
+    progress_bar = tqdm(data_loader)
+
+    for batch in progress_bar:
+        batch, actual_labels = batch
+        batch = batch.numpy()
+        outs = pipeline(images=batch)
+        predicted_labels = outs.labels
+
+        for actual, predicted in zip(actual_labels, predicted_labels):
+            total += 1
+
+            if actual.item() == predicted:
+                correct += 1
+
+        if total > 0:
+            progress_bar.set_postfix(
+                {"Running Accuracy": f"{correct * 100 / total:.2f}%"}
+            )
+
+    # prevent division by zero
+    if total == 0:
+        epsilon = 1e-5
+        total += epsilon
+
+    print(f"Accuracy: {correct * 100 / total:.2f} %")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -81,7 +81,7 @@ resnet50_imagenet_pruned = (
     type=str,
     default=resnet50_imagenet_pruned,
     help="Path/SparseZoo stub for the Image Classification model to be "
-    "evaluated. Defaults to resnet50 trained on Imagenette",
+    "evaluated. Defaults to dense (vanilla) resnet50 trained on Imagenette",
     show_default=True,
 )
 @click.option(

--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -29,7 +29,8 @@ Options:
                                   base-none]
   --batch-size, --batch_size INTEGER
                                   Test batch size, must divide the dataset
-                                  evenly  [default: 1]
+                                  evenly, else the last batch will be dropped
+                                  [default: 1]
   --help                          Show this message and exit.
 
 #########
@@ -90,7 +91,8 @@ resnet50_imagenet_pruned = (
     type=int,
     default=1,
     show_default=True,
-    help="Test batch size, must divide the dataset evenly",
+    help="Test batch size, must divide the dataset evenly, else last "
+         "batch will be dropped",
 )
 def main(dataset_path: str, model_path: str, batch_size: int):
     """
@@ -110,6 +112,7 @@ def main(dataset_path: str, model_path: str, batch_size: int):
     data_loader = DataLoader(
         dataset=dataset,
         batch_size=batch_size,
+        drop_last=True,
     )
 
     pipeline = Pipeline.create(


### PR DESCRIPTION
This PR will add a validation script for image classification pipelines. The goal is to make testing easier and make sure the pipelines work as intended.

This also updates IC pipelines to work with `numpy.ndarray` out of the box

Note: In it's current form it needs the dataset to be pre-downloaded on local filesystem.

Usage:
```bash
python validation_script.py --dataset-path ~/data/imagenette-160/val
```
Output:
```bash
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 0.11.2 (ca6e29a5) (release) (optimized) (system=avx512, binary=avx512)
100%|████████████████| 500/500 [00:06<00:00, 77.58it/s, Running Accuracy=99.00%]
Accuracy: 99.00 %
```

Output from `python validation_script.py --help`

```bash
Usage: validation_script.py [OPTIONS]

  Validation Script for Image Classification Models

Options:
  --dataset-path, --dataset_path DIRECTORY
                                  Path to the validation dataset  [required]
  --model-path, --model_path TEXT
                                  Path/SparseZoo stub for the Image
                                  Classification model to be evaluated.
                                  Defaults to resnet50 trained on
                                  Imagenette  [default: zoo:cv/classification/
                                  resnet_v1-50/pytorch/sparseml/imagenette/
                                  base-none]
  --batch-size, --batch_size INTEGER
                                  Test batch size, must divide the dataset
                                  evenly  [default: 1]
  --help    
```