### PR TITLE
Add a BucketingPipeline

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -17,7 +17,6 @@ Classes and registry for end to end inference pipelines that wrap an underlying
 inference engine and include pre/postprocessing
 """
 
-
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -42,14 +41,14 @@ __all__ = [
     "token_classification_pipeline",
     "image_classification_pipeline",
     "yolo_pipeline",
+    "Bucketable",
+    "BucketingPipeline",
 ]
-
 
 DEEPSPARSE_ENGINE = "deepsparse"
 ORT_ENGINE = "onnxruntime"
 
 SUPPORTED_PIPELINE_ENGINES = [DEEPSPARSE_ENGINE, ORT_ENGINE]
-
 
 _REGISTERED_PIPELINES = {}
 
@@ -508,6 +507,23 @@ class Pipeline(ABC):
                 "provide a model path for pipelines that do not have a default defined"
             )
 
+        if issubclass(
+            pipeline_constructor, Bucketable
+        ) and pipeline_constructor.should_bucket(**kwargs):
+            buckets = pipeline_constructor.create_pipeline_buckets(
+                task=task,
+                model_path=model_path,
+                engine_type=engine_type,
+                batch_size=batch_size,
+                num_cores=num_cores,
+                scheduler=scheduler,
+                input_shapes=input_shapes,
+                alias=alias,
+                context=context,
+                **kwargs,
+            )
+            return BucketingPipeline(pipelines=buckets)
+
         return pipeline_constructor(
             model_path=model_path,
             engine_type=engine_type,
@@ -850,3 +866,73 @@ class PipelineConfig(BaseModel):
             "into the pipeline as kwargs"
         ),
     )
+
+
+class BucketingPipeline(Pipeline):
+    """
+    A Pipeline that adds Bucketing functionality
+    """
+
+    def __init__(self, pipelines: List[Pipeline]):
+        self._pipelines = pipelines
+        self._pipeline_class = pipelines[0]
+        self._update_props()
+
+    def __call__(self, inputs):
+        pipeline = self._pipeline_class.route_input_to_bucket(
+            input_schema=self._pipeline_class.parse_inputs(**inputs),
+            pipelines=self._pipelines,
+        )
+        return pipeline(**inputs)
+
+    def setup_onnx_file_path(self) -> str:
+        raise NotImplementedError
+
+    def process_inputs(
+        self,
+        inputs: BaseModel,
+    ) -> Union[List[numpy.ndarray], Tuple[List[numpy.ndarray], Dict[str, Any]]]:
+        raise NotImplementedError
+
+    def process_engine_outputs(
+        self, engine_outputs: List[numpy.ndarray], **kwargs
+    ) -> BaseModel:
+        raise NotImplementedError
+
+    @property
+    def input_schema(self) -> Type[BaseModel]:
+        return self._pipeline_class.input_schema
+
+    @property
+    def output_schema(self) -> Type[BaseModel]:
+        return self._pipeline_class.output_schema
+
+    def _update_props(self):
+        # TODO: Current implementation might have unintended side effects, should only
+        # TODO: copy over props
+        self.__dict__.update(self._pipeline_class.__dict__)
+
+
+class Bucketable(ABC):
+    """
+    A contract, that ensures implementing Pipeline class can create multiple Pipeline
+    instances and route each input sample to correct instance based off of specific
+    implementations of abstract methods defined in this contract
+    """
+
+    @staticmethod
+    @abstractmethod
+    def should_bucket(*args, **kwargs) -> bool:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def create_pipeline_buckets(*args, **kwargs) -> List[Pipeline]:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def route_input_to_bucket(
+        *args, input_schema: BaseModel, pipelines: List[Pipeline], **kwargs
+    ) -> Pipeline:
+        pass

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -511,13 +511,12 @@ class Pipeline(ABC):
             pipeline_constructor, Bucketable
         ) and pipeline_constructor.should_bucket(**kwargs):
             if not context:
-                context = Context()
+                context = Context(num_cores=num_cores)
             buckets = pipeline_constructor.create_pipeline_buckets(
                 task=task,
                 model_path=model_path,
                 engine_type=engine_type,
                 batch_size=batch_size,
-                num_cores=num_cores,
                 scheduler=scheduler,
                 input_shapes=input_shapes,
                 alias=alias,
@@ -880,7 +879,7 @@ class BucketingPipeline(Pipeline):
         self._pipeline_class = pipelines[0]
         self._update_props()
 
-    def __call__(self, inputs):
+    def __call__(self, **inputs):
         pipeline = self._pipeline_class.route_input_to_bucket(
             input_schema=self._pipeline_class.parse_inputs(**inputs),
             pipelines=self._pipelines,

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -510,6 +510,8 @@ class Pipeline(ABC):
         if issubclass(
             pipeline_constructor, Bucketable
         ) and pipeline_constructor.should_bucket(**kwargs):
+            if not context:
+                context = Context()
             buckets = pipeline_constructor.create_pipeline_buckets(
                 task=task,
                 model_path=model_path,

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -874,6 +874,9 @@ class PipelineConfig(BaseModel):
 class BucketingPipeline(object):
     """
     A Proxy class that adds Bucketing functionality to Pipelines
