### PR TITLE
BUGFIX: update `pipeline_cli` to work with new pipeline refactor

### DIFF
--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -169,12 +169,12 @@ def pipeline(
     **kwargs,
 ) -> Pipeline:
     """
-    [DEPRECATED] - deepsparse.transformers.pipeline is deprecated to craete DeepSparse
-    pipelines for tranformers tasks use deepsparse.Pipeline.create(task, ...)
+    [DEPRECATED] - deepsparse.transformers.pipeline is deprecated to create DeepSparse
+    pipelines for transformers tasks use deepsparse.Pipeline.create(task, ...)
 
     Utility factory method to build a Pipeline
 
-    :param task: name of the task to define which pipeline to create. Currently
+    :param task: name of the task to define which pipeline to create. Currently,
         supported task - "question-answering"
     :param model_name: canonical name of the hugging face model this model is based on
     :param model_path: path to model directory containing `model.onnx`, `config.json`,
@@ -194,8 +194,8 @@ def pipeline(
     :return: Pipeline object for the given taks and model
     """
     warnings.warn(
-        "[DEPRECATED] - deepsparse.transformers.pipeline is deprecated to craete "
-        "DeepSparse pipelines for tranformers tasks use deepsparse.Pipeline.create()"
+        "[DEPRECATED] - deepsparse.transformers.pipeline is deprecated to create "
+        "DeepSparse pipelines for transformers tasks use deepsparse.Pipeline.create()"
     )
 
     if config is not None or tokenizer is not None:

--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -242,8 +242,7 @@ def response_to_json(response: Any):
     elif isinstance(response, dict):
         return {key: response_to_json(val) for key, val in response.items()}
     elif hasattr(response, "json") and callable(response.json):
-        fixed = response.json()
-        return fixed
+        return response.json()
     return json.dumps(response)
 
 

--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -22,7 +22,6 @@ usage: deepsparse.transformers.run_inference [-h]
                            text-classification,token-classification}]
                            -d DATA [--model-name MODEL_NAME] --model-path
                            MODEL_PATH [--engine-type {deepsparse,onnxruntime}]
-                           [--config CONFIG] [--tokenizer TOKENIZER]
                            [--max-length MAX_LENGTH] [--num-cores NUM_CORES]
                            [-b BATCH_SIZE] [--scheduler {multi,single}]
                            [-o OUTPUT_FILE]
@@ -50,12 +49,6 @@ optional arguments:
   --engine-type {deepsparse,onnxruntime}, --engine_type {deepsparse,onnxruntime}
                         inference engine name to use. Supported options are
                         'deepsparse'and 'onnxruntime'
-  --config CONFIG       Huggingface model config, if none provided, default
-                        will be usedwhich will be from the model name or
-                        sparsezoo stub if given for model path
-  --tokenizer TOKENIZER
-                        Huggingface tokenizer, if none provided, default will
-                        be used
   --max-length MAX_LENGTH, --max_length MAX_LENGTH
                         Maximum sequence length of model inputs. default is
                         128
@@ -78,7 +71,6 @@ Example commands:
 2) deepsparse.transformers.run_inference --task ner \
     --model-path models/bert-ner-test.onnx \
     --data input.txt \
-    --config ner-config.json \
     --output-file out.txt \
     --batch_size 2
 
