### PR TITLE
zscp: argument checks for hypothesis template and nli indexes

### DIFF
--- a/src/deepsparse/transformers/pipelines/mnli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/mnli_text_classification.py
@@ -125,6 +125,15 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
                 "if no static labels are provided then batch_size must be set to 1"
             )
 
+        if self._config.hypothesis_template is not None and self._config.hypothesis_template.format("sample_label") == self._config.hypothesis_template:
+            raise ValueError(
+                "The provided hypothesis_template "
+                f"`{self._config.hypothesis_template}` was not able to be formatted. "
+                "Make sure the passed template includes formatting syntax such "
+                "as {} where the label should go."
+            )
+
+
         kwargs.update({"batch_size": batch_size})
         super().__init__(model_path=model_path, **kwargs)
 
@@ -191,7 +200,7 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
         # check for invalid hypothesis template
         if hypothesis_template.format(labels[0]) == hypothesis_template:
             raise ValueError(
-                f"The provided hypothesis_template {hypothesis_template} was not "
+                f"The provided hypothesis_template `{hypothesis_template}` was not "
                 "able to be formatted with the target labels. Make sure the "
                 "passed template includes formatting syntax such as {} where "
                 "the label should go."

--- a/src/deepsparse/transformers/pipelines/mnli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/mnli_text_classification.py
@@ -125,14 +125,17 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
                 "if no static labels are provided then batch_size must be set to 1"
             )
 
-        if self._config.hypothesis_template is not None and self._config.hypothesis_template.format("sample_label") == self._config.hypothesis_template:
+        if (
+            self._config.hypothesis_template is not None
+            and self._config.hypothesis_template.format("sample_label")
+            == self._config.hypothesis_template
+        ):
             raise ValueError(
                 "The provided hypothesis_template "
                 f"`{self._config.hypothesis_template}` was not able to be formatted. "
                 "Make sure the passed template includes formatting syntax such "
                 "as {} where the label should go."
             )
-
 
         kwargs.update({"batch_size": batch_size})
         super().__init__(model_path=model_path, **kwargs)

--- a/src/deepsparse/transformers/pipelines/mnli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/mnli_text_classification.py
@@ -137,6 +137,15 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
                 "as {} where the label should go."
             )
 
+        if self._config.entailment_index == self._config.contradiction_index:
+            raise ValueError("entailment_index must differ from contradiction_index")
+
+        if self._config.entailment_index > 2:
+            raise ValueError("entailment_index must be less than or equal to 2")
+
+        if self._config.contradiction_index > 2:
+            raise ValueError("contradiction_index must be less than or equal to 2")
+
         kwargs.update({"batch_size": batch_size})
         super().__init__(model_path=model_path, **kwargs)
 


### PR DESCRIPTION
These were issues that were brought up in QA. Both of these argument checks cause errors during run time, but can be checked at pipeline instantiation time.