### PR TITLE
Zero shot multistream

### DIFF
--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -561,7 +561,7 @@ class Engine(object):
 
 class Context(object):
     """
-    Contexts can be used to run multiple instances of the MultiModelEngine with the same
+    Contexts can be used to run multiple instances of the (MultiModelEngine) with the same
     scheduler. This allows one scheduler to manage the resources of the system
     effectively, keeping engines that are running different models from fighting over system
     resources.
@@ -575,12 +575,13 @@ class Context(object):
 
     def __init__(
         self,
-        num_cores: int = None,
-        num_streams: int = None,
+        num_cores: Optional[int] = None,
+        num_streams: Optional[int] = None,
     ):
         self._num_cores = _validate_num_cores(num_cores)
         self._num_streams = _validate_num_streams(num_streams, self._num_cores)
         self._scheduler = Scheduler.from_str("elastic")
+        print([self._num_cores, self._num_streams, self._scheduler.value])
         self._deepsparse_context = LIB.deepsparse_context(
             self._num_cores, self._num_streams, self._scheduler.value
         )
@@ -627,12 +628,16 @@ class MultiModelEngine(Engine):
         batch_size: int,
         context: Context,
         input_shapes: List[List[int]] = None,
+        scheduler: Scheduler = None,
     ):
         self._model_path = model_to_path(model)
         self._batch_size = _validate_batch_size(batch_size)
         self._num_cores = context.num_cores
         self._num_streams = context.num_streams
-        self._scheduler = _validate_scheduler(context.scheduler)
+        if scheduler is not None:
+            self._scheduler == _validate_scheduler(scheduler)
+        else:
+            self._scheduler = _validate_scheduler(context.scheduler)
         self._input_shapes = input_shapes
         self._cpu_avx_type = AVX_TYPE
         self._cpu_vnni = VNNI

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -581,7 +581,6 @@ class Context(object):
         self._num_cores = _validate_num_cores(num_cores)
         self._num_streams = _validate_num_streams(num_streams, self._num_cores)
         self._scheduler = Scheduler.from_str("elastic")
-        print([self._num_cores, self._num_streams, self._scheduler.value])
         self._deepsparse_context = LIB.deepsparse_context(
             self._num_cores, self._num_streams, self._scheduler.value
         )

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -561,7 +561,7 @@ class Engine(object):
 
 class Context(object):
     """
-    Contexts can be used to run multiple instances of the (MultiModelEngine) with the same
+    Contexts can be used to run multiple instances of the MultiModelEngine with the same
     scheduler. This allows one scheduler to manage the resources of the system
     effectively, keeping engines that are running different models from fighting over system
     resources.

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -181,10 +181,10 @@ class Engine(object):
         self,
         model: Union[str, Model, File],
         batch_size: int,
-        num_cores: int = None,
-        num_streams: int = None,
-        scheduler: Scheduler = None,
-        input_shapes: List[List[int]] = None,
+        num_cores: Optional[int] = None,
+        num_streams: Optional[int] = None,
+        scheduler: Optional[Scheduler] = None,
+        input_shapes: Optional[List[List[int]]] = None,
     ):
         self._model_path = model_to_path(model)
         self._batch_size = _validate_batch_size(batch_size)
@@ -627,8 +627,8 @@ class MultiModelEngine(Engine):
         model: Union[str, Model, File],
         batch_size: int,
         context: Context,
-        input_shapes: List[List[int]] = None,
-        scheduler: Scheduler = None,
+        input_shapes: Optional[List[List[int]]] = None,
+        scheduler: Optional[Scheduler] = None,
     ):
         self._model_path = model_to_path(model)
         self._batch_size = _validate_batch_size(batch_size)
