### PR TITLE
Fix deepsparse.benchmark CLI test

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -46,7 +46,7 @@ def test_benchmark_help():
         (
             "zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/"
             "pruned_quant-aggressive_95",
-            ["-s", "async", "-nstreams", "10"],
+            ["-s", "async", "-nstreams", "4"],
         ),
         (
             "zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/"


### PR DESCRIPTION
This PR fixes one of the tests of the `deepsparse.benchmark` command which is now failing in our Jenkins environment.

The failure is related to a newly enforced rule that the number of streams cannot exceed the number of cores. The fix reduces the value passed via the `-nstreams` flag to match our Jenkins environment.