@@ -91,14 +83,26 @@ Example commands:
 """
 
 import argparse
-from typing import Optional
+import json
+from typing import Any, Callable, Optional
 
-from .loaders import SUPPORTED_EXTENSIONS
-from .pipelines import SUPPORTED_ENGINES, SUPPORTED_TASKS, pipeline, process_dataset
+from pydantic import BaseModel
+
+from deepsparse.pipeline import SUPPORTED_PIPELINE_ENGINES
+from deepsparse.transformers import fix_numpy_types
+from deepsparse.transformers.loaders import SUPPORTED_EXTENSIONS, get_batch_loader
+from deepsparse.transformers.pipelines import pipeline
 
 
 __all__ = [
     "cli",
+]
+
+SUPPORTED_TASKS = [
+    "question_answering",
+    "text_classification",
+    "token_classification",
+    "ner",
 ]
 
 
@@ -111,8 +115,8 @@ def _parse_args() -> argparse.Namespace:
         "-t",
         "--task",
         help="Name of the task to define which pipeline to create."
-        f" Currently supported tasks {list(SUPPORTED_TASKS.keys())}",
-        choices=SUPPORTED_TASKS.keys(),
+        f" Currently supported tasks {SUPPORTED_TASKS}",
+        choices=SUPPORTED_TASKS,
         type=str,
         default="sentiment-analysis",
     )
@@ -150,24 +154,8 @@ def _parse_args() -> argparse.Namespace:
         help="Inference engine name to use. Supported options are 'deepsparse'"
         "and 'onnxruntime'",
         type=str,
-        choices=SUPPORTED_ENGINES,
-        default=SUPPORTED_ENGINES[0],
-    )
-
-    parser.add_argument(
-        "--config",
-        help="Huggingface model config, if none provided, default will be used"
-        "which will be from the model name or sparsezoo stub if given for "
-        "model path",
-        type=str,
-        default=None,
-    )
-
-    parser.add_argument(
-        "--tokenizer",
-        help="Huggingface tokenizer, if none provided, default will be used",
-        type=str,
-        default=None,
+        choices=SUPPORTED_PIPELINE_ENGINES,
+        default=SUPPORTED_PIPELINE_ENGINES[0],
     )
 
     parser.add_argument(
@@ -229,8 +217,6 @@ def cli():
         model_name=_args.model_name,
         model_path=_args.model_path,
         engine_type=_args.engine_type,
-        config=_args.config,
-        tokenizer=_args.tokenizer,
         max_length=_args.max_length,
         num_cores=_args.num_cores,
         batch_size=_args.batch_size,
@@ -243,6 +229,54 @@ def cli():
         batch_size=_args.batch_size,
         task=_args.task,
     )
+
+
+def response_to_json(response: Any):
+    """
+    Converts a response to a json string
+
+    :param response: A List[Any] or Dict[Any, Any] or a Pydantic model,
+        that should be converted to a valid json string
+    :return: A json string representation of the response
+    """
+    if isinstance(response, list):
+        return [response_to_json(val) for val in response]
+    elif isinstance(response, dict):
+        return {key: response_to_json(val) for key, val in response.items()}
+    elif hasattr(response, "json") and callable(response.json):
+        fixed = response.json()
+        return fixed
+    return json.dumps(response)
+
+
+def process_dataset(
+    pipeline_object: Callable,
+    data_path: str,
+    batch_size: int,
+    task: str,
+    output_path: str,
+) -> None:
+    """
+    :param pipeline_object: An instantiated pipeline Callable object
+    :param data_path: Path to input file, supports csv, json and text files
+    :param batch_size: batch_size to use for inference
+    :param task: The task pipeline is instantiated for
+    :param output_path: Path to a json file to output inference results to
+    """
+    batch_loader = get_batch_loader(
+        data_file=data_path,
+        batch_size=batch_size,
+        task=task,
+    )
+    # Wraps pipeline object to make numpy types serializable
+    pipeline_object = fix_numpy_types(pipeline_object)
+    with open(output_path, "a") as output_file:
+        for batch in batch_loader:
+            batch_output = pipeline_object(**batch)
+            json_output = response_to_json(batch_output)
+
+            json.dump(json_output, output_file)
+            output_file.write("\n")
 
 
 if __name__ == "__main__":

--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -86,8 +86,6 @@ import argparse
 import json
 from typing import Any, Callable, Optional
 
-from pydantic import BaseModel
-
 from deepsparse.pipeline import SUPPORTED_PIPELINE_ENGINES
 from deepsparse.transformers import fix_numpy_types
 from deepsparse.transformers.loaders import SUPPORTED_EXTENSIONS, get_batch_loader


### PR DESCRIPTION
This PR accomplishes the following:

- Update `deepsparse.transformers.pipelines_cli` to work with new pipelines refactor 
- Update a few typos in docstring in `pipeline.py`
- Also noting that `from deepsparse import Pipeline` works

The local tests performed are as follows:

```bash
deepsparse.run_inference \
    --model-path zoo:nlp/token_classification/bert-base/pytorch/huggingface/conll2003/12layer_pruned80_quant-none-vnni \
    --task ner \
    --data input.txt
```
Input (`input.txt`):
```
My name is rahul and i am a student of computer science and engineering.
```
```
Output in out.json
```json
"{\"predictions\": [[{\"entity\": \"LABEL_0\", \"score\": 0.9998608231544495, \"index\": 1, \"word\": \"my\", \"start\": 0, \"end\": 2, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9996172785758972, \"index\": 2, \"word\": \"name\", \"start\": 3, \"end\": 7, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9998311996459961, \"index\": 3, \"word\": \"is\", \"start\": 8, \"end\": 10, \"is_grouped\": false}, {\"entity\": \"LABEL_1\", \"score\": 0.999155580997467, \"index\": 4, \"word\": \"ra\", \"start\": 11, \"end\": 13, \"is_grouped\": false}, {\"entity\": \"LABEL_1\", \"score\": 0.7973057627677917, \"index\": 5, \"word\": \"##hul\", \"start\": 13, \"end\": 16, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9999052286148071, \"index\": 6, \"word\": \"and\", \"start\": 17, \"end\": 20, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.999871015548706, \"index\": 7, \"word\": \"i\", \"start\": 21, \"end\": 22, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9999074339866638, \"index\": 8, \"word\": \"am\", \"start\": 23, \"end\": 25, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9998987913131714, \"index\": 9, \"word\": \"a\", \"start\": 26, \"end\": 27, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9998655319213867, \"index\": 10, \"word\": \"student\", \"start\": 28, \"end\": 35, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9998788237571716, \"index\": 11, \"word\": \"of\", \"start\": 36, \"end\": 38, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9884167313575745, \"index\": 12, \"word\": \"computer\", \"start\": 39, \"end\": 47, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9930113554000854, \"index\": 13, \"word\": \"science\", \"start\": 48, \"end\": 55, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9991596937179565, \"index\": 14, \"word\": \"and\", \"start\": 56, \"end\": 59, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9913791418075562, \"index\": 15, \"word\": \"engineering\", \"start\": 60, \"end\": 71, \"is_grouped\": false}, {\"entity\": \"LABEL_0\", \"score\": 0.9998722672462463, \"index\": 16, \"word\": \".\", \"start\": 71, \"end\": 72, \"is_grouped\": false}]]}"
```

Tests to check pipeline import:
```python
Python 3.8.12 (default, Jan 15 2022, 18:39:47) 
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from deepsparse import Pipeline
>>> Pipeline.create(
... task="ner"
... )
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 0.12.0 (5f03c9f3) (release) (optimized) (system=avx512, binary=avx512)
<deepsparse.transformers.pipelines.token_classification.TokenClassificationPipeline object at 0x7f37b31bc6d0>
>>> 
```