### PR TITLE
Bugfix: Task Matching for transformers pipeline_cli `loaders`

### DIFF
--- a/src/deepsparse/transformers/loaders.py
+++ b/src/deepsparse/transformers/loaders.py
@@ -113,6 +113,7 @@ class _TextBatchLoader(_BatchLoader):
 
     def __init__(self, data_file: str, batch_size: int = 1, task: str = None):
         super().__init__(data_file=data_file, batch_size=batch_size)
+        task = task.lower().replace("_", "-") if task else ""
         if task in ["ner", "token-classification"]:
             self.header = ["inputs"]
         elif task in ["sentiment-analysis", "text-classification"]:


### PR DESCRIPTION
This PR fixes a regression after the recent transformer pipelines refactor,

Before: Supported tasks was importable as a dictionary from pipelines, this served as a source of `truth` w.r.t which tasks were supported and their corresponding keys

After: With the new refactor, The importable `SUPPORTED_TASKS` dictionary was removed, and a list of keys was added in `pipelines_cli`. This created a regression with confusion b/w tasks like `question-answering` and `question_answering`, (with the latter not being identified correctly)

The current PR fixes this regression by applying a small normalization step to the task name before comparison, specifically lowercasing the task name and replacing underscores with hyphens before matching. 