+
+    :param pipelines: A list of Pipeline objects/buckets that implement
+        `Bucketable` contract
     """
 
     def __init__(self, pipelines: List[Pipeline]):
@@ -920,6 +923,9 @@ class BucketingPipeline(object):
 
     def _validate_pipeline_class(self):
         # validate all pipelines belong to the same class
+
+        if not issubclass(self._pipeline_class, Bucketable):
+            raise ValueError(f"{self._pipeline_class} is not Bucketable")
 
         is_valid = all(
             isinstance(pipeline, self._pipeline_class) for pipeline in self._pipelines

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -517,7 +517,6 @@ class Pipeline(ABC):
                 model_path=model_path,
                 engine_type=engine_type,
                 batch_size=batch_size,
-                scheduler=scheduler,
                 input_shapes=input_shapes,
                 alias=alias,
                 context=context,

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -886,25 +886,53 @@ class BucketingPipeline(Pipeline):
         return pipeline(**inputs)
 
     def setup_onnx_file_path(self) -> str:
+        """
+        Performs any setup to unwrap and process the given `model_path` and other
+        class properties into an inference ready onnx file to be compiled by the
+        engine of the pipeline
+
+        :return: file path to the ONNX file for the engine to compile
+        """
         raise NotImplementedError
 
     def process_inputs(
         self,
         inputs: BaseModel,
     ) -> Union[List[numpy.ndarray], Tuple[List[numpy.ndarray], Dict[str, Any]]]:
+        """
+        :param inputs: inputs to the pipeline. Must be the type of the `input_schema`
+            of this pipeline
+        :return: inputs of this model processed into a list of numpy arrays that
+            can be directly passed into the forward pass of the pipeline engine. Can
+            also include a tuple with engine inputs and special key word arguments
+            to pass to process_engine_outputs to facilitate information from the raw
+            inputs to postprocessing that may not be included in the engine inputs
+        """
         raise NotImplementedError
 
     def process_engine_outputs(
         self, engine_outputs: List[numpy.ndarray], **kwargs
     ) -> BaseModel:
+        """
+        :param engine_outputs: list of numpy arrays that are the output of the engine
+            forward pass
+        :return: outputs of engine post-processed into an object in the `output_schema`
+            format of this pipeline
+        """
         raise NotImplementedError
 
     @property
     def input_schema(self) -> Type[BaseModel]:
+        """
+        :return: pydantic model class that inputs to this pipeline must comply to
+        """
         return self._pipeline_class.input_schema
 
     @property
     def output_schema(self) -> Type[BaseModel]:
+        """
+        :return: pydantic model class that outputs of this pipeline must comply to
+        """
         return self._pipeline_class.output_schema
 
     def _update_props(self):
@@ -927,11 +955,18 @@ class Bucketable(ABC):
     @staticmethod
     @abstractmethod
     def should_bucket(*args, **kwargs) -> bool:
+        """
+        :returns: True if buckets should be created else False
+        """
         pass
 
     @staticmethod
     @abstractmethod
     def create_pipeline_buckets(*args, **kwargs) -> List[Pipeline]:
+        """
+        :return: Create and return a list of Pipeline objects
+            representing different buckets
+        """
         pass
 
     @staticmethod
@@ -939,4 +974,9 @@ class Bucketable(ABC):
     def route_input_to_bucket(
         *args, input_schema: BaseModel, pipelines: List[Pipeline], **kwargs
     ) -> Pipeline:
+        """
+        :param input_schema: The schema representing an input to the pipeline
+        :param pipelines: Different buckets to be used
+        :return: The correct Pipeline object (or Bucket) to route input to
+        """
         pass

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -29,7 +29,6 @@ from deepsparse import Context, Engine, MultiModelEngine, Scheduler
 from deepsparse.benchmark import ORTEngine
 from deepsparse.tasks import SupportedTasks
 
-
 __all__ = [
     "DEEPSPARSE_ENGINE",
     "ORT_ENGINE",
@@ -909,9 +908,13 @@ class BucketingPipeline(Pipeline):
         return self._pipeline_class.output_schema
 
     def _update_props(self):
-        # TODO: Current implementation might have unintended side effects, should only
-        # TODO: copy over props
-        self.__dict__.update(self._pipeline_class.__dict__)
+        # propagate props to this level if not already defined
+        for key, value in self._pipeline_class.__dict__:
+            if (
+                type(getattr(self._pipeline_class, f"{key}")) == property
+                and key not in self.__dict__
+            ):
+                self.__dict__[key] = value
 
 
 class Bucketable(ABC):

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -29,6 +29,7 @@ from deepsparse import Context, Engine, MultiModelEngine, Scheduler
 from deepsparse.benchmark import ORTEngine
 from deepsparse.tasks import SupportedTasks
 
+
 __all__ = [
     "DEEPSPARSE_ENGINE",
     "ORT_ENGINE",

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -16,14 +16,13 @@
 Base Pipeline class for transformers inference pipeline
 """
 
