### PR TITLE
[Bugfix] add torchvision in image_classification dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ _onnxruntime_deps = [
 ]
 
 _ic_integration_deps = [
+    "torchvision>=0.3.0,<=0.10.1",
     "click<8.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -86,11 +86,6 @@ _onnxruntime_deps = [
     "onnxruntime>=1.7.0",
 ]
 
-_ic_integration_deps = [
-    "torchvision>=0.3.0,<=0.10.1",
-    "click<8.1",
-]
-
 _yolo_integration_deps = [
     "torchvision>=0.3.0,<=0.10.1",
     "opencv-python",
@@ -198,7 +193,6 @@ def _setup_extras() -> Dict:
         "dev": _dev_deps,
         "server": _server_deps,
         "onnxruntime": _onnxruntime_deps,
-        "image_classification": _ic_integration_deps,
         "yolo": _yolo_integration_deps,
     }
 

--- a/src/deepsparse/image_classification/__init__.py
+++ b/src/deepsparse/image_classification/__init__.py
@@ -31,6 +31,17 @@ def _check_torchvision_install(raise_on_fail=False):
         return torchvision_import_exception
 
 
+def _check_click_install(raise_on_fail=False):
+    try:
+        import click as _click
+
+        return None
+    except Exception as click_import_exception:
+        if raise_on_fail:
+            raise click_import_exception
+        return click_import_exception
+
+
 def _check_install_deps():
     torchvision_import_exception = _check_torchvision_install
     if not torchvision_import_exception:
@@ -62,6 +73,30 @@ def _check_install_deps():
             "Unable to import or install torchvision, a requirement of "
             f"deepsparse.image_classification. Failed with exception: "
             f"{torchvision_exception}"
+        )
+
+    try:
+        _subprocess.check_call(
+            [
+                _sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "click<8.1",
+            ]
+        )
+
+        _check_click_install(raise_on_fail=True)
+
+        _LOGGER.info(
+            "click dependency of deepsparse.image_classification "
+            "sucessfully installed"
+        )
+    except Exception as click_exception:
+        raise ValueError(
+            "Unable to import or install click, a requirement of "
+            f"deepsparse.image_classification. Failed with exception: "
+            f"{click_exception}"
         )
 
 

--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -43,9 +43,16 @@ python validation_script.py \
   --dataset-path /path/to/imagenette/
 
 """
-import click
-import torchvision
-from torchvision import transforms
+try:
+    import click
+    import torchvision
+    from torchvision import transforms
+except Exception as e:
+    raise ModuleNotFoundError(
+        "Some dependencies might be missing, install them using"
+        f" `pip install deepsparse[image_classification]`"
+        f"\nOriginal Exception: {e}"
+    )
 from tqdm import tqdm
 
 from deepsparse.image_classification.constants import (

--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -43,16 +43,10 @@ python validation_script.py \
   --dataset-path /path/to/imagenette/
 
 """
-try:
-    import click
-    import torchvision
-    from torchvision import transforms
-except Exception as e:
-    raise ModuleNotFoundError(
-        "Some dependencies might be missing, install them using"
-        f" `pip install deepsparse[image_classification]`"
-        f"\nOriginal Exception: {e}"
-    )
+
+import click
+import torchvision
+from torchvision import transforms
 from tqdm import tqdm
 
 from deepsparse.image_classification.constants import (


### PR DESCRIPTION
This PR, adds torchvision to image_classification dependencies,

And wraps external library imports into a try catch block, showing apt install command to the user