### PR TITLE
zeroshot eval_downstream, slight input change, doc updates

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -742,7 +742,7 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
     meant for this task.
 
     This class upon construction returns an instance of a child Pipeline which
-    inherits from ZeroShotTextClassificationImplementation. Which type of Pipeline
+    inherits from ZeroShotTextClassificationPipelineBase. Which type of Pipeline
     is returned depends on the value of the passed model_scheme argument.
 
     example dynamic labels:
@@ -756,10 +756,11 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
 
     sequence_to_classify = "Who are you voting for in 2020?"
     candidate_labels = ["Europe", "public health", "politics"]
-    zero_shot_text_classifier(sequence_to_classify, candidate_labels)
-    >>> sequences=['Who are you voting for in 2020?']
-        labels=[['politics', 'Europe', 'public health']]
-        scores=[[0.7635, 0.1357, 0.1007]]
+    zero_shot_text_classifier(sequences=sequence_to_classify, labels=candidate_labels)
+    >>> ZeroShotTextClassificationOutput(
+        sequences='Who are you voting for in 2020?',
+        labels=['politics', 'public health', 'Europe'],
+        scores=[0.9073666334152222, 0.046810582280159, 0.04582275450229645])
     ```
 
     example static labels:
@@ -768,15 +769,17 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
         task="zero_shot_text_classification",
         batch_size=3,
         model_scheme="mnli",
+        model_config={"hypothesis_template": "This text is related to {}"},
         model_path="mnli_model_dir/",
         labels=["politics", "Europe", "public health"]
     )
 
     sequence_to_classify = "Who are you voting for in 2020?"
-    zero_shot_text_classifier(sequence_to_classify)
-    >>> sequences=['Who are you voting for in 2020?']
-        labels=[['politics', 'Europe', 'public health']]
-        scores=[[0.7635, 0.1357, 0.1007]]
+    zero_shot_text_classifier(sequences=sequence_to_classify)
+    >>> ZeroShotTextClassificationOutput(
+        sequences='Who are you voting for in 2020?',
+        labels=['politics', 'public health', 'Europe'],
+        scores=[0.9073666334152222, 0.046810582280159, 0.04582275450229645])
     ```
 
     Note that labels must either be provided during pipeline instantiation via
@@ -801,10 +804,6 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
         to use model as-is. Default is None
     :param alias: optional name to give this pipeline instance, useful when
         inferencing with multiple models. Default is None
-    :param sequence_length: sequence length to compile model and tokenizer for.
-        If a list of lengths is provided, then for each length, a model and
-        tokenizer will be compiled capable of handling that sequence length
-        (also known as a bucket). Default is 128
     :param default_model_name: huggingface transformers model name to use to
         load a tokenizer and model config when none are provided in the `model_path`.
         Default is "bert-base-uncased"

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -63,8 +63,8 @@ from pstats import Stats
 
 from tqdm.auto import tqdm
 
-#from deepsparse import Pipeline
-from transformers import pipeline as Pipeline # bookmark
+from deepsparse import Pipeline
+#from transformers import pipeline as Pipeline # bookmark
 
 
 from datasets import load_dataset, load_metric  # isort: skip
@@ -235,7 +235,7 @@ def sst2_zero_shot_eval(args):
     sst2_metrics = load_metric("glue", "sst2")
 
     # load pipeline
-    """
+    #"""
     text_classify = Pipeline.create(
         task="zero_shot_text_classification",
         batch_size=2,
@@ -243,15 +243,15 @@ def sst2_zero_shot_eval(args):
         model_config={"hypothesis_template": "The sentiment of this text is {}",
                       "multi_class": True},
         #model_path=args.onnx_filepath,
-        model_path="zoo:nlp/text_classification/bert-large/pytorch/huggingface/mnli/pruned80_quant-none-vnni",
+        model_path="zoo:nlp/text_classification/bert-base/pytorch/huggingface/mnli/12layer_pruned90-none",
         engine_type=args.engine,
         num_cores=args.num_cores,
         sequence_length=args.max_sequence_length,
         labels=["positive", "negative"]
     )
-    """
+    #"""
 
-    text_classify = Pipeline("zero-shot-classification", model="/home/kyle/downloads/3b681313-3ef1-4865-81a9-ace5ae7cc6e0/pytorch")
+    #text_classify = Pipeline("zero-shot-classification", model="./downloads/4422c5be-f1bf-4659-a28f-06acb18c6308/pytorch")
     #print(f"Engine info: {text_classify.engine}")
 
     label_map = {"positive": 1, "negative": 0}
