### PR TITLE
Add: Dynamic batch support for YOLACT Pipelines

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,5 +5,7 @@ FROM python:3.8-slim-bullseye
 RUN python3.8 -m venv /venv
 ENV PATH="venv/bin:$PATH"
 
+# Setup DeepSparse
+RUN pip3 install --no-cache-dir --upgrade deepsparse[server]
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,5 @@ FROM python:3.8-slim-bullseye
 RUN python3.8 -m venv /venv
 ENV PATH="venv/bin:$PATH"
 
-# Setup DeepSparse
-RUN pip3 install --no-cache-dir --upgrade deepsparse[server]
 
 

--- a/src/deepsparse/yolact/pipelines.py
+++ b/src/deepsparse/yolact/pipelines.py
@@ -33,7 +33,6 @@ except ModuleNotFoundError as cv2_import_error:
     cv2 = None
     cv2_error = cv2_import_error
 
-
 __all__ = ["YOLACTPipeline"]
 
 
@@ -151,9 +150,11 @@ class YOLACTPipeline(Pipeline):
             max_num_detections=inputs.max_num_detections,
         )
 
-        return [
+        preprocessed_images = [
             preprocess_array(array, self.image_size) for array in images
-        ], postprocessing_kwargs
+        ]
+        image_batch = numpy.concatenate(preprocessed_images, axis=0)
+        return [image_batch], postprocessing_kwargs
 
     def process_engine_outputs(
         self, engine_outputs: List[numpy.ndarray], **kwargs

--- a/src/deepsparse/yolact/schemas.py
+++ b/src/deepsparse/yolact/schemas.py
@@ -17,10 +17,12 @@ Input/Output Schemas for Image Segmentation with YOLACT
 """
 
 from collections import namedtuple
-from typing import List, Optional, Union
+from typing import Generator, Iterable, List, Optional, Union
 
 import numpy
 from pydantic import BaseModel, Field
+
+from deepsparse.pipelines import Joinable, Splittable
 
 
 __all__ = [
@@ -33,7 +35,7 @@ _YOLACTImageOutput = namedtuple(
 )
 
 
-class YOLACTInputSchema(BaseModel):
+class YOLACTInputSchema(BaseModel, Splittable):
     """
     Input Model for YOLACT
     """
@@ -86,8 +88,34 @@ class YOLACTInputSchema(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
+    def split(self) -> Generator["YOLACTInputSchema", None, None]:
+        """
+        Split a current `YOLACTInputSchema` object with a batch size b, into a
+        generator of b smaller objects with batch size 1, the returned
+        object can be iterated on.
 
-class YOLACTOutputSchema(BaseModel):
+        :return: A Generator of smaller `YOLACTInputSchema` objects each
+            representing an input of batch-size 1
+        """
+        images = self.images
+
+        is_batch_size_1 = isinstance(images, str) or (
+            isinstance(images, numpy.ndarray) and images.ndim == 3
+        )
+        if is_batch_size_1:
+            # case 1: str, numpy.ndarray(3D)
+            yield self
+
+        elif isinstance(images, numpy.ndarray) and images.ndim != 4:
+            raise ValueError(f"Could not breakdown {self} into smaller batches")
+
+        else:
+            # case 2: List[str, Any], numpy.ndarray(4D) -> multiple images of size 1
+            for image in images:
+                yield YOLACTInputSchema(images=image)
+
+
+class YOLACTOutputSchema(BaseModel, Joinable):
     """
     Output Model for YOLACT
     """
@@ -122,3 +150,28 @@ class YOLACTOutputSchema(BaseModel):
     def __iter__(self):
         for index in range(len(self.classes)):
             yield self[index]
+
+    @staticmethod
+    def join(outputs: Iterable["YOLACTOutputSchema"]) -> "YOLACTOutputSchema":
+        """
+        Takes in ab Iterable of `YOLACTOutputSchema` objects and combines
+        them into one object representing a bigger batch size
+
+        :return: A new `YOLACTOutputSchema` object that represents a bigger batch
+        """
+
+        classes = list()
+        scores = list()
+        boxes = list()
+        masks = list()
+
+        for yolact_output in outputs:
+            for image_output in yolact_output:
+                classes.append(image_output.classes)
+                scores.append(image_output.scores)
+                boxes.append(image_output.boxes)
+                masks.append(image_output.masks)
+
+        return YOLACTOutputSchema(
+            classes=classes, scores=scores, boxes=boxes, masks=masks
+        )

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -244,10 +244,14 @@ class YOLOPipeline(Pipeline):
             batch_scores.append(image_output[:, 4].tolist())
             batch_labels.append(image_output[:, 5].tolist())
             if self.class_names is not None:
-                batch_labels[-1] = [
-                    getattr(self.class_names, str(int(label)))
-                    for label in batch_labels[-1]
+                batch_labels_as_strings = [
+                    str(int(label)) for label in batch_labels[-1]
                 ]
+                batch_class_names = [
+                    self.class_names[label_string]
+                    for label_string in batch_labels_as_strings
+                ]
+                batch_labels[-1] = batch_class_names
 
         return YOLOOutput(
             predictions=batch_predictions,

--- a/tests/deepsparse/pipelines/data_helpers.py
+++ b/tests/deepsparse/pipelines/data_helpers.py
@@ -92,5 +92,6 @@ def create_test_inputs(task, batch_size: int = 1):
         "token_classification": token_classification,
         "yolo": computer_vision,
         "image_classification": computer_vision,
+        "yolact": computer_vision,
     }
     return dispatcher[task](batch_size=batch_size)

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -39,6 +39,7 @@ _SUPPORTED_TASKS = [
     "token_classification",
     "yolo",
     "image_classification",
+    "yolact",
 ]
 
 _BATCH_SIZES = [
@@ -141,9 +142,10 @@ class TestDynamicBatchPipeline:
         actual_dict = dynamic_batch_outputs.dict()
 
         # Check that order is maintained
-        assert static_batch_outputs == dynamic_batch_outputs or compare(
-            expected_dict, actual_dict
-        )
+        try:
+            assert static_batch_outputs == dynamic_batch_outputs
+        except Exception:
+            assert compare(expected_dict, actual_dict)
 
 
 @pytest.mark.parametrize("task", _SUPPORTED_TASKS)


### PR DESCRIPTION
This PR adds dynamic batch support to Yolact Pipelines, before this PR a YOLACT pipeline could only operate on a fixed static batch size, with this PR it can now accept inputs with different batch sizes.

Tests:
Automated test for YOLACT pipeline added. The tests were green locally.

Note: Right now the base branch is `bugfix-yolact-static-pipeline` to make the review process easier. Also because this PR relies on changes from #542. The base branch should be changed to `yolact-fixes` before landing

- [ ] Change base branch to `yolact-fixes` before landing