-
 import warnings
-from typing import Any, List, Mapping, Optional
+from typing import Any, List, Mapping, Optional, Union
 
 import numpy
 from transformers.models.auto import AutoConfig, AutoTokenizer
 
-from deepsparse import Pipeline
+from deepsparse import Bucketable, Pipeline
 from deepsparse.transformers.helpers import (
     get_onnx_path_and_configs,
     overwrite_transformer_onnx_model_inputs,
@@ -36,7 +35,7 @@ __all__ = [
 ]
 
 
-class TransformersPipeline(Pipeline):
+class TransformersPipeline(Pipeline, Bucketable):
     """
     Base deepsparse.Pipeline class for transformers model loading. This class handles
     the parsing of deepsparse-transformers files and model inputs, supporting loading
@@ -153,6 +152,21 @@ class TransformersPipeline(Pipeline):
             )
 
         return [tokens[name] for name in self.onnx_input_names]
+
+    @staticmethod
+    def should_bucket(*args, sequence_length: Union[int, List[int]], **kwargs) -> bool:
+        return isinstance(sequence_length, list)
+
+    @staticmethod
+    def create_pipeline_buckets(
+        *args, sequence_length: List[int], **kwargs
+    ) -> List[Pipeline]:
+        pipelines = []
+        for seq_len in sorted(sequence_length):
+            curr_pipeline = Pipeline.create(*args, sequence_length=seq_len, **kwargs)
+            pipelines.append(curr_pipeline)
+
+        return pipelines
 
 
 def pipeline(

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -17,7 +17,7 @@ Base Pipeline class for transformers inference pipeline
 """
 
 import warnings
-from typing import Any, List, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional
 
 import numpy
 from transformers.models.auto import AutoConfig, AutoTokenizer

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -154,7 +154,8 @@ class TransformersPipeline(Pipeline, Bucketable):
         return [tokens[name] for name in self.onnx_input_names]
 
     @staticmethod
-    def should_bucket(*args, sequence_length: Union[int, List[int]], **kwargs) -> bool:
+    def should_bucket(*args, **kwargs) -> bool:
+        sequence_length = kwargs.get("sequence_length", 128)
         return isinstance(sequence_length, list)
 
     @staticmethod

--- a/src/deepsparse/transformers/pipelines/question_answering.py
+++ b/src/deepsparse/transformers/pipelines/question_answering.py
@@ -311,6 +311,18 @@ class QuestionAnsweringPipeline(TransformersPipeline):
                 answer=example.context_text[char_start[0] : char_end[1]],
             )
 
+    @staticmethod
+    def route_input_to_bucket(
+        *args, input_schema: BaseModel, pipelines: List[TransformersPipeline], **kwargs
+    ) -> Pipeline:
+
+        current_seq_len = len(input_schema.question.split())
+
+        for pipeline in pipelines:
+            if pipeline.sequence_length > current_seq_len:
+                return pipeline
+        return pipelines[-1]
+
     def _process_single_feature(self, feature, engine_outputs):
         """
         :param feature: a SQuAD feature object

--- a/src/deepsparse/transformers/pipelines/question_answering.py
+++ b/src/deepsparse/transformers/pipelines/question_answering.py
@@ -315,7 +315,11 @@ class QuestionAnsweringPipeline(TransformersPipeline):
     def route_input_to_bucket(
         *args, input_schema: BaseModel, pipelines: List[TransformersPipeline], **kwargs
     ) -> Pipeline:
-
+        """
+        :param input_schema: The schema representing an input to the pipeline
+        :param pipelines: Different buckets to be used
+        :return: The correct Pipeline object (or Bucket) to route input to
+        """
         current_seq_len = len(input_schema.question.split())
 
         for pipeline in pipelines:

--- a/src/deepsparse/transformers/pipelines/text_classification.py
+++ b/src/deepsparse/transformers/pipelines/text_classification.py
@@ -261,7 +261,8 @@ class TextClassificationPipeline(TransformersPipeline):
         :return: The correct Pipeline object (or Bucket) to route input to
         """
         current_seq_len = TextClassificationPipeline._get_current_sequence_length(
-            input_schema)
+            input_schema
+        )
 
         for pipeline in pipelines:
             if pipeline.sequence_length > current_seq_len:
