### PR TITLE
require `tokenizer.json` for transformers pipeline configs

### DIFF
--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -99,7 +99,7 @@ def get_onnx_path_and_configs(
         for framework_file in zoo_model.framework_files:
             if framework_file.display_name == _MODEL_DIR_CONFIG_NAME:
                 config_path = _get_file_parent(framework_file.downloaded_path())
-            if "tokenizer" in framework_file.display_name:
+            if "tokenizer.json" in framework_file.display_name:
                 tokenizer_path = _get_file_parent(framework_file.downloaded_path())
     elif require_configs and (config_path is None or tokenizer_path is None):
         raise RuntimeError(


### PR DESCRIPTION
previously `tokenizer_config.json` was also accepted which leads to a hard to read exception