### PR TITLE
parse messy benchmark 'engine' output

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -414,9 +414,9 @@ def benchmark_model(
 def _parse_export_dict_engine_key(payload: Dict) -> Dict:
     """Extract metadata from str(Model)"""
 
-    formatted_metadata = "engine: " + payload.get("engine", "").replace("\t", "").replace(
-        ":", "", 1
-    )
+    formatted_metadata = "engine: " + payload.get("engine", "").replace(
+        "\t", ""
+    ).replace(":", "", 1)
     return {**payload, **yaml.load(formatted_metadata, Loader=Loader)}
 
 

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -95,10 +95,9 @@ import argparse
 import json
 import logging
 import os
-import subprocess
 from typing import Dict
 
-from deepsparse import Scheduler, __version__, compile_model
+from deepsparse import Scheduler, __version__, compile_model, generated_version
 from deepsparse.benchmark.ort_engine import ORTEngine
 from deepsparse.benchmark.stream_benchmark import model_stream_benchmark
 from deepsparse.cpu import cpu_architecture
@@ -381,7 +380,7 @@ def benchmark_model(
     export_dict = {
         "engine": str(model),
         "version": __version__,
-        "commit": get_latest_commit_sha_for_path(),
+        "commit": generated_version.revision,
         "orig_model_path": orig_model_path,
         "model_path": model_path,
         "batch_size": batch_size,
@@ -413,23 +412,6 @@ def _parse_export_dict_engine_key(payload):
     for i in range(2, len(engine_split) - 1, 2):
         payload[engine_split[i]] = engine_split[i + 1].strip()
     return payload
-
-
-def get_latest_commit_sha_for_path(
-    relative_path: str = "",
-    repo_path: str = os.getcwd(),
-) -> str:
-    """Use git log to fetch the most recent commit sha that impacted the given
-    relative path."""
-    args = ["git", "log", "--pretty=format:%H", "--max-count=1"]
-    if relative_path:
-        args += [
-            "--",
-            relative_path,
-        ]
-
-    commit_sha = subprocess.check_output(args, cwd=repo_path).decode("utf-8")
-    return commit_sha
 
 
 def main():

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -421,17 +421,13 @@ def get_latest_commit_sha_for_path(
 ) -> str:
     """Use git log to fetch the most recent commit sha that impacted the given
     relative path."""
+    args = ["git", "log", "--pretty=format:%H", "--max-count=1"]
     if relative_path:
-        args = [
-            "git",
-            "log",
-            "--pretty=format:%H",
-            "--max-count=1",
+        args += [
             "--",
             relative_path,
         ]
-    else:
-        args = ["git", "log", "--pretty=format:%H", "--max-count=1"]
+
     commit_sha = subprocess.check_output(args, cwd=repo_path).decode("utf-8")
     return commit_sha
 

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -119,7 +119,7 @@ from deepsparse.utils import (
 )
 
 
-__all__ = ["benchmark_model"]
+__all__ = ["benchmark_model", "parse_export_dict_engine_key"]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -400,7 +400,7 @@ def benchmark_model(
         "benchmark_result": benchmark_result,
     }
 
-    parsed_export_dict = _parse_export_dict_engine_key(export_dict)
+    parsed_export_dict = parse_export_dict_engine_key(export_dict)
 
     # Export results
     if export_path:
@@ -411,7 +411,7 @@ def benchmark_model(
     return parsed_export_dict
 
 
-def _parse_export_dict_engine_key(payload: Dict) -> Dict:
+def parse_export_dict_engine_key(payload: Dict) -> Dict:
     """Extract metadata from str(Model)"""
 
     formatted_metadata = "engine: " + payload.get("engine", "").replace(

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -95,15 +95,6 @@ import argparse
 import json
 import logging
 import os
-
-import yaml
-
-
-try:
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Loader
-
 from typing import Dict
 
 from deepsparse import Scheduler, compile_model
@@ -119,7 +110,7 @@ from deepsparse.utils import (
 )
 
 
-__all__ = ["benchmark_model", "parse_export_dict_engine_key"]
+__all__ = ["benchmark_model"]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -387,7 +378,7 @@ def benchmark_model(
     )
 
     export_dict = {
-        "engine": str(model),
+        "engine": engine,
         "orig_model_path": orig_model_path,
         "model_path": model_path,
         "batch_size": batch_size,
@@ -399,8 +390,7 @@ def benchmark_model(
         "num_streams": num_streams,
         "benchmark_result": benchmark_result,
     }
-
-    parsed_export_dict = parse_export_dict_engine_key(export_dict)
+    parsed_export_dict = {**model._properties_dict(), **export_dict}
 
     # Export results
     if export_path:
@@ -409,15 +399,6 @@ def benchmark_model(
             json.dump(parsed_export_dict, out, indent=2)
 
     return parsed_export_dict
-
-
-def parse_export_dict_engine_key(payload: Dict) -> Dict:
-    """Extract metadata from str(Model)"""
-
-    formatted_metadata = "engine: " + payload.get("engine", "").replace(
-        "\t", ""
-    ).replace(":", "", 1)
-    return {**payload, **yaml.load(formatted_metadata, Loader=Loader)}
 
 
 def main():

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -392,13 +392,25 @@ def benchmark_model(
         "benchmark_result": benchmark_result,
     }
 
+    parsed_export_dict = _parse_export_dict_engine_key(export_dict)
+
     # Export results
     if export_path:
         _LOGGER.info("Saving benchmark results to JSON file at {}".format(export_path))
         with open(export_path, "w") as out:
-            json.dump(export_dict, out, indent=2)
+            json.dump(parsed_export_dict, out, indent=2)
 
-    return export_dict
+    return parsed_export_dict
+
+
+def _parse_export_dict_engine_key(payload):
+
+    engine_split = payload["engine"].replace("\n\t", ":").split(":")
+    engine = engine_split[0]
+    payload["engine"] = engine
+    for i in range(2, len(engine_split) - 1, 2):
+        payload[engine_split[i]] = engine_split[i + 1].strip()
+    return payload
 
 
 def main():

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -95,6 +95,15 @@ import argparse
 import json
 import logging
 import os
+
+import yaml
+
+
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
+
 from typing import Dict
 
 from deepsparse import Scheduler, compile_model
@@ -379,8 +388,6 @@ def benchmark_model(
 
     export_dict = {
         "engine": str(model),
-        # "version": __version__,
-        # "commit": generated_version.revision,
         "orig_model_path": orig_model_path,
         "model_path": model_path,
         "batch_size": batch_size,
@@ -404,14 +411,13 @@ def benchmark_model(
     return parsed_export_dict
 
 
-def _parse_export_dict_engine_key(payload):
+def _parse_export_dict_engine_key(payload: Dict) -> Dict:
     """Extract metadata from str(Model)"""
-    engine_split = payload["engine"].replace("\n\t", ":").split(":")
-    engine = engine_split[0]
-    payload["engine"] = engine
-    for i in range(2, len(engine_split) - 1, 2):
-        payload[engine_split[i]] = engine_split[i + 1].strip()
-    return payload
+
+    formatted_metadata = "engine: " + payload["engine"].replace("\t", "").replace(
+        ":", "", 1
+    )
+    return {**payload, **yaml.load(formatted_metadata, Loader=Loader)}
 
 
 def main():

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -414,7 +414,7 @@ def benchmark_model(
 def _parse_export_dict_engine_key(payload: Dict) -> Dict:
     """Extract metadata from str(Model)"""
 
-    formatted_metadata = "engine: " + payload["engine"].replace("\t", "").replace(
+    formatted_metadata = "engine: " + payload.get("engine", "").replace("\t", "").replace(
         ":", "", 1
     )
     return {**payload, **yaml.load(formatted_metadata, Loader=Loader)}

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -97,7 +97,7 @@ import logging
 import os
 from typing import Dict
 
-from deepsparse import Scheduler, __version__, compile_model, generated_version
+from deepsparse import Scheduler, compile_model
 from deepsparse.benchmark.ort_engine import ORTEngine
 from deepsparse.benchmark.stream_benchmark import model_stream_benchmark
 from deepsparse.cpu import cpu_architecture
@@ -379,8 +379,8 @@ def benchmark_model(
 
     export_dict = {
         "engine": str(model),
-        "version": __version__,
-        "commit": generated_version.revision,
+        # "version": __version__,
+        # "commit": generated_version.revision,
         "orig_model_path": orig_model_path,
         "model_path": model_path,
         "batch_size": batch_size,

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -24,8 +24,10 @@ from typing import Dict, Iterable, List, Optional, Tuple, Union
 import numpy
 from tqdm.auto import tqdm
 
+from deepsparse import generated_version
 from deepsparse.benchmark import BenchmarkResults
 from deepsparse.utils import model_to_path, override_onnx_input_shapes
+from deepsparse.version import __version__
 
 
 try:
@@ -540,6 +542,8 @@ class Engine(object):
 
     def _properties_dict(self) -> Dict:
         return {
+            "version": __version__,
+            "commit": generated_version.revision,
             "onnx_file_path": self.model_path,
             "batch_size": self.batch_size,
             "num_cores": self.num_cores,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -15,7 +15,6 @@
 from typing import Dict, List
 
 import pytest
-from src.deepsparse.benchmark.benchmark_model import parse_export_dict_engine_key
 from tests.helpers import predownload_stub, run_command
 
 
@@ -131,43 +130,3 @@ def test_benchmark_local(model_stub: str):
     assert res.returncode == 0
     assert "error" not in res.stdout.lower()
     assert "fail" not in res.stdout.lower()
-
-
-@pytest.mark.parametrize(
-    ("engine_key", "expected"),
-    [
-        (
-            "deepsparse.engine.Engine:\n\tversion: 1.1.0.20220805\n\tcommit: 8f2ea328"
-            "\n\tonnx_file_path: /home/george/.cache/sparsezoo/61686faf-c724-42f9"
-            "-b9ae-749266e3f669/model.onnx\n\tbatch_size: 1\n\tnum_cores: 18\n\t"
-            "num_streams: 9\n\tscheduler: Scheduler.multi_stream\n\t"
-            "cpu_avx_type: avx512"
-            "\n\tcpu_vnni: False",
-            {
-                "engine": "deepsparse.engine.Engine",
-                "version": "1.1.0.20220805",
-                "commit": "8f2ea328",
-                "onnx_file_path": (
-                    "/home/george/.cache/sparsezoo/"
-                    "61686faf-c724-42f9-b9ae-749266e3f669/model.onnx"
-                ),
-                "batch_size": 1,
-                "num_cores": 18,
-                "num_streams": 9,
-                "scheduler": "Scheduler.multi_stream",
-                "cpu_avx_type": "avx512",
-                "cpu_vnni": False,
-                "persistent_key": "this entry should be persistent",
-            },
-        ),
-    ],
-)
-def test_parse_export_dict_engine_key(engine_key: str, expected: Dict):
-    input_payload = {
-        "engine": engine_key,
-        "persistent_key": "this entry should be persistent",
-    }
-    response = parse_export_dict_engine_key(input_payload)
-    assert (
-        expected == response
-    ), f"Error in parsing str(model). Expected {expected}\ngot {response}"

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -15,6 +15,7 @@
 from typing import Dict, List
 
 import pytest
+from src.deepsparse.benchmark.benchmark_model import parse_export_dict_engine_key
 from tests.helpers import predownload_stub, run_command
 
 
@@ -130,3 +131,43 @@ def test_benchmark_local(model_stub: str):
     assert res.returncode == 0
     assert "error" not in res.stdout.lower()
     assert "fail" not in res.stdout.lower()
+
+
+@pytest.mark.parametrize(
+    ("engine_key", "expected"),
+    [
+        (
+            "deepsparse.engine.Engine:\n\tversion: 1.1.0.20220805\n\tcommit: 8f2ea328"
+            "\n\tonnx_file_path: /home/george/.cache/sparsezoo/61686faf-c724-42f9"
+            "-b9ae-749266e3f669/model.onnx\n\tbatch_size: 1\n\tnum_cores: 18\n\t"
+            "num_streams: 9\n\tscheduler: Scheduler.multi_stream\n\t"
+            "cpu_avx_type: avx512"
+            "\n\tcpu_vnni: False",
+            {
+                "engine": "deepsparse.engine.Engine",
+                "version": "1.1.0.20220805",
+                "commit": "8f2ea328",
+                "onnx_file_path": (
+                    "/home/george/.cache/sparsezoo/"
+                    "61686faf-c724-42f9-b9ae-749266e3f669/model.onnx"
+                ),
+                "batch_size": 1,
+                "num_cores": 18,
+                "num_streams": 9,
+                "scheduler": "Scheduler.multi_stream",
+                "cpu_avx_type": "avx512",
+                "cpu_vnni": False,
+                "persistent_key": "this entry should be persistent",
+            },
+        ),
+    ],
+)
+def test_parse_export_dict_engine_key(engine_key: str, expected: Dict):
+    input_payload = {
+        "engine": engine_key,
+        "persistent_key": "this entry should be persistent",
+    }
+    response = parse_export_dict_engine_key(input_payload)
+    assert (
+        expected == response
+    ), f"Error in parsing str(model). Expected {expected}\ngot {response}"


### PR DESCRIPTION
Parse messy output from deepsparse.benchmark
Also added commit sha info

To run: `deepsparse.benchmark zoo:nlp/text_classification/bert-base/pytorch/huggingface/sst2/base-none -x benchmark.json`


Before:
https://github.com/neuralmagic/deepsparse/blob/main/src/deepsparse/benchmark/img/json_output.png

After:
<img width="620" alt="Screen Shot 2022-08-26 at 9 22 36 AM" src="https://user-images.githubusercontent.com/28371594/186914186-d3a10fb3-0066-4aed-be4f-5d8780d88941.png">



