### PR TITLE
Make artifact download use src/deepsparse/version.py as default

### DIFF
--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -53,10 +53,16 @@ def get_release_and_version(package_path: str) -> Tuple[bool, str, str, str, str
     """
     Load version and release info from deepsparse package
     """
+    # deepsparse/src/deepsparse/version.py always exists, default source of truth
+    version_path = os.path.join(package_path, "version.py")
 
-    version_path = os.path.join(package_path, "generated_version.py")
-    if not os.path.exists(version_path):
-        version_path = os.path.join(package_path, "version.py")
+    # If deepsparse/engine-version.txt exists, use the generated_version
+    engine_version_path = os.path.abspath(
+        os.path.join(package_path, os.pardir, os.pardir, "engine-version.txt")
+    )
+    gen_version_path = os.path.join(package_path, "generated_version.py")
+    if os.path.exists(engine_version_path) and os.path.exists(gen_version_path):
+        version_path = gen_version_path
 
     # exec() cannot set local variables so need to manually
     locals_dict = {}

--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -30,7 +30,7 @@ __all__ = [
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Benchmark ONNX models in the DeepSparse Engine"
+        description="Download binaries for the engine"
     )
 
     parser.add_argument(

--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -29,9 +29,7 @@ __all__ = [
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Download binaries for the engine"
-    )
+    parser = argparse.ArgumentParser(description="Download binaries for the engine")
 
     parser.add_argument(
         "package_path",


### PR DESCRIPTION
It was possible to be stuck in a loop because a previously downloaded generated_version.py would be used as the source of truth over the version.py that gets updated within deepsparse