### PR TITLE
Fixed nesting annotation results folders

### DIFF
--- a/src/deepsparse/yolo/utils/utils.py
+++ b/src/deepsparse/yolo/utils/utils.py
@@ -890,9 +890,8 @@ def get_annotations_save_dir(
     :return: A new unique dir path to save annotations to
     """
     name = tag or f"{engine}-annotations"
-    initial_save_dir = os.path.join(initial_save_dir, name)
     counter = 0
-    new_save_dir = initial_save_dir
+    new_save_dir = os.path.join(initial_save_dir, name)
     while Path(new_save_dir).exists() and any(Path(new_save_dir).iterdir()):
         counter += 1
         new_save_dir = os.path.join(initial_save_dir, f"{name}-{counter:03d}")


### PR DESCRIPTION
This PR fixes a bug where annotation results would be nested into subfolders.

Previously
annotation-results/deepsparse-annotations/
annotation-results/deepsparse-annotations/deepsparse-annotations-001/
annotation-results/deepsparse-annotations/deepsparse-annotations-002/

Now
annotation-results/deepsparse-annotations/
annotation-results/deepsparse-annotations-001/
annotation-results/deepsparse-annotations-002/

This mimics the folder structure of how sparseml results are written to disk.