### PR TITLE
[cherry-pick] fix transformers eval_downstream config path for zoo models

### DIFF
--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -55,7 +55,6 @@ python eval_downstream.py \
 
 import argparse
 import json
-import os
 
 from tqdm.auto import tqdm
 
@@ -123,7 +122,7 @@ def mnli_eval(args):
     )
     print(f"Engine info: {text_classify.engine}")
 
-    label_map = _get_label2id(args.onnx_filepath)
+    label_map = _get_label2id(text_classify.config_path)
 
     for idx, sample in _enumerate_progress(mnli_matched, args.max_samples):
         pred = text_classify([[sample["premise"], sample["hypothesis"]]])
@@ -163,7 +162,7 @@ def qqp_eval(args):
     )
     print(f"Engine info: {text_classify.engine}")
 
-    label_map = _get_label2id(args.onnx_filepath)
+    label_map = _get_label2id(text_classify.config_path)
 
     for idx, sample in _enumerate_progress(qqp, args.max_samples):
         pred = text_classify([[sample["question1"], sample["question2"]]])
@@ -194,7 +193,7 @@ def sst2_eval(args):
     )
     print(f"Engine info: {text_classify.engine}")
 
-    label_map = _get_label2id(args.onnx_filepath)
+    label_map = _get_label2id(text_classify.config_path)
 
     for idx, sample in _enumerate_progress(sst2, args.max_samples):
         pred = text_classify(
@@ -217,8 +216,7 @@ def _enumerate_progress(dataset, max_steps):
     return enumerate(progress_bar)
 
 
-def _get_label2id(onnx_file_path):
-    config_file_path = os.path.join(onnx_file_path, "config.json")
+def _get_label2id(config_file_path):
     with open(config_file_path) as f:
         config = json.load(f)
     return config["label2id"]

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -16,7 +16,7 @@
 Base Pipeline class for transformers inference pipeline
 """
 
-
+import os
 import warnings
 from typing import Any, List, Mapping, Optional
 
@@ -76,6 +76,8 @@ class TransformersPipeline(Pipeline):
 
         self.config = None
         self.tokenizer = None
+        self.config_path = None
+        self.tokenizer_config_path = None  # path to 'tokenizer.json'
         self.onnx_input_names = None
 
         self._temp_model_directory = None
@@ -106,6 +108,8 @@ class TransformersPipeline(Pipeline):
         self.tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_path, model_max_length=self.sequence_length
         )
+        self.config_path = os.path.join(config_path, "config.json")
+        self.tokenizer_config_path = os.path.join(tokenizer_path, "tokenizer.json")
 
         # overwrite onnx graph to given required input shape
         (


### PR DESCRIPTION
current implementation assumes model and config are in same directory which under current sparsezoo implementation is not always the case