### PR TITLE
Add averaged FPS counter for ultralytics-yolo/annotate.py

### DIFF
--- a/examples/ultralytics-yolo/annotate.py
+++ b/examples/ultralytics-yolo/annotate.py
@@ -387,8 +387,8 @@ def _run_model(
 
 
 class AverageFPS:
-    def __init__(self, num_times_to_average=50):
-        self.frame_times = deque(maxlen=num_times_to_average)
+    def __init__(self, num_samples=50):
+        self.frame_times = deque(maxlen=num_samples)
 
     def measure(self, duration):
         self.frame_times.append(duration)

--- a/examples/ultralytics-yolo/annotate.py
+++ b/examples/ultralytics-yolo/annotate.py
@@ -386,8 +386,8 @@ def _run_model(
     return outputs
 
 
-class FPS:
-    def __init__(self, num_times_to_average=100):
+class AverageFPS:
+    def __init__(self, num_times_to_average=50):
         self.frame_times = deque(maxlen=num_times_to_average)
 
     def measure(self, duration):
@@ -415,7 +415,7 @@ def annotate(args):
     )
 
     # Keep a running average of frame times
-    fps = FPS()
+    fps = AverageFPS()
 
     for iteration, (inp, source_img) in enumerate(loader):
         if args.device not in ["cpu", None]:
@@ -450,7 +450,7 @@ def annotate(args):
             source_img,
             outputs,
             model_input_size=args.image_shape,
-            images_per_sec=measured_fps,
+            images_per_sec=average_fps,
         )
 
         # display

--- a/examples/ultralytics-yolo/annotate.py
+++ b/examples/ultralytics-yolo/annotate.py
@@ -105,10 +105,10 @@ python annotate.py \
 
 
 import argparse
-from collections import deque
 import logging
 import os
 import time
+from collections import deque
 from typing import Any, List, Union
 
 import numpy

--- a/examples/ultralytics-yolo/annotate.py
+++ b/examples/ultralytics-yolo/annotate.py
@@ -105,6 +105,7 @@ python annotate.py \
 
 
 import argparse
+from collections import deque
 import logging
 import os
 import time
@@ -385,6 +386,20 @@ def _run_model(
     return outputs
 
 
+class FPS:
+    def __init__(self, num_times_to_average=100):
+        self.frame_times = deque(maxlen=num_times_to_average)
+
+    def measure(self, duration):
+        self.frame_times.append(duration)
+
+    def calculate(self):
+        if len(self.frame_times) > 1:
+            return numpy.average(self.frame_times)
+        else:
+            return 0.0
+
+
 def annotate(args):
     save_dir = _get_save_dir(args)
     model, has_postprocessing = _load_model(args)
@@ -398,6 +413,9 @@ def annotate(args):
         if not has_postprocessing
         else None
     )
+
+    # Keep a running average of frame times
+    fps = FPS()
 
     for iteration, (inp, source_img) in enumerate(loader):
         if args.device not in ["cpu", None]:
@@ -426,6 +444,8 @@ def annotate(args):
         measured_fps = (
             args.target_fps or (1.0 / (time.time() - iter_start)) if is_video else None
         )
+        fps.measure(measured_fps)
+        average_fps = fps.calculate()
         annotated_img = annotate_image(
             source_img,
             outputs,
@@ -451,7 +471,7 @@ def annotate(args):
 
     if saver:
         saver.close()
-    _LOGGER.info(f"Results saved to {save_dir}")
+        _LOGGER.info(f"Results saved to {save_dir}")
 
 
 def main():

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -661,6 +661,38 @@ _YOLO_CLASS_COLORS = list(itertools.product([0, 255, 128, 64, 192], repeat=3))
 _YOLO_CLASS_COLORS.remove((255, 255, 255))  # remove white from possible colors
 
 
+def draw_text(
+    img,
+    text,
+    font=cv2.FONT_HERSHEY_SIMPLEX,
+    pos=(0, 0),
+    font_scale=1,
+    font_thickness=2,
+    text_color=(0, 255, 0),
+    text_color_bg=(0, 0, 0),
+):
+
+    offset = (5, 5)
+    x, y = pos
+    text_size, _ = cv2.getTextSize(text, font, font_scale, font_thickness)
+    text_w, text_h = text_size
+    rec_start = tuple(x - y for x, y in zip(pos, offset))
+    rec_end = tuple(x + y for x, y in zip((x + text_w, y + text_h), offset))
+    cv2.rectangle(img, rec_start, rec_end, text_color_bg, -1)
+    cv2.putText(
+        img,
+        text,
+        (x, int(y + text_h + font_scale - 1)),
+        font,
+        font_scale,
+        text_color,
+        font_thickness,
+        cv2.LINE_AA,
+    )
+
+    return text_size
+
+
 def annotate_image(
     img: numpy.ndarray,
     outputs: numpy.ndarray,
@@ -746,15 +778,14 @@ def annotate_image(
             )
 
     if images_per_sec is not None:
-        cv2.putText(
+        draw_text(
             img_res,
             f"FPS: {images_per_sec:0.1f}",
-            (10, 10),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            1.0,  # font scale
-            (245, 46, 6),  # color
-            2,  # thickness
-            cv2.LINE_AA,
+            pos=(20, 20),
+            font_scale=1.0,
+            text_color=(204, 85, 17),
+            text_color_bg=(255, 255, 255),
+            font_thickness=2,
         )
     return img_res
 

--- a/examples/ultralytics-yolo/deepsparse_utils.py
+++ b/examples/ultralytics-yolo/deepsparse_utils.py
@@ -748,8 +748,8 @@ def annotate_image(
     if images_per_sec is not None:
         cv2.putText(
             img_res,
-            f"images_per_sec: {int(images_per_sec)}",
-            (50, 50),
+            f"FPS: {images_per_sec:0.1f}",
+            (10, 10),
             cv2.FONT_HERSHEY_SIMPLEX,
             1.0,  # font scale
             (245, 46, 6),  # color


### PR DESCRIPTION
Stabilizes the FPS counter by averaging over several frame times, defaulting to 50 samples. 
Building on top of https://github.com/neuralmagic/deepsparse/pull/384.