@@ -668,10 +668,10 @@ class MultiModelEngine(Engine):
 def compile_model(
     model: Union[str, Model, File],
     batch_size: int = 1,
-    num_cores: int = None,
-    num_streams: int = None,
-    scheduler: Scheduler = None,
-    input_shapes: List[List[int]] = None,
+    num_cores: Optional[int] = None,
+    num_streams: Optional[int] = None,
+    scheduler: Optional[Scheduler] = None,
+    input_shapes: Optional[List[List[int]]] = None,
 ) -> Engine:
     """
     Convenience function to compile a model in the DeepSparse Engine
@@ -707,15 +707,15 @@ def benchmark_model(
     model: Union[str, Model, File],
     inp: List[numpy.ndarray],
     batch_size: int = 1,
-    num_cores: int = None,
-    num_streams: int = None,
+    num_cores: Optional[int] = None,
+    num_streams: Optional[int] = None,
     num_iterations: int = 20,
     num_warmup_iterations: int = 5,
     include_inputs: bool = False,
     include_outputs: bool = False,
     show_progress: bool = False,
-    scheduler: Scheduler = None,
-    input_shapes: List[List[int]] = None,
+    scheduler: Optional[Scheduler] = None,
+    input_shapes: Optional[List[List[int]]] = None,
 ) -> BenchmarkResults:
     """
     Convenience function to benchmark a model in the DeepSparse Engine
@@ -774,14 +774,14 @@ def analyze_model(
     model: Union[str, Model, File],
     inp: List[numpy.ndarray],
     batch_size: int = 1,
-    num_cores: int = None,
+    num_cores: Optional[int] = None,
     num_iterations: int = 20,
     num_warmup_iterations: int = 5,
     optimization_level: int = 1,
     imposed_as: Optional[float] = None,
     imposed_ks: Optional[float] = None,
-    scheduler: Scheduler = None,
-    input_shapes: List[List[int]] = None,
+    scheduler: Optional[Scheduler] = None,
+    input_shapes: Optional[List[List[int]]] = None,
 ) -> dict:
     """
     Function to analyze a model's performance in the DeepSparse Engine.

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -479,7 +479,7 @@ class Pipeline(ABC):
         task: str,
         model_path: str = None,
         engine_type: str = DEEPSPARSE_ENGINE,
-        batch_size: int = 1,
+        batch_size: Optional[int] = None,
         num_cores: int = None,
         scheduler: Scheduler = None,
         input_shapes: List[List[int]] = None,

--- a/src/deepsparse/transformers/pipelines/nli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/nli_text_classification.py
@@ -35,7 +35,7 @@ with nli models
 
 
 from concurrent.futures import wait
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import numpy
 from pydantic import BaseModel, Field
@@ -75,6 +75,10 @@ class NliTextClassificationConfig(BaseModel):
     contradiction_index: int = Field(
         description="Index of nli model outputs which denotes contradiction", default=2
     )
+    multi_class: bool = Field(
+        description="True if class probabilities are independent, default False",
+        default=False,
+    )
 
 
 class NliTextClassificationInput(BaseModel):
@@ -88,10 +92,21 @@ class NliTextClassificationInput(BaseModel):
         description="A string or List of strings representing input to "
         "zero_shot_text_classification task"
     )
-    labels: Union[List[List[str]], List[str], str] = Field(
+    labels: Union[None, List[List[str]], List[str], str] = Field(
         description="The set of possible class labels to classify each "
         "sequence into. Can be a single label, a string of comma-separated "
         "labels, or a list of labels."
+    )
+    hypothesis_template: Optional[str] = Field(
+        description="A formattable template for wrapping around the provided "
+        "labels to create an nli hypothesis. If provided, overrides the template "
+        "in the nli config.",
+        default=None,
+    )
+    multi_class: Optional[bool] = Field(
+        description="True if class probabilities are independent, default False. "
+        "If provided, overrides the multi_class value in the nli config.",
+        default=None,
     )
 
 
@@ -108,14 +123,15 @@ def process_nli_inputs(
         can be directly passed into the forward pass of the pipeline engine
     """
     sequences = inputs.sequences
