### PR TITLE
[cherry-pick] Bump max `torchvision` version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ _onnxruntime_deps = [
     "onnxruntime>=1.7.0",
 ]
 _yolo_integration_deps = [
-    "torchvision>=0.3.0,<=0.10.1",
+    "torchvision>=0.3.0,<=0.12.0",
     "opencv-python",
 ]
 

--- a/src/deepsparse/image_classification/__init__.py
+++ b/src/deepsparse/image_classification/__init__.py
@@ -25,7 +25,7 @@ _Dependency = namedtuple("_Dependency", ["name", "version", "necessary"])
 
 def _auto_install_dependencies():
     dependencies = [
-        _Dependency(name="torchvision", version=">=0.3.0,<=0.10.1", necessary=True),
+        _Dependency(name="torchvision", version=">=0.3.0,<=0.12.0", necessary=True),
         _Dependency(name="click", version="<8.1", necessary=False),
     ]
 

--- a/src/deepsparse/yolact/__init__.py
+++ b/src/deepsparse/yolact/__init__.py
@@ -27,7 +27,7 @@ def _auto_install_dependencies():
     dependencies = [
         _Dependency(
             name="torchvision",
-            version=">=0.3.0,<=0.10.1",
+            version=">=0.3.0,<=0.12.0",
             necessary=True,
             import_name=None,
         ),


### PR DESCRIPTION
Bump max `torchvision` version from `0.10.1` to `0.12.0`, implicitly increases the `torch` version to `1.11.0`

This has been done to add pre-liminary `python3.10` support