### PR TITLE
standardize names in pipeline registry to lowercase + underscores

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -525,6 +525,8 @@ class Pipeline(ABC):
         if task_aliases:
             task_names.extend(task_aliases)
 
+        task_names = [task_name.lower().replace("-", "_") for task_name in task_names]
+
         def _register_task(task_name, pipeline_class):
             if task_name in _REGISTERED_PIPELINES and (
                 pipeline_class is not _REGISTERED_PIPELINES[task_name]


### PR DESCRIPTION
registry lookup (`Pipeline.create`) runs `task.lower().replace("-", "_")` on all task creations, this PR performs the same standardization on names passed to `Pipeline.register` so they may be discoverable on `create`.

Bug discovered by @dbarbuzzi 