### PR TITLE
transformers eval support for conll2003 token classification (NER)

### DIFF
--- a/src/deepsparse/transformers/pipelines/token_classification.py
+++ b/src/deepsparse/transformers/pipelines/token_classification.py
@@ -76,6 +76,14 @@ class TokenClassificationInput(BaseModel):
             "a token_classification task"
         )
     )
+    is_split_into_words: bool = Field(
+        default=False,
+        description=(
+            "True if the input is a batch size 1 list of strings representing. "
+            "individual word tokens. Currently only supports batch size 1. "
+            "Default is False"
+        ),
+    )
 
 
 class TokenClassificationResult(BaseModel):
@@ -247,6 +255,9 @@ class TokenClassificationPipeline(TransformersPipeline):
             and dictionary containing offset mappings and special tokens mask to
             be used during postprocessing
         """
+        if inputs.is_split_into_words and self.engine.batch_size != 1:
+            raise ValueError("is_split_into_words=True only supported for batch size 1")
+
         tokens = self.tokenizer(
             inputs.inputs,
             return_tensors="np",
@@ -254,6 +265,7 @@ class TokenClassificationPipeline(TransformersPipeline):
             padding=PaddingStrategy.MAX_LENGTH.value,
             return_special_tokens_mask=True,
             return_offsets_mapping=self.tokenizer.is_fast,
+            is_split_into_words=inputs.is_split_into_words,
         )
 
         offset_mapping = (
@@ -262,11 +274,29 @@ class TokenClassificationPipeline(TransformersPipeline):
             else [None] * len(inputs.inputs)
         )
         special_tokens_mask = tokens.pop("special_tokens_mask")
+
+        word_start_mask = None
+        if inputs.is_split_into_words:
+            # create mask for word in the split words where values are True
+            # if they are the start of a tokenized word
+            word_start_mask = []
+            word_ids = tokens.word_ids(batch_index=0)
+            previous_id = None
+            for word_id in word_ids:
+                if word_id is None:
+                    continue
+                if word_id != previous_id:
+                    word_start_mask.append(True)
+                    previous_id = word_id
+                else:
+                    word_start_mask.append(False)
+
         postprocessing_kwargs = dict(
             inputs=inputs,
             tokens=tokens,
             offset_mapping=offset_mapping,
             special_tokens_mask=special_tokens_mask,
+            word_start_mask=word_start_mask,
         )
 
         return self.tokens_to_engine_input(tokens), postprocessing_kwargs
@@ -286,6 +316,7 @@ class TokenClassificationPipeline(TransformersPipeline):
         tokens = kwargs["tokens"]
         offset_mapping = kwargs["offset_mapping"]
         special_tokens_mask = kwargs["special_tokens_mask"]
+        word_start_mask = kwargs["word_start_mask"]
 
         predictions = []  # type: List[List[TokenClassificationResult]]
 
@@ -295,6 +326,7 @@ class TokenClassificationPipeline(TransformersPipeline):
             scores = numpy.exp(current_entities) / numpy.exp(current_entities).sum(
                 -1, keepdims=True
             )
+
             pre_entities = self._gather_pre_entities(
                 inputs.inputs[entities_index],
                 input_ids,
@@ -305,9 +337,11 @@ class TokenClassificationPipeline(TransformersPipeline):
             grouped_entities = self._aggregate(pre_entities)
             # Filter anything that is in self.ignore_labels
             current_results = []  # type: List[TokenClassificationResult]
-            for entity in grouped_entities:
-                if entity.get("entity") in self.ignore_labels or (
-                    entity.get("entity_group") in self.ignore_labels
+            for entity_idx, entity in enumerate(grouped_entities):
+                if (
+                    entity.get("entity") in self.ignore_labels
+                    or (entity.get("entity_group") in self.ignore_labels)
+                    or (word_start_mask and not word_start_mask[entity_idx])
                 ):
                     continue
                 if entity.get("entity_group"):


### PR DESCRIPTION
eval support for conll2003 NER token classification
support added for passing tokens directly to pipeline, following train script eval logic: https://github.com/neuralmagic/sparseml/blob/af9f60e67b0685ee080443e65340247398b95ac5/src/sparseml/transformers/token_classification.py#L524 (tokens re-labeled to `-100` are ignored on eval)

**test_plan**:
confirmed accuracy matches expected (98.29) for [pruned 90 distilbert on conll2003](https://sparsezoo.neuralmagic.com/models/nlp%2Ftoken_classification%2Fdistilbert-none%2Fpytorch%2Fhuggingface%2Fconll2003%2Fpruned90-none):

```bash
$ deepsparse.transformers.eval_downstream zoo:nlp/token_classification/distilbert-none/pytorch/huggingface/conll2003/pruned90-none --dataset conll2003

...

100%|█████████████████████████████████████████████████████████████████████████████████| 3251/3251 [01:03<00:00, 51.55it/s]

conll2003 eval results: {'LOC': {'precision': 0.9390374331550803, 'recall': 0.9559063690800218, 'f1': 0.9473968168330187, 'number': 1837}, 'MISC': {'precision': 0.823271130625686, 'recall': 0.8134490238611713, 'f1': 0.818330605564648, 'number': 922}, 'ORG': {'precision': 0.8586156111929307, 'recall': 0.8695003728560775, 'f1': 0.8640237124861059, 'number': 1341}, 'PER': {'precision': 0.9620726495726496, 'recall': 0.9777415852334419, 'f1': 0.9698438341410877, 'number': 1842}, 'overall_precision': 0.9104974213941108, 'overall_recall': 0.921070346684618, 'overall_f1': 0.9157533673554756, 
'overall_accuracy': 0.9829640590319692
}
```