@@ -279,8 +280,7 @@ class TextClassificationPipeline(TransformersPipeline):
                     current_seq_len = max(len(_input.split()), current_seq_len)
                 elif isinstance(_input, list):
                     current_seq_len = max(
-                        *(len(__input.split()) for __input in _input),
-                        current_seq_len
+                        *(len(__input.split()) for __input in _input), current_seq_len
                     )
         else:
             raise ValueError(

--- a/src/deepsparse/transformers/pipelines/text_classification.py
+++ b/src/deepsparse/transformers/pipelines/text_classification.py
@@ -255,7 +255,11 @@ class TextClassificationPipeline(TransformersPipeline):
     def route_input_to_bucket(
         *args, input_schema: BaseModel, pipelines: List[TransformersPipeline], **kwargs
     ) -> Pipeline:
-
+        """
+        :param input_schema: The schema representing an input to the pipeline
+        :param pipelines: Different buckets to be used
+        :return: The correct Pipeline object (or Bucket) to route input to
+        """
         current_seq_len = TextClassificationPipeline._get_current_sequence_length(
             input_schema)
 

--- a/src/deepsparse/transformers/pipelines/token_classification.py
+++ b/src/deepsparse/transformers/pipelines/token_classification.py
@@ -326,7 +326,11 @@ class TokenClassificationPipeline(TransformersPipeline):
     def route_input_to_bucket(
         *args, input_schema: BaseModel, pipelines: List[TransformersPipeline], **kwargs
     ) -> Pipeline:
-
+        """
+        :param input_schema: The schema representing an input to the pipeline
+        :param pipelines: Different buckets to be used
+        :return: The correct Pipeline object (or Bucket) to route input to
+        """
         if isinstance(input_schema.inputs, str):
             current_seq_len = len(input_schema.inputs.split())
         elif isinstance(input_schema.inputs, list):


### PR DESCRIPTION
This PR adds `Bucketing` support to transformer based Tasks.

### What's Bucketing(In our context)?

Bucketing refers to the transformation of a set of items into categories or bins. 

In our context, we wanted to run multiple buckets (or instances of Pipeline objects) in the background (initialized with different sequence lengths) and dynamically route each input example to the Pipeline object most suited for that example (for now based on sequence length, but can be extended to other criterions like batch_size, ..., etc)

### Solution?

This PR adds a `Bucketable` contract/interface that describes methods needed to make a Pipeline support Bucketing functionality, On top of that we also add a `BucketingPipeline` proxy object that emulates a `Pipeline` but uses `Bucketing` under the hood. We create an instances of `BucketingPipeline` on the fly if needed, this allows users to create Pipelines in the same old fashion they're used to i.e using `Pipeline.create(.....)`; The example code given below can be used to test this functionality. 

In it's current form `Bucketing` support has been added to the following tasks:
- [x] question_answering
- [x] token_classification
- [x] text_classification
 
Completed:
- [x] Propagate same context across all pipeline instances
- [x] Add same changes `route...` function to other transformer tasks
- [x] Running into an assertion error on `Pipeline.create`, to be fixed

Noting current flows with sequence_length = 1 are broken on the engine side, tested code with sequence_length > 1

### Test Code
```python
from deepsparse import Pipeline

_input = {
    'question': "What's my name?",
    "context": "My name is Snorlax",
}

bucket_qa = Pipeline.create(
    task='question_answering',
    sequence_length=[10, 128]
)

_output = bucket_qa(
    **_input
)

print(bucket_qa.model_path)
print( _output)

```

Output:
```bash
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 0.13.0.20220610 (0cbb6f7f) (release) (optimized) (system=avx512, binary=avx512)
zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/12layer_pruned80_quant-none-vnni
score=0.9946680068969727 answer='Snorlax' start=11 end=18

Process finished with exit code 0
```
 
 Noting: As synced offline, the `BucketingPipeline` does not inherit from `Pipelines` anymore
 
 ### Infrastructure

The following diagram shows a simplified view of the architecture
![bucketing-infrastructure](https://user-images.githubusercontent.com/25380596/173878678-c28b5b25-1754-4970-a6ca-f33d85fe62b3.jpg)

