### PR TITLE
update transformers pipelines_cli for pydantic json

### DIFF
--- a/src/deepsparse/transformers/pipelines_cli.py
+++ b/src/deepsparse/transformers/pipelines_cli.py
@@ -244,7 +244,7 @@ def response_to_json(response: Any):
     elif isinstance(response, dict):
         return {key: response_to_json(val) for key, val in response.items()}
     elif isinstance(response, BaseModel):
-        return dict(response)
+        return response.dict()
     return json.dumps(response)
 
 


### PR DESCRIPTION
This change fixes a bug in json serialization for token classification results in `pipelines_cli.py`. Calling `dict(model)` on a `pydantic` model will not recurse the dict call onto nested models such as in `TokenClassificationOutput`, calling `model.dict()` will however.