### PR TITLE
[Pipeline] remove kwargs from engine_forward

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -140,7 +140,7 @@ class Pipeline(ABC):
         if "engine_inputs" in kwargs:
             raise ValueError(
                 "invalid kwarg engine_inputs. engine inputs determined "
-                f"by {self.__class__.__name__}.parse_inputs"
+                f"by {self.__class__.__qualname__}.parse_inputs"
             )
 
         # parse inputs into input_schema schema if necessary

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -140,7 +140,7 @@ class Pipeline(ABC):
         if "engine_inputs" in kwargs:
             raise ValueError(
                 "invalid kwarg engine_inputs. engine inputs determined "
-                f"by {self.__class__.name}.parse_inputs"
+                f"by {self.__class__.__name__}.parse_inputs"
             )
 
         # parse inputs into input_schema schema if necessary

--- a/src/deepsparse/transformers/pipelines/question_answering.py
+++ b/src/deepsparse/transformers/pipelines/question_answering.py
@@ -186,11 +186,19 @@ class QuestionAnsweringPipeline(TransformersPipeline):
         """
         return QuestionAnsweringOutput
 
-    # Override engine_forward to account for multiple sets of inputs (multiple spans)
-    def engine_forward(self, inputs: List[List[numpy.ndarray]], **kwargs):
+    def engine_forward(
+        self,
+        engine_inputs: List[List[numpy.ndarray]],
+    ) -> List[List[numpy.ndarray]]:
+        """
+        runs one forward pass for each span of the preprocessed input
+
+        :param engine_inputs: list of multiple inputs to engine forward pass
+        :return: result of each forward pass
+        """
         engine_outputs = []
-        for inps in inputs:
-            engine_outputs.append(self.engine(inps))
+        for inputs in engine_inputs:
+            engine_outputs.append(self.engine(inputs))
 
         return engine_outputs
 

--- a/src/deepsparse/transformers/pipelines/question_answering.py
+++ b/src/deepsparse/transformers/pipelines/question_answering.py
@@ -196,11 +196,7 @@ class QuestionAnsweringPipeline(TransformersPipeline):
         :param engine_inputs: list of multiple inputs to engine forward pass
         :return: result of each forward pass
         """
-        engine_outputs = []
-        for inputs in engine_inputs:
-            engine_outputs.append(self.engine(inputs))
-
-        return engine_outputs
+        return [self.engine(inputs) for inputs in engine_inputs]
 
     def process_inputs(
         self,


### PR DESCRIPTION
passing kwargs to `__call__` which are meant for `parse_inputs` can lead to namespace conflicts if `input` is a kwarg to `__call__`. Given kwargs are not used by any `engine_forward` implementation, this PR proposes to remove support to fix this issue (existing issues with token classification pipeline). Minor style fixes included as well.