### PR TITLE
Pin protobuf to exclude v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ _deps = [
     "pydantic>=1.8.2",
     "requests>=2.0.0",
     "tqdm>=4.0.0",
-    "protobuf>=3.12.2",
+    "protobuf>=3.12.2,<4",
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_base}"]
 _dev_deps = [


### PR DESCRIPTION
This PR pins protobuf to a pre-v4 release due to breaking changes.