### PR TITLE
transformers pipelines raise exception if tokenizer and config not supplied

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -66,10 +66,8 @@ def question_answering_pipeline(*args, **kwargs) -> "Pipeline":
     )
     ```
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -83,9 +81,6 @@ def question_answering_pipeline(*args, **kwargs) -> "Pipeline":
         inferencing with multiple models. Default is None
     :param sequence_length: sequence length to compile model and tokenizer for.
         Default is 128
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     :param doc_stride: if the context is too long to fit with the question for the
         model, it will be split in several chunks with some overlap. This argument
         controls the size of that overlap. Currently, only reading the first span
@@ -129,10 +124,8 @@ def text_classification_pipeline(*args, **kwargs) -> "Pipeline":
     sentiments = text_classifier([["the food tastes great"], ["the food tastes bad"]])
     ```
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -146,9 +139,6 @@ def text_classification_pipeline(*args, **kwargs) -> "Pipeline":
         inferencing with multiple models. Default is None
     :param sequence_length: sequence length to compile model and tokenizer for.
         Default is 128
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     :param return_all_scores: if True, instead of returning the prediction as the
         argmax of model class predictions, will return all scores and labels as
         a list for each result in the batch. Default is False
@@ -187,10 +177,8 @@ def sentiment_analysis_pipeline(*args, **kwargs) -> "Pipeline":
     sentiments = text_classifier([["the food tastes great"], ["the food tastes bad"]])
     ```
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -204,9 +192,6 @@ def sentiment_analysis_pipeline(*args, **kwargs) -> "Pipeline":
         inferencing with multiple models. Default is None
     :param sequence_length: sequence length to compile model and tokenizer for.
         Default is 128
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     :param return_all_scores: if True, instead of returning the prediction as the
         argmax of model class predictions, will return all scores and labels as
         a list for each result in the batch. Default is False
@@ -227,10 +212,8 @@ def token_classification_pipeline(*args, **kwargs) -> "Pipeline":
     )
     ```
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -244,9 +227,6 @@ def token_classification_pipeline(*args, **kwargs) -> "Pipeline":
         inferencing with multiple models. Default is None
     :param sequence_length: sequence length to compile model and tokenizer for.
         Default is 128
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     :param aggregation_strategy: how to aggregate tokens in postprocessing. Options
         include 'none', 'simple', 'first', 'average', and 'max'. Default is None
     :param ignore_labels: list of label names to ignore in output. Default is
@@ -774,6 +754,7 @@ class Pipeline(ABC):
         if engine_type == DEEPSPARSE_ENGINE:
             if self.context is not None and isinstance(self.context, Context):
                 self._engine_args.pop("num_cores", None)
+                self._engine_args.pop("scheduler", None)
                 self._engine_args["context"] = self.context
                 return MultiModelEngine(
                     model=self.onnx_file_path,

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -49,10 +49,8 @@ class TransformersPipeline(Pipeline):
     be added to the supported nlp tasks in deepsparse.tasks so they can be properly
     imported at runtime.
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -65,21 +63,16 @@ class TransformersPipeline(Pipeline):
     :param alias: optional name to give this pipeline instance, useful when
         inferencing with multiple models. Default is None
     :param sequence_length: static sequence length to use for inference
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     """
 
     def __init__(
         self,
         *,
         sequence_length: int = 128,
-        default_model_name: str = "bert-base-uncased",
         **kwargs,
     ):
 
         self._sequence_length = sequence_length
-        self._default_model_name = default_model_name
 
         self.config = None
         self.tokenizer = None
@@ -96,30 +89,16 @@ class TransformersPipeline(Pipeline):
         """
         return self._sequence_length
 
-    @property
-    def default_model_name(self) -> str:
-        """
-        :return: huggingface transformers model name to use to
-            load a tokenizer and model config when none are provided in the
-            `model_path`
-        """
-        return self._default_model_name
-
     def setup_onnx_file_path(self) -> str:
         """
         Parses ONNX, tokenizer, and config file paths from the given `model_path`.
-        Supports sparsezoo stubs. If a tokenizer and/or config file are not found,
-        they will be defaulted to the default_model_name in the transformers repo
+        Supports sparsezoo stubs
 
         :return: file path to the processed ONNX file for the engine to compile
         """
         onnx_path, config_path, tokenizer_path = get_onnx_path_and_configs(
-            self.model_path
+            self.model_path, require_configs=True
         )
-
-        # default config + tokenizer if necessary
-        config_path = config_path or self.default_model_name
-        tokenizer_path = tokenizer_path or self.default_model_name
 
         self.config = AutoConfig.from_pretrained(
             config_path, finetuning_task=self.task if hasattr(self, "task") else None
@@ -214,6 +193,5 @@ def pipeline(
         num_cores=num_cores,
         scheduler=scheduler,
         sequence_length=max_length,
-        default_model_name=model_name,
         **kwargs,
     )

--- a/src/deepsparse/transformers/pipelines/question_answering.py
+++ b/src/deepsparse/transformers/pipelines/question_answering.py
@@ -96,10 +96,8 @@ class QuestionAnsweringPipeline(TransformersPipeline):
     )
     ```
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -113,9 +111,6 @@ class QuestionAnsweringPipeline(TransformersPipeline):
         inferencing with multiple models. Default is None
     :param sequence_length: sequence length to compile model and tokenizer for.
         Default is 128
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     :param doc_stride: if the context is too long to fit with the question for the
         model, it will be split in several chunks with some overlap. This argument
         controls the size of that overlap. Default is 128

--- a/src/deepsparse/transformers/pipelines/text_classification.py
+++ b/src/deepsparse/transformers/pipelines/text_classification.py
@@ -115,10 +115,8 @@ class TextClassificationPipeline(TransformersPipeline):
     sentiments = text_classifier([["the food tastes great"], ["the food tastes bad"]])
     ```
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -132,9 +130,6 @@ class TextClassificationPipeline(TransformersPipeline):
         inferencing with multiple models. Default is None
     :param sequence_length: sequence length to compile model and tokenizer for.
         Default is 128
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     :param return_all_scores: if True, instead of returning the prediction as the
         argmax of model class predictions, will return all scores and labels as
         a list for each result in the batch. Default is False

--- a/src/deepsparse/transformers/pipelines/token_classification.py
+++ b/src/deepsparse/transformers/pipelines/token_classification.py
@@ -141,10 +141,8 @@ class TokenClassificationPipeline(TransformersPipeline):
     )
     ```
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
     :param batch_size: static batch size to use for inference. Default is 1
@@ -158,9 +156,6 @@ class TokenClassificationPipeline(TransformersPipeline):
         inferencing with multiple models. Default is None
     :param sequence_length: sequence length to compile model and tokenizer for.
         Default is 128
-    :param default_model_name: huggingface transformers model name to use to
-        load a tokenizer and model config when none are provided in the `model_path`.
-        Default is 'bert-base-uncased'
     :param aggregation_strategy: how to aggregate tokens in postprocessing. Options
         include 'none', 'simple', 'first', 'average', and 'max'. Default is None
     :param ignore_labels: list of label names to ignore in output. Default is


### PR DESCRIPTION
raising this exception will avoid hidden issues if incorrect default tokenizers/configs are used