@@ -261,13 +261,13 @@ def sst2_zero_shot_eval(args):
             sequences=sample["sentence"],
             candidate_labels=["positive", "negative"],
             hypothesis_template="The sentiment of this text is {}",
-            multi_label=True,
-            #multi_class=True,
+            #multi_label=True,
+            multi_class=True,
         )
 
         sst2_metrics.add_batch(
-            #predictions=[label_map.get(pred.labels[0])],
-            predictions=[label_map.get(pred["labels"][0])],
+            predictions=[label_map.get(pred.labels[0])],
+            #predictions=[label_map.get(pred["labels"][0])],
             references=[sample["label"]],
         )
 

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -63,8 +63,8 @@ from pstats import Stats
 
 from tqdm.auto import tqdm
 
-from deepsparse import Pipeline
-#from transformers import pipeline as Pipeline # bookmark
+#from deepsparse import Pipeline
+from transformers import pipeline as Pipeline # bookmark
 
 
 from datasets import load_dataset, load_metric  # isort: skip
@@ -235,7 +235,7 @@ def sst2_zero_shot_eval(args):
     sst2_metrics = load_metric("glue", "sst2")
 
     # load pipeline
-    #"""
+    """
     text_classify = Pipeline.create(
         task="zero_shot_text_classification",
         batch_size=2,
@@ -243,15 +243,15 @@ def sst2_zero_shot_eval(args):
         model_config={"hypothesis_template": "The sentiment of this text is {}",
                       "multi_class": True},
         #model_path=args.onnx_filepath,
-        model_path="zoo:nlp/text_classification/bert-base/pytorch/huggingface/mnli/base-none",
+        model_path="zoo:nlp/text_classification/distilbert-none/pytorch/huggingface/mnli/pruned90-none",
         engine_type=args.engine,
         num_cores=args.num_cores,
         sequence_length=args.max_sequence_length,
         labels=["positive", "negative"]
     )
-    #"""
+    """
 
-    #text_classify = Pipeline("zero-shot-classification")
+    text_classify = Pipeline("zero-shot-classification", model="./downloads/f94ff44e-7468-4837-b2fa-7b050ac81013/pytorch")
     #print(f"Engine info: {text_classify.engine}")
 
     label_map = {"positive": 1, "negative": 0}
@@ -261,12 +261,13 @@ def sst2_zero_shot_eval(args):
             sequences=sample["sentence"],
             candidate_labels=["positive", "negative"],
             hypothesis_template="The sentiment of this text is {}",
-            multi_class=True,
+            multi_label=True,
+            #multi_class=True,
         )
 
         sst2_metrics.add_batch(
-            predictions=[label_map.get(pred.labels[0])],
-            #predictions=[label_map.get(pred["labels"][0])],
+            #predictions=[label_map.get(pred.labels[0])],
+            predictions=[label_map.get(pred["labels"][0])],
             references=[sample["label"]],
         )
 

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -243,7 +243,7 @@ def sst2_zero_shot_eval(args):
         model_config={"hypothesis_template": "The sentiment of this text is {}",
                       "multi_class": True},
         #model_path=args.onnx_filepath,
-        model_path="zoo:nlp/text_classification/distilbert-none/pytorch/huggingface/mnli/pruned90-none",
+        model_path="zoo:nlp/text_classification/bert-large/pytorch/huggingface/mnli/pruned80_quant-none-vnni",
         engine_type=args.engine,
         num_cores=args.num_cores,
         sequence_length=args.max_sequence_length,
@@ -251,7 +251,7 @@ def sst2_zero_shot_eval(args):
     )
     """
 
-    text_classify = Pipeline("zero-shot-classification", model="./downloads/f94ff44e-7468-4837-b2fa-7b050ac81013/pytorch")
+    text_classify = Pipeline("zero-shot-classification", model="/home/kyle/downloads/3b681313-3ef1-4865-81a9-ace5ae7cc6e0/pytorch")
     #print(f"Engine info: {text_classify.engine}")
 
     label_map = {"positive": 1, "negative": 0}

