### PR TITLE
Bugfix + Dynamic batch Support for Yolact

### DIFF
--- a/src/deepsparse/yolact/pipelines.py
+++ b/src/deepsparse/yolact/pipelines.py
@@ -33,7 +33,6 @@ except ModuleNotFoundError as cv2_import_error:
     cv2 = None
     cv2_error = cv2_import_error
 
-
 __all__ = ["YOLACTPipeline"]
 
 
@@ -151,9 +150,11 @@ class YOLACTPipeline(Pipeline):
             max_num_detections=inputs.max_num_detections,
         )
 
-        return [
+        preprocessed_images = [
             preprocess_array(array, self.image_size) for array in images
-        ], postprocessing_kwargs
+        ]
+        image_batch = numpy.concatenate(preprocessed_images, axis=0)
+        return [image_batch], postprocessing_kwargs
 
     def process_engine_outputs(
         self, engine_outputs: List[numpy.ndarray], **kwargs

--- a/src/deepsparse/yolact/schemas.py
+++ b/src/deepsparse/yolact/schemas.py
@@ -17,10 +17,12 @@ Input/Output Schemas for Image Segmentation with YOLACT
 """
 
 from collections import namedtuple
-from typing import List, Optional, Union
+from typing import Generator, Iterable, List, Optional, Union
 
 import numpy
 from pydantic import BaseModel, Field
+
+from deepsparse.pipelines import Joinable, Splittable
 
 
 __all__ = [
@@ -33,7 +35,7 @@ _YOLACTImageOutput = namedtuple(
 )
 
 
-class YOLACTInputSchema(BaseModel):
+class YOLACTInputSchema(BaseModel, Splittable):
     """
     Input Model for YOLACT
     """
@@ -86,8 +88,34 @@ class YOLACTInputSchema(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
+    def split(self) -> Generator["YOLACTInputSchema", None, None]:
+        """
+        Split a current `YOLACTInputSchema` object with a batch size b, into a
+        generator of b smaller objects with batch size 1, the returned
+        object can be iterated on.
 
-class YOLACTOutputSchema(BaseModel):
+        :return: A Generator of smaller `YOLACTInputSchema` objects each
+            representing an input of batch-size 1
+        """
+        images = self.images
+
+        is_batch_size_1 = isinstance(images, str) or (
+            isinstance(images, numpy.ndarray) and images.ndim == 3
+        )
+        if is_batch_size_1:
+            # case 1: str, numpy.ndarray(3D)
+            yield self
+
+        elif isinstance(images, numpy.ndarray) and images.ndim != 4:
+            raise ValueError(f"Could not breakdown {self} into smaller batches")
+
+        else:
+            # case 2: List[str, Any], numpy.ndarray(4D) -> multiple images of size 1
+            for image in images:
+                yield YOLACTInputSchema(images=image)
+
+
+class YOLACTOutputSchema(BaseModel, Joinable):
     """
     Output Model for YOLACT
     """
@@ -122,3 +150,28 @@ class YOLACTOutputSchema(BaseModel):
     def __iter__(self):
         for index in range(len(self.classes)):
             yield self[index]
+
+    @staticmethod
+    def join(outputs: Iterable["YOLACTOutputSchema"]) -> "YOLACTOutputSchema":
+        """
+        Takes in ab Iterable of `YOLACTOutputSchema` objects and combines
+        them into one object representing a bigger batch size
+
+        :return: A new `YOLACTOutputSchema` object that represents a bigger batch
+        """
+
+        classes = list()
+        scores = list()
+        boxes = list()
+        masks = list()
+
+        for yolact_output in outputs:
+            for image_output in yolact_output:
+                classes.append(image_output.classes)
+                scores.append(image_output.scores)
+                boxes.append(image_output.boxes)
+                masks.append(image_output.masks)
+
+        return YOLACTOutputSchema(
+            classes=classes, scores=scores, boxes=boxes, masks=masks
+        )

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -244,10 +244,14 @@ class YOLOPipeline(Pipeline):
             batch_scores.append(image_output[:, 4].tolist())
             batch_labels.append(image_output[:, 5].tolist())
             if self.class_names is not None:
-                batch_labels[-1] = [
-                    getattr(self.class_names, str(int(label)))
-                    for label in batch_labels[-1]
+                batch_labels_as_strings = [
+                    str(int(label)) for label in batch_labels[-1]
                 ]
+                batch_class_names = [
+                    self.class_names[label_string]
+                    for label_string in batch_labels_as_strings
+                ]
+                batch_labels[-1] = batch_class_names
 
         return YOLOOutput(
             predictions=batch_predictions,

--- a/tests/deepsparse/pipelines/data_helpers.py
+++ b/tests/deepsparse/pipelines/data_helpers.py
@@ -92,5 +92,6 @@ def create_test_inputs(task, batch_size: int = 1):
         "token_classification": token_classification,
         "yolo": computer_vision,
         "image_classification": computer_vision,
+        "yolact": computer_vision,
     }
     return dispatcher[task](batch_size=batch_size)

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -23,10 +23,10 @@ from .data_helpers import create_test_inputs
 
 
 _SUPPORTED_TASKS = [
-    "text_classification",
-    "token_classification",
-    "yolo",
-    "image_classification",
+    # "text_classification",
+    # "token_classification",
+    # "yolo",
+    # "image_classification",
     "yolact",
 ]
 
@@ -79,4 +79,7 @@ def test_dynamic_is_same_as_static(task):
         actual_dict = dynamic_outputs.dict()
 
         # Check that order is maintained
-        assert static_outputs == dynamic_outputs or compare(expected_dict, actual_dict)
+        try:
+            assert static_outputs == dynamic_outputs
+        except Exception:
+            assert compare(expected_dict, actual_dict)

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -39,6 +39,7 @@ _SUPPORTED_TASKS = [
     "token_classification",
     "yolo",
     "image_classification",
+    "yolact",
 ]
 
 _BATCH_SIZES = [
@@ -141,9 +142,10 @@ class TestDynamicBatchPipeline:
         actual_dict = dynamic_batch_outputs.dict()
 
         # Check that order is maintained
-        assert static_batch_outputs == dynamic_batch_outputs or compare(
-            expected_dict, actual_dict
-        )
+        try:
+            assert static_batch_outputs == dynamic_batch_outputs
+        except Exception:
+            assert compare(expected_dict, actual_dict)
 
 
 @pytest.mark.parametrize("task", _SUPPORTED_TASKS)

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -39,8 +39,8 @@ def compare(expected, actual):
     assert type(expected) == type(actual)
 
     if isinstance(expected, (list, float, numpy.ndarray)):
-        expected_np = numpy.asarray(expected)
-        actual_np = numpy.asarray(actual)
+        expected_np = numpy.asarray(expected, dtype=float)
+        actual_np = numpy.asarray(actual, dtype=float)
         assert numpy.allclose(expected_np, actual_np, rtol=1e-3)
     elif isinstance(expected, dict):
         assert list(expected.keys()).sort() == list(actual.keys()).sort()

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -31,9 +31,7 @@ _SUPPORTED_TASKS = [
 ]
 
 _BATCH_SIZES = [
-    1,
     2,
-    10,
 ]
 
 

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -53,7 +53,6 @@ def compare(expected, actual):
     return True
 
 
-
 @pytest.mark.parametrize("task", _SUPPORTED_TASKS)
 def test_dynamic_is_same_as_static(task):
     executor = ThreadPoolExecutor()

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -23,10 +23,10 @@ from .data_helpers import create_test_inputs
 
 
 _SUPPORTED_TASKS = [
-    # "text_classification",
-    # "token_classification",
-    # "yolo",
-    # "image_classification",
+    "text_classification",
+    "token_classification",
+    "yolo",
+    "image_classification",
     "yolact",
 ]
 


### PR DESCRIPTION
This PR is a combination of two different PRs namely #543 + BugFix

Description for BugFix:
This PR fixes a bug in Yolact static Pipeline where inputs for batch_size > 1 were not being processed correctly.

**also includes dynamic batch support, see comment and #843 for details**

The bug was in `process_inputs` function, where (for example sake) a batch of two images was being returned as `[ndarray(1, 3, 550, 550), ndarray(1, 3, 550, 550)]` instead of `[ndarray(2, 3, 550, 550)]`. This PR fixes that.

Tests:
```python
from deepsparse import Pipeline

inputs = {
    "images": ["./test_images/buddy.jpeg", "./test_images/basilica.jpg"]
}

pipe = Pipeline.create(
    task="yolact",
    batch_size=2,
)

print(pipe.use_dynamic_batch())
print(pipe(**inputs))
``` 

Before this PR the above test would fail with the following error:

```bash
pipe(**inputs)
Traceback (most recent call last):
  File "/home/rahul/virtual_environments/deepsparse3.8/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3251, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-8-75ce9cee5455>", line 1, in <module>
    pipe(**inputs)
  File "/home/rahul/projects/deepsparse/src/deepsparse/pipeline.py", line 194, in __call__
    else self._run(*args, **kwargs)  # Blocking call
  File "/home/rahul/projects/deepsparse/src/deepsparse/pipeline.py", line 602, in _run
    pipeline_outputs = self._run_with_static_batch(pipeline_inputs)
  File "/home/rahul/projects/deepsparse/src/deepsparse/pipeline.py", line 631, in _run_with_static_batch
    engine_outputs: List[numpy.ndarray] = self.engine_forward(engine_inputs)
  File "/home/rahul/projects/deepsparse/src/deepsparse/pipeline.py", line 576, in engine_forward
    return self.engine(engine_inputs)
  File "/home/rahul/projects/deepsparse/src/deepsparse/engine.py", line 231, in __call__
    return self.run(inp, val_inp)
  File "/home/rahul/projects/deepsparse/src/deepsparse/engine.py", line 343, in run
    self._validate_inputs(inp)
  File "/home/rahul/projects/deepsparse/src/deepsparse/engine.py", line 528, in _validate_inputs
    raise ValueError(
ValueError: array batch size of 1 must match the batch size the model was instantiated with 2
```

After This PR the test executes successfully:
```bash
False
classes=[[16, 77, 21, 59, 13, 57, 2, 17, 29, 18, 0, 56, 15, 37, 19, 3, 35, 34, 72, 8, 7, 52, 14, 55, 24, 60, 30, 53, 28, 32, 36, 58, 38, 63, 31, 10, 1, 23, 5, 61, 20, 62, 51, 69, 27, 45, 25, 33, 39, 26], [3, 2, 2, 2, 0, 2, 3, 2, 2, 2, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 9, 0, 3, 2, 2, 0, 2, 2, 2, 0, 0, 2, 0, 0, 9, 0, 0, 0, 0, 2, 0, 0, 9, 2, 0, 2, 0, 0]] scores=[[0.9948970675468445, 0.010447071865200996, 0.00890077743679285, 0.007473588455468416, 0.006367410533130169, 0.006367410533130169, 0.004276489373296499, 0.004276489373296499, 0.0040816618129611015, 0.003059301758185029, 0.0027361134998500347, 0.0021885542664676905, 0.0021885542664676905, 0.001400244771502912, 0.0012523205950856209, 0.001001702155917883, 0.0006839483394287527, 0.0005731877172365785, 0.0005460330285131931, 0.0005126352189108729, 0.0004883492365479469, 0.0003500203019939363, 0.0002623482432682067, 0.0002623482432682067, 0.0002623482432682067, 0.0002623482432682067, 0.0002098463592119515, 0.00020028631843160838, 0.00018767788424156606, 0.0001791278482414782, 0.0001501192746218294, 0.0001501192746218294, 0.00013426042278297246, 0.00013426042278297246, 0.00013426042278297246, 0.00012007695477223024, 0.00010739185381680727, 8.590031211497262e-05, 8.183075988199562e-05, 6.870967627037317e-05, 6.870967627037317e-05, 6.545453652506694e-05, 6.450048385886475e-05, 6.14510863670148e-05, 5.245545253274031e-05, 4.9153317377204075e-05, 4.396069925860502e-05, 4.396069925860502e-05, 4.1957922803703696e-05, 3.5163157008355483e-05], [0.9973782300949097, 0.981572151184082, 0.9544133543968201, 0.9382479786872864, 0.91972815990448, 0.8972421884536743, 0.8961465358734131, 0.698532223701477, 0.668432354927063, 0.6123167276382446, 0.5630231499671936, 0.5471418499946594, 0.5235462188720703, 0.5200692415237427, 0.5157318115234375, 0.507266640663147, 0.4959675073623657, 0.491064190864563, 0.4846365451812744, 0.46531757712364197, 0.4641565680503845, 0.41628506779670715, 0.4094214141368866, 0.37814319133758545, 0.37461215257644653, 0.3700478971004486, 0.3686436116695404, 0.35995951294898987, 0.3571665287017822, 0.3500162661075592, 0.3451613485813141, 0.3381393551826477, 0.3345198929309845, 0.334433376789093, 0.32948410511016846, 0.31347453594207764, 0.3131786286830902, 0.31074777245521545, 0.30949902534484863, 0.28215619921684265, 0.2751275300979614, 0.27006763219833374, 0.26596394181251526, 0.2659320831298828, 0.263455867767334, 0.2561451494693756, 0.25296443700790405, 0.25123074650764465, 0.24692052602767944, 0.24385683238506317]] boxes=[[[0.08344998955726624, 0.141443133354187, 0.930778980255127, 1.0150748491287231], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.04495960474014282, 0.11195564270019531, 0.9550403952598572, 1.0313575267791748], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.04495960474014282, 0.11195564270019531, 0.9550403952598572, 1.0313575267791748], [0.04495960474014282, 0.11195564270019531, 0.9550403952598572, 1.0313575267791748], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.10908854007720947, 0.13760367035865784, 0.9478271007537842, 0.9849326610565186], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.10908854007720947, 0.13760367035865784, 0.9478271007537842, 0.9849326610565186], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.04495960474014282, 0.11195564270019531, 0.9550403952598572, 1.0313575267791748], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.04495960474014282, 0.11195564270019531, 0.9550403952598572, 1.0313575267791748], [0.10908854007720947, 0.13760367035865784, 0.9478271007537842, 0.9849326610565186], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.10908854007720947, 0.13760367035865784, 0.9478271007537842, 0.9849326610565186], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.10908854007720947, 0.13760367035865784, 0.9478271007537842, 0.9849326610565186], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.04495960474014282, 0.11195564270019531, 0.9550403952598572, 1.0313575267791748], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.04495960474014282, 0.11195564270019531, 0.9550403952598572, 1.0313575267791748], [0.05594366788864136, 0.13958361744880676, 0.9566946625709534, 0.9955910444259644], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.10908854007720947, 0.13760367035865784, 0.9478271007537842, 0.9849326610565186], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558], [0.10908854007720947, 0.13760367035865784, 0.9478271007537842, 0.9849326610565186], [0.031787216663360596, 0.14179620146751404, 0.9606056809425354, 1.0066698789596558]], [[0.26712948083877563, 0.7150249481201172, 0.5460811257362366, 0.9669517874717712], [0.5711366534233093, 0.6084333658218384, 0.6138927340507507, 0.6466557383537292], [0.3257606327533722, 0.6105538606643677, 0.37872475385665894, 0.6893625855445862], [0.4896131753921509, 0.6069713830947876, 0.5464867353439331, 0.6467838883399963], [0.35904860496520996, 0.6117796897888184, 0.46717020869255066, 0.8935561180114746], [0.6441465020179749, 0.6012173891067505, 0.6743795871734619, 0.635382890701294], [0.47528383135795593, 0.6724684238433838, 0.6051722764968872, 0.852432131767273], [0.7994635105133057, 0.6108871102333069, 0.8413618206977844, 0.6758239269256592], [0.6221714019775391, 0.603965699672699, 0.6408991813659668, 0.633892297744751], [0.636343240737915, 0.6022033095359802, 0.6541407704353333, 0.6353402137756348], [0.8139185309410095, 0.5620378255844116, 0.8228193521499634, 0.5819463729858398], [0.23280742764472961, 0.6016680002212524, 0.2507892847061157, 0.6925505995750427], [0.21647825837135315, 0.6013690829277039, 0.23679901659488678, 0.6950728893280029], [0.6719380021095276, 0.6144078969955444, 0.7082700729370117, 0.7907006740570068], [0.14622749388217926, 0.6079120635986328, 0.15843474864959717, 0.6708793640136719], [0.8269199728965759, 0.6035739183425903, 0.8952666521072388, 0.7644366025924683], [0.16595205664634705, 0.6069983839988708, 0.19190582633018494, 0.7507708668708801], [0.07043392211198807, 0.637434720993042, 0.11066340655088425, 0.7856872081756592], [0.47241905331611633, 0.6262479424476624, 0.5373632907867432, 0.7388418316841125], [0.2035549134016037, 0.6011467576026917, 0.224294051527977, 0.6948505640029907], [0.6490519046783447, 0.6102777719497681, 0.669788658618927, 0.6424170136451721], [0.01665392890572548, 0.6269034147262573, 0.04946238175034523, 0.7372131943702698], [0.8288829326629639, 0.561349630355835, 0.8377837538719177, 0.5829491019248962], [0.4245006740093231, 0.5922475457191467, 0.4334014654159546, 0.615681529045105], [0.46955832839012146, 0.6390657424926758, 0.5662040710449219, 0.7785415649414062], [0.5318778157234192, 0.6164683103561401, 0.5509911775588989, 0.6437724232673645], [0.3965299427509308, 0.605435848236084, 0.4216965436935425, 0.6277058124542236], [0.7657262086868286, 0.5984765291213989, 0.7894002199172974, 0.6462985277175903], [0.3785918056964874, 0.6167080998420715, 0.39675575494766235, 0.645733654499054], [0.32747748494148254, 0.6057168841362, 0.36342883110046387, 0.6252238154411316], [0.611756443977356, 0.6023623943328857, 0.6242150068283081, 0.6310936808586121], [0.4972788989543915, 0.5898483991622925, 0.506179690361023, 0.6067618727684021], [0.758902907371521, 0.6108144521713257, 0.7927336692810059, 0.7907369136810303], [0.57450270652771, 0.6105339527130127, 0.606641948223114, 0.6323546171188354], [0.23519547283649445, 0.5997470617294312, 0.2477816641330719, 0.6516308188438416], [0.7471389174461365, 0.6012120246887207, 0.7585057616233826, 0.6379035711288452], [0.020121466368436813, 0.5330281257629395, 0.04478318989276886, 0.5953641533851624], [0.14433182775974274, 0.6152282953262329, 0.16268391907215118, 0.7222046852111816], [0.3164190948009491, 0.5930371880531311, 0.32531988620758057, 0.6297287344932556], [0.27392497658729553, 0.5970649123191833, 0.28814825415611267, 0.6420506834983826], [0.7311874032020569, 0.6113169193267822, 0.7432708740234375, 0.6511248350143433], [0.4465712606906891, 0.609340250492096, 0.47024527192115784, 0.6411536335945129], [0.10995471477508545, 0.5963200330734253, 0.14145278930664062, 0.7343502044677734], [0.7209069728851318, 0.6166748404502869, 0.7611364722251892, 0.7679796814918518], [0.8101159930229187, 0.5599222779273987, 0.8190168142318726, 0.5831186771392822], [0.647022545337677, 0.5965484976768494, 0.6724469065666199, 0.612952709197998], [0.8060285449028015, 0.5923467874526978, 0.8149293661117554, 0.6096084713935852], [0.6623417735099792, 0.5995677709579468, 0.6801393032073975, 0.6310586333274841], [0.611756443977356, 0.6023623943328857, 0.6242150068283081, 0.6310936808586121], [0.7400510907173157, 0.6327669024467468, 0.7696810364723206, 0.7465009093284607]]] masks=[array([[[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       ...,

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]]], dtype=float32), array([[[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       ...,

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]],

       [[0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        ...,
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.],
        [0., 0., 0., ..., 0., 0., 0.]]], dtype=float32)]

Process finished with exit code 0
```

Description of Dynamic batch support: #543 


This PR also reduces the number of model compilations needed for `test_dynamic_batch_pipeline.py` by an order of 2
