### PR TITLE
Fix font scale 

### DIFF
--- a/examples/ultralytics-yolo/annotate.py
+++ b/examples/ultralytics-yolo/annotate.py
@@ -435,8 +435,11 @@ def annotate(args):
 
         # display
         if is_webcam:
+            cv2.namedWindow("annotations", cv2.WINDOW_NORMAL)
             cv2.imshow("annotations", annotated_img)
-            cv2.waitKey(1)
+            ch = cv2.waitKey(1)
+            if ch == 27 or ch == ord("q") or ch == ord("Q"):
+                break
 
         # save
         if saver:
@@ -445,6 +448,7 @@ def annotate(args):
         iter_end = time.time()
         elapsed_time = 1000 * (iter_end - iter_start)
         _LOGGER.info(f"Inference {iteration} processed in {elapsed_time} ms")
+        _LOGGER.info(f"Inference FPS: {measured_fps} FPS")
 
     if saver:
         saver.close()

--- a/examples/ultralytics-yolo/annotate.py
+++ b/examples/ultralytics-yolo/annotate.py
@@ -448,7 +448,6 @@ def annotate(args):
         iter_end = time.time()
         elapsed_time = 1000 * (iter_end - iter_start)
         _LOGGER.info(f"Inference {iteration} processed in {elapsed_time} ms")
-        _LOGGER.info(f"Inference FPS: {measured_fps} FPS")
 
     if saver:
         saver.close()

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -751,7 +751,7 @@ def annotate_image(
             f"images_per_sec: {int(images_per_sec)}",
             (50, 50),
             cv2.FONT_HERSHEY_SIMPLEX,
-            2.0,  # font scale
+            1.0,  # font scale
             (245, 46, 6),  # color
             2,  # thickness
             cv2.LINE_AA,


### PR DESCRIPTION
This PR fixes the overly large `images_per_sec` text annotation when running `annotate.py` in https://github.com/neuralmagic/deepsparse/tree/main/examples/ultralytics-yolo 

This PR also adds the ability to resize the inference window and the ability to close the window by hitting `Q` or `Esc` key on the keyboard.

Closes #383.