-    labels = inputs.labels
-
-    num_sequences = 1 if isinstance(sequences, str) else len(sequences)
-    if num_sequences != pipeline._batch_size:
-        raise ValueError(
-            f"the number of sequences {num_sequences} must be equal to "
-            f"the batch size the model was instantiated with {pipeline._batch_size}"
-        )
+    labels = pipeline._labels or inputs.labels
+    hypothesis_template = (
+        inputs.hypothesis_template
+        if inputs.hypothesis_template is not None
+        else config.hypothesis_template
+    )
+    multi_class = (
+        inputs.multi_class if inputs.multi_class is not None else config.multi_class
+    )
 
     if len(labels) == 0 or len(sequences) == 0:
         raise ValueError(
@@ -124,21 +140,22 @@ def process_nli_inputs(
 
     if isinstance(sequences, str):
         sequences = [sequences]
+
     labels = pipeline._parse_labels(labels)
 
-    if config.hypothesis_template.format(labels[0]) == config.hypothesis_template:
+    if hypothesis_template.format(labels[0]) == hypothesis_template:
         raise ValueError(
             (
                 'The provided hypothesis_template "{}" was not able to be '
                 "formatted with the target labels. Make sure the passed template "
                 "includes formatting syntax such as {{}} where the label should go."
-            ).format(config.hypothesis_template)
+            ).format(hypothesis_template)
         )
 
     sequence_pairs = []
     for sequence in sequences:
         sequence_pairs.extend(
-            [[sequence, config.hypothesis_template.format(label)] for label in labels]
+            [[sequence, hypothesis_template.format(label)] for label in labels]
         )
 
     tokens = pipeline.tokenizer(
@@ -153,6 +170,7 @@ def process_nli_inputs(
     postprocessing_kwargs = dict(
         sequences=sequences,
         labels=labels,
+        multi_class=multi_class,
     )
 
     return pipeline.tokens_to_engine_input(tokens), postprocessing_kwargs
@@ -174,6 +192,7 @@ def process_nli_engine_outputs(
     """
     sequences = kwargs["sequences"]
     candidate_labels = kwargs["labels"]
+    multi_class = kwargs["multi_class"]
 
     outputs = engine_outputs
     if isinstance(outputs, list):
@@ -184,7 +203,7 @@ def process_nli_engine_outputs(
     reshaped_outputs = outputs.reshape((num_sequences, len(candidate_labels), -1))
 
     # Calculate scores
-    if not pipeline._multi_class:
+    if not multi_class:
         entailment_logits = reshaped_outputs[:, :, config.entailment_index]
         scores = numpy_softmax(entailment_logits, axis=1)
     else:
@@ -218,35 +237,32 @@ def nli_engine_forward(
         pass
     :return: result of forward pass to Pipeline engine
     """
-
-    def _engine_forward(batch_index: int, batch_origin: int):
-        labelwise_inputs = engine_inputs[
-            :, batch_origin : batch_origin + pipeline._batch_size, :
-        ]
-        labelwise_inputs = [labelwise_input for labelwise_input in labelwise_inputs]
-        engine_output = pipeline.engine(labelwise_inputs)  # TODO: Parallelize
-        engine_outputs[batch_index] = engine_output
-
     # engine_inputs.shape: [transformer_inputs (3), num_labels * num_seqs, seq_len]
-    engine_inputs = numpy.array(engine_inputs)
-    engine_outputs = [
-        None for _ in range(engine_inputs.shape[1] // pipeline._batch_size)
-    ]
+    # Execute in parallel threads (dynamic labels) or as one batch (static labels)
+    if pipeline._labels is None:
 
-    # Execute in parallel threads or sequentially
-    if pipeline._thread_pool is not None:
+        def _engine_forward(batch_index: int, batch_origin: int):
+            labelwise_inputs = engine_inputs_numpy[
+                :, batch_origin : batch_origin + pipeline._batch_size, :
+            ]
+            labelwise_inputs = [labelwise_input for labelwise_input in labelwise_inputs]
+            engine_output = pipeline.engine(labelwise_inputs)
+            engine_outputs[batch_index] = engine_output
+
+        engine_inputs_numpy = numpy.array(engine_inputs)
+        engine_outputs = [
+            None for _ in range(engine_inputs_numpy.shape[1] // pipeline._batch_size)
+        ]
+
         futures = [
             pipeline._thread_pool.submit(_engine_forward, batch_index, batch_origin)
             for batch_index, batch_origin in enumerate(
-                range(0, engine_inputs.shape[1], pipeline._batch_size)
+                range(0, engine_inputs_numpy.shape[1], pipeline._batch_size)
             )
         ]
         wait(futures)
     else:
-        for batch_index, batch_origin in enumerate(
-            range(0, engine_inputs.shape[1], pipeline._batch_size)
-        ):
-            _engine_forward(batch_index, batch_origin)
+        engine_outputs = pipeline.engine(engine_inputs)
 
     engine_outputs = numpy.array(engine_outputs)
     return engine_outputs

--- a/src/deepsparse/transformers/pipelines/nli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/nli_text_classification.py
@@ -219,9 +219,7 @@ def nli_engine_forward(
     :return: result of forward pass to Pipeline engine
     """
 
-    def _engine_forward(
-        batch_index: int, batch_origin: int, engine_outputs: List[numpy.ndarray]
-    ):
+    def _engine_forward(batch_index: int, batch_origin: int):
         labelwise_inputs = engine_inputs[
             :, batch_origin : batch_origin + pipeline._batch_size, :
         ]

--- a/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
@@ -106,7 +106,7 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
     zero_shot_text_classifier = Pipeline.create(
         task="zero_shot_text_classification",
         model_scheme="nli",
-        model_scheme_config={"hypothesis_template": "This text is related to {}"},
+        model_config={"hypothesis_template": "This text is related to {}"},
         model_path="nli_model_dir/",
     )
     ```
@@ -121,13 +121,18 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
         scores=[[0.7635, 0.1357, 0.1007]]
     ```
 
+    Note that labels must either be provided during pipeline instantiation via
+    the constructor, at inference time, but not both.
+
+    Note that if a hypothesis_template is provided at inference time, then it
+    will override the value provided during model instantiation
+
     :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
         (preferred) a directory containing a model.onnx, tokenizer config, and model
         config. If no tokenizer and/or model config(s) are found, then they will be
         loaded from huggingface transformers using the `default_model_name` key
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
-    :param batch_size: static batch size to use for inference. Default is 1
     :param num_cores: number of CPU cores to allocate for inference engine. None
         specifies all available cores. Default is None
     :param scheduler: (deepsparse only) kind of scheduler to execute with.
@@ -143,19 +148,25 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
         Default is "bert-base-uncased"
     :param model_scheme: training scheme used to train the model used for zero shot.
         Currently supported schemes are "nli"
-    :param model_scheme_config: Config object or a dict of config keyword arguments
-    :param multi_class: True if class probabilities are independent, default False
+    :param model_config: config object specific to the model_scheme of this model
+        or a dict of config keyword arguments
+    :param num_sequences: the number of sequences to handle per batch.
+    :param labels: static list of labels to perform text classification with. Can
+        also be provided at inference time
     :param context: context for engine. If None, then the engine will be initialized
         with 2 streams to make use of parallel inference of labels
     """
 
+    # Note batch_size is for compatibility and users should instead use num_sequences
     def __init__(
         self,
         *,
         model_scheme: str = ModelSchemes.nli.value,
-        model_scheme_config: Optional[Union[NliTextClassificationConfig, dict]] = None,
-        multi_class: bool = False,
-        context: Context = None,
+        model_config: Optional[Union[NliTextClassificationConfig, dict]] = None,
+        num_sequences: int = 1,
+        labels: Optional[List] = None,
+        context: Optional[Context] = None,
+        batch_size: Optional[int] = None,
         **kwargs,
     ):
         if model_scheme not in ModelSchemes.to_list():
@@ -165,18 +176,43 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
             )
 
         self._model_scheme = model_scheme
-        self._config = self._parse_config(model_scheme_config)
-        self._multi_class = multi_class
+        self._config = self._parse_config(model_config)
+        self._num_sequences = num_sequences
+        self._labels = self._parse_labels(labels)
         self._thread_pool = None
 
-        if context is None and model_scheme == ModelSchemes.nli.value:
-            num_streams = 2  # Arbitrarily chosen value >= 2
-            context = Context(num_cores=None, num_streams=num_streams)
-            kwargs.update({"context": context})
+        # If dynamic labels
+        if self._labels is None:
+            if context is None:
+                # num_streams is arbitrarily chosen to be any value >= 2
+                context = Context(num_cores=None, num_streams=2)
+                kwargs.update({"context": context})
+
             self._thread_pool = ThreadPoolExecutor(
-                max_workers=num_streams,
+                max_workers=context.num_streams or 2,
                 thread_name_prefix="deepsparse.pipelines.zero_shot_text_classifier",
             )
+
+            if batch_size is not None and batch_size != num_sequences:
+                raise ValueError(
+                    f"This pipeline requires that batch_size {batch_size} match "
+                    f"num_sequences {num_sequences} when no static labels are "
+                    f"provided"
+                )
+            kwargs.update({"batch_size": num_sequences})
+
+        # If static labels
+        else:
+            if batch_size is not None and batch_size != num_sequences * len(
+                self._labels
+            ):
+                raise ValueError(
+                    f"This pipeline requires that batch_size {batch_size} match "
+                    f"num_sequences times the number labels "
+                    f"{num_sequences * len(self._labels)} when static labels are "
+                    f"provided"
+                )
+            kwargs.update({"batch_size": num_sequences * len(self._labels)})
 
         super().__init__(**kwargs)
 
@@ -222,7 +258,7 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
         """
         return ZeroShotTextClassificationOutput
 
-    def _parse_labels(self, labels: Union[List[str], str]) -> List[str]:
+    def _parse_labels(self, labels: Union[None, List[str], str]) -> List[str]:
         """
         If given a string of comma separated labels, parses values into a list
 
@@ -268,6 +304,31 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
         :return: inputs of this model processed into a list of numpy arrays that
             can be directly passed into the forward pass of the pipeline engine
         """
+
+        # Check for absent labels
+        if inputs.labels is None and self._labels is None:
+            raise ValueError(
+                "You must provide either static labels during pipeline creation or "
+                "dynamic labels at inference time"
+            )
+
+        # Check for conflicting labels
+        if inputs.labels is not None and self._labels is not None:
+            raise ValueError(
+                "Found both static labels and dynamic labels at inference time. You "
+                "must provide only one"
+            )
+
+        # Check for incorrect number of sequences
+        num_sequences = (
+            1 if isinstance(inputs.sequences, str) else len(inputs.sequences)
+        )
+        if num_sequences != self._num_sequences:
+            raise ValueError(
+                f"number of sequences {num_sequences} must match the number of "
+                f"sequences the pipeline was instantiated with {self._num_sequences}"
+            )
+
         if self._model_scheme == ModelSchemes.nli.value:
             return process_nli_inputs(self, inputs, self._config)
 


### PR DESCRIPTION
This PR adds support for multistream inference of labels by default with the zero shot pipeline. It also fixes some typing errors in `engine.py`.

Here are some sample improved inference times.
Batch = 3 sequences, 1003 labels

```
1 stream : 55 seconds
2 streams: 45 seconds
4 streams: 40 seconds
6 streams: 40 seconds
```