--- a/src/deepsparse/transformers/pipelines/mnli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/mnli_text_classification.py
@@ -271,8 +271,8 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
             probabilities = numpy_softmax(entailment_contradiction_logits, axis=2)
             scores = probabilities[:, :, 0]
 
-        # perform reversed sort
-        sorted_indexes = list(reversed(numpy.argsort(scores, axis=1)))
+        # negate scores to perform reversed sort
+        sorted_indexes = numpy.argsort(scores * -1, axis=1)
         labels = [
             numpy.array(candidate_labels)[sorted_indexes[i]].tolist()
             for i in range(num_sequences)

--- a/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
@@ -286,15 +286,14 @@ class ZeroShotTextClassificationPipelineBase(TransformersPipeline):
             )
 
         if args:
-            if len(args) == 1:
-                if isinstance(args[0], self.input_schema):
-                    return args[0]
-                if isinstance(args[0], str):
-                    return self.input_schema(sequences=args[0])
+            if len(args) == 1 and isinstance(args[0], self.input_schema):
+                input = args[0]
             else:
-                return self.input_schema(sequences=args)
+                input = self.input_schema(*args)
+        else:
+            input = self.input_schema(**kwargs)
 
-        return self.input_schema(**kwargs)
+        return input
 
     @staticmethod
     def route_input_to_bucket(

--- a/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
@@ -119,9 +119,9 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
     candidate_labels = ["Europe", "public health", "politics"]
     zero_shot_text_classifier(sequences=sequence_to_classify, labels=candidate_labels)
     >>> ZeroShotTextClassificationOutput(
-        sequences=['Who are you voting for in 2020?'],
-        labels=[['politics', 'public health', 'Europe']],
-        scores=[[0.9073666334152222, 0.046810582280159, 0.04582275450229645]])
+        sequences='Who are you voting for in 2020?',
+        labels=['politics', 'public health', 'Europe'],
+        scores=[0.9073666334152222, 0.046810582280159, 0.04582275450229645])
     ```
 
     example static labels:
@@ -138,9 +138,9 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
     sequence_to_classify = "Who are you voting for in 2020?"
     zero_shot_text_classifier(sequences=sequence_to_classify)
     >>> ZeroShotTextClassificationOutput(
-        sequences=['Who are you voting for in 2020?'],
-        labels=[['politics', 'public health', 'Europe']],
-        scores=[[0.9073666334152222, 0.046810582280159, 0.04582275450229645]])
+        sequences='Who are you voting for in 2020?',
+        labels=['politics', 'public health', 'Europe'],
+        scores=[0.9073666334152222, 0.046810582280159, 0.04582275450229645])
     ```
 
     Note that labels must either be provided during pipeline instantiation via
@@ -286,14 +286,15 @@ class ZeroShotTextClassificationPipelineBase(TransformersPipeline):
             )
 
         if args:
-            if len(args) == 1 and isinstance(args[0], self.input_schema):
-                input = args[0]
+            if len(args) == 1:
+                # passed input_schema schema directly
+                if isinstance(args[0], self.input_schema):
+                    return args[0]
+                return self.input_schema(sequences=args[0])
             else:
-                input = self.input_schema(*args)
-        else:
-            input = self.input_schema(**kwargs)
+                return self.input_schema(sequences=args)
 
-        return input
+        return self.input_schema(**kwargs)
 
     @staticmethod
     def route_input_to_bucket(

--- a/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
@@ -286,14 +286,15 @@ class ZeroShotTextClassificationPipelineBase(TransformersPipeline):
             )
 
         if args:
-            if len(args) == 1 and isinstance(args[0], self.input_schema):
-                input = args[0]
+            if len(args) == 1:
+                if isinstance(args[0], self.input_schema):
+                    return args[0]
+                if isinstance(args[0], str):
+                    return self.input_schema(sequences=args[0])
             else:
-                input = self.input_schema(*args)
-        else:
-            input = self.input_schema(**kwargs)
+                return self.input_schema(sequences=args)
 
-        return input
+        return self.input_schema(**kwargs)
 
     @staticmethod
     def route_input_to_bucket(


### PR DESCRIPTION
This PR does 3 things
* changes the output when the pipeline is fed a string. Before, feeding a str would result in sequences=["my sequence"], now it's sequences="my sequence". This change supports...
* tests for eval_downstream. Since zero shot text classification shares the sst2 dataset with text classification, I added an argument to eval_downstream that modifies the task with "_zero_shot"
* Minor fixes to documentation