### PR TITLE
[BugFix] AutoInstall of depencies for IC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,6 @@ _onnxruntime_deps = [
     "onnxruntime>=1.7.0",
 ]
 
-_ic_integration_deps = [
-    "click<8.1",
-]
-
 _yolo_integration_deps = [
     "torchvision>=0.3.0,<=0.10.1",
     "opencv-python",
@@ -197,7 +193,6 @@ def _setup_extras() -> Dict:
         "dev": _dev_deps,
         "server": _server_deps,
         "onnxruntime": _onnxruntime_deps,
-        "image_classification": _ic_integration_deps,
         "yolo": _yolo_integration_deps,
     }
 

--- a/src/deepsparse/image_classification/__init__.py
+++ b/src/deepsparse/image_classification/__init__.py
@@ -23,14 +23,14 @@ _LOGGER = _logging.getLogger(__name__)
 _Dependency = namedtuple("_Dependency", ["name", "version", "necessary"])
 
 
-def _check_if_dependency_installed(dependency: _Dependency, raise_on_fail=False):
-    try:
-        _dep = importlib.import_module(dependency.name)
-        return None
-    except Exception as dependency_import_error:
-        if raise_on_fail:
-            raise dependency_import_error
-        return dependency_import_error
+def _auto_install_dependencies():
+    dependencies = [
+        _Dependency(name="torchvision", version=">=0.3.0,<=0.10.1", necessary=True),
+        _Dependency(name="click", version="<8.1", necessary=False),
+    ]
+
+    for dependency in dependencies:
+        _check_and_install_dependency(dependency=dependency)
 
 
 def _check_and_install_dependency(dependency: _Dependency):
@@ -82,14 +82,14 @@ def _check_and_install_dependency(dependency: _Dependency):
             )
 
 
-def _auto_install_dependencies():
-    dependencies = [
-        _Dependency(name="torchvision", version=">=0.3.0,<=0.10.1", necessary=True),
-        _Dependency(name="click", version="<8.1", necessary=False),
-    ]
-
-    for dependency in dependencies:
-        _check_and_install_dependency(dependency=dependency)
+def _check_if_dependency_installed(dependency: _Dependency, raise_on_fail=False):
+    try:
+        _dep = importlib.import_module(dependency.name)
+        return None
+    except Exception as dependency_import_error:
+        if raise_on_fail:
+            raise dependency_import_error
+        return dependency_import_error
 
 
 _auto_install_dependencies()


### PR DESCRIPTION
BugFix:  AutoInstall of click and torchvision for IC
CleanUp: AutoInstall Logic
Remove: deepsparse[image_classification] installable in favour of AutoInstall

Noting the last PR #416 was closed out in favor of re-opening once logic was as expected, however permissions don't allow me to re-open closed PRs (Will take care in future)

The install has been tested locally, and all comments from #416 have been addressed here, (again sorry for inconvenience)