### PR TITLE
[cherrypick] Add `utils/artifacts.py` to MANIFEST (#495)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
+include utils/artifacts.py
 recursive-include src/deepsparse/avx2 *
 recursive-include src/deepsparse/avx512 *


### PR DESCRIPTION
The functions needed for the artifact store functionality to work in setup.py aren't included by default in the source distribution

https://packaging.python.org/en/latest/guides/using-manifest-in/