### PR TITLE
Add warning that elastic scheduler is deprecated

### DIFF
--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -18,9 +18,9 @@ Code related to interfacing with a Neural Network in the DeepSparse Engine using
 
 import logging
 import time
+import warnings
 from enum import Enum
 from typing import Dict, Iterable, List, Optional, Tuple, Union
-import warnings
 
 import numpy
 from tqdm.auto import tqdm

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -140,6 +140,11 @@ def _validate_scheduler(scheduler: Union[None, str, Scheduler]) -> Scheduler:
             "unsupported type for scheduler: {} ({})".format(scheduler, type(scheduler))
         )
 
+    if scheduler == Scheduler.elastic:
+        _LOGGER.warn(
+            "Scheduler.elastic is an alias for Scheduler.multistream - will be deprecated in 1.3"
+        )
+
     return scheduler
 
 

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -20,6 +20,7 @@ import logging
 import time
 from enum import Enum
 from typing import Dict, Iterable, List, Optional, Tuple, Union
+import warnings
 
 import numpy
 from tqdm.auto import tqdm
@@ -141,8 +142,10 @@ def _validate_scheduler(scheduler: Union[None, str, Scheduler]) -> Scheduler:
         )
 
     if scheduler == Scheduler.elastic:
-        _LOGGER.warn(
-            "Scheduler.elastic is an alias for Scheduler.multistream - will be deprecated in 1.3"
+        warnings.warn(
+            "Scheduler.elastic is an alias for Scheduler.multistream",
+            DeprecationWarning,
+            stacklevel=2,
         )
 
     return scheduler

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -144,7 +144,7 @@ def _validate_scheduler(scheduler: Union[None, str, Scheduler]) -> Scheduler:
     if scheduler == Scheduler.elastic:
         warnings.warn(
             "Scheduler.elastic is an alias for Scheduler.multistream",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 


### PR DESCRIPTION
```
deepsparse.benchmark zoo:cv/classification/efficientnet-b0/pytorch/sparseml/imagenet/base-none -s elastic
...
2022-08-09 13:51:32 deepsparse.engine WARNING  Scheduler.elastic is an alias for Scheduler.multistream - will be deprecated in 1.3
```