### PR TITLE
Fixes for Question Answering pipelines

### DIFF
--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -86,6 +86,8 @@ import argparse
 import json
 from typing import Any, Callable, Optional
 
+from pydantic import BaseModel
+
 from deepsparse.pipeline import SUPPORTED_PIPELINE_ENGINES
 from deepsparse.transformers import fix_numpy_types
 from deepsparse.transformers.loaders import SUPPORTED_EXTENSIONS, get_batch_loader
@@ -241,8 +243,8 @@ def response_to_json(response: Any):
         return [response_to_json(val) for val in response]
     elif isinstance(response, dict):
         return {key: response_to_json(val) for key, val in response.items()}
-    elif hasattr(response, "json") and callable(response.json):
-        return response.json()
+    elif isinstance(response, BaseModel):
+        return dict(response)
     return json.dumps(response)
 
 
@@ -274,7 +276,6 @@ def process_dataset(
                 batch = {key: value[0] for key, value in batch.items()}
             batch_output = pipeline_object(**batch)
             json_output = response_to_json(batch_output)
-
             json.dump(json_output, output_file)
             output_file.write("\n")
 

--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -269,6 +269,9 @@ def process_dataset(
     pipeline_object = fix_numpy_types(pipeline_object)
     with open(output_path, "a") as output_file:
         for batch in batch_loader:
+            if task == "question_answering":
+                # Un-Wrap list cause only batch_size 1 is supported
+                batch = {key: value[0] for key, value in batch.items()}
             batch_output = pipeline_object(**batch)
             json_output = response_to_json(batch_output)
 


### PR DESCRIPTION
The following PR fixes validation errors for question answering pipeline

`QuestionAnsweringPipeline` is special: Only batch-size `1` is supported
Thus the 
`SquadExample` class expects `input.question` and `input.context` to be `str`(s) instead of `List[str]`

This PR now addresses that by unwrapping `List[str]` returned by batch loaders if the `task` is `question-answering`

Test Command:
```bash
deepsparse.transformers.run_inference \
    --task question_answering \
    --model-path zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned_6layers-aggressive_98 \
    --data csv_input.csv \
    --output-file output.json \
    --scheduler single
```

contents of `csv_input.csv`
```csv
question,context
What's my name,My name is Snorlax
What's my name,My name is Pikachu
What's my name,My name is Bulbasaur
```


contents of `output.json`
```json                                                                                                                                                     
{"score": 0.982067346572876, "answer": "Snorlax", "start": 11, "end": 18}
{"score": 0.9871792197227478, "answer": "Pikachu", "start": 11, "end": 18}
{"score": 0.9809777140617371, "answer": "Bulbasaur", "start": 11, "end": 20}
```
