### PR TITLE
Fix small bug incurred by top_k predictions functionality in IC pipeline.

### DIFF
--- a/src/deepsparse/image_classification/pipelines.py
+++ b/src/deepsparse/image_classification/pipelines.py
@@ -232,9 +232,10 @@ class ImageClassificationPipeline(Pipeline):
 
         if self.class_names is not None:
             labels = numpy.vectorize(self.class_names.__getitem__)(labels)
-
-        if isinstance(labels, numpy.ndarray):
             labels = labels.tolist()
+
+        if isinstance(labels[0], numpy.ndarray):
+            labels = [label.tolist() for label in labels]
 
         if len(labels) == 1:
             labels = labels[0]


### PR DESCRIPTION
The band-aid for:
```
>>> input_image = "test.png" # path to input image 
>>> inference = cv_pipeline(images=input_image)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dhuang/docs/venv/lib/python3.8/site-packages/deepsparse/pipeline.py", line 163, in __call__
    pipeline_outputs = self.process_engine_outputs(
  File "/home/dhuang/docs/venv/lib/python3.8/site-packages/deepsparse/image_classification/pipelines.py", line 243, in process_engine_outputs
    return self.output_schema(
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ImageClassificationOutput
labels
  value is not a valid list (type=type_error.list)
  ```