### PR TITLE
[cherry-pick] fix sst2 eval for default label names

### DIFF
--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -193,7 +193,7 @@ def sst2_eval(args):
     )
     print(f"Engine info: {text_classify.engine}")
 
-    label_map = {"negative": 0, "positive": 1}
+    label_map = {"negative": 0, "positive": 1, "LABEL_0": 0, "LABEL_1": 1}
 
     for idx, sample in enumerate(tqdm(sst2)):
         pred = text_classify(


### PR DESCRIPTION
accuracy will always be 0% if default label names are not mapped