### PR TITLE
Revert Haystack to Auto Install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,6 @@ _PACKAGE_NAME = "deepsparse" if is_release else "deepsparse-nightly"
 binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
 
-def _parse_requirements_file(file_path):
-    with open(file_path, "r") as requirements_file:
-        lines = requirements_file.read().splitlines()
-
-    return [line for line in lines if len(line) > 0 and line[0] != "#"]
-
-
 _deps = [
     "numpy>=1.16.3",
     "onnx>=1.5.0,<=1.12.0",
@@ -99,22 +92,6 @@ _yolo_integration_deps = [
     "torchvision>=0.3.0,<=0.12.0",
     "opencv-python",
 ]
-
-# haystack dependencies are installed from a requirements file to avoid
-# conflicting versions with NM's deepsparse/transformers
-_haystack_requirements_file_path = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
-    "src",
-    "deepsparse",
-    "transformers",
-    "haystack",
-    "haystack_reqs.txt",
-)
-_haystack_integration_deps = _parse_requirements_file(
-    _haystack_requirements_file_path
-) + [
-    "farm-haystack[all]==1.4.0"
-]  # install farm-haystack last
 
 
 def _check_supported_system():
@@ -219,7 +196,6 @@ def _setup_extras() -> Dict:
         "server": _server_deps,
         "onnxruntime": _onnxruntime_deps,
         "yolo": _yolo_integration_deps,
-        "haystack": _haystack_integration_deps,
     }
 
 

--- a/src/deepsparse/transformers/haystack/__init__.py
+++ b/src/deepsparse/transformers/haystack/__init__.py
@@ -28,14 +28,7 @@ import deepsparse as _deepsparse
 
 _HAYSTACK_PREFERRED_VERSION = "1.4.0"
 _HAYSTACK_EXTRAS = "[all]"
-_HAYSTACK_REQS_PATH = _os.path.join(
-    *[
-        f"{_deepsparse.__path__[0]}",
-        "transformers",
-        "haystack",
-        "haystack_reqs.txt",
-    ]
-)
+_HAYSTACK_REQS_PATH = _os.path.join(_os.path.dirname(__file__), "haystack_reqs.txt")
 
 
 # check haystack installation

--- a/src/deepsparse/transformers/haystack/__init__.py
+++ b/src/deepsparse/transformers/haystack/__init__.py
@@ -19,6 +19,112 @@ deepset-ai/haystack
 # flake8: noqa
 # isort: skip_file
 
+
+import logging as _logging
+import os as _os
+
+import deepsparse as _deepsparse
+
+
+_HAYSTACK_PREFERRED_VERSION = "1.4.0"
+_HAYSTACK_EXTRAS = "[all]"
+_HAYSTACK_REQS_PATH = _os.path.join(
+    *[
+        f"{_deepsparse.__path__[0]}",
+        "transformers",
+        "haystack",
+        "haystack_reqs.txt",
+    ]
+)
+
+
+# check haystack installation
+try:
+    import haystack as _haystack
+
+    if _haystack.__version__ != _HAYSTACK_PREFERRED_VERSION:
+        raise ValueError(
+            f"Deepsparse requires farm-haystack=={_HAYSTACK_PREFERRED_VERSION}, "
+            f"but found {_haystack.__version__}"
+        )
+    _haystack_import_error = None
+except Exception as _haystack_import_err:
+    _haystack_import_error = _haystack_import_err
+
+_LOGGER = _logging.getLogger(__name__)
+
+
+def _install_haystack_and_deps():
+    import subprocess as _subprocess
+    import sys as _sys
+
+    try:
+        _subprocess.check_call(
+            [
+                _sys.executable,
+                "-m",
+                "pip",
+                "install",
+                f"farm-haystack{_HAYSTACK_EXTRAS}=={_HAYSTACK_PREFERRED_VERSION}",
+                "--no-dependencies",
+                "-r",
+                _HAYSTACK_REQS_PATH,
+            ]
+        )
+
+        import haystack as _haystack
+
+        _LOGGER.info("haystack and dependencies successfully installed")
+    except Exception:
+        raise ValueError(
+            "Unable to install and import haystack dependencies. Check "
+            "that haystack is installed, if not, install via "
+            "`pip install "
+            f"farm-haystack{_HAYSTACK_EXTRAS}=={_HAYSTACK_PREFERRED_VERSION} "
+            f"--no-dependencies -r {_HAYSTACK_REQS_PATH}`"
+        )
+
+
+def _check_haystack_install():
+    if _haystack_import_error is not None:
+        import os
+
+        if os.getenv("NM_NO_AUTOINSTALL_HAYSTACK", False):
+            _LOGGER.warning(
+                "Unable to import haystack, skipping auto installation "
+                "due to NM_NO_AUTOINSTALL_HAYSTACK"
+            )
+            # skip any further checks
+            return
+        else:
+            _LOGGER.warning(
+                "haystack installation not detected. Installing "
+                "haystack dependencies if haystack is already "
+                "installed in the environment, it will be overwritten. Set "
+                "environment variable NM_NO_AUTOINSTALL_HAYSTACK to disable"
+            )
+            _install_haystack_and_deps()
+
+    # re check import after potential install
+    try:
+        import haystack as _haystack
+
+        if _haystack.__version__ != _HAYSTACK_PREFERRED_VERSION:
+            raise ValueError(
+                f"Deepsparse requires farm-haystack=={_HAYSTACK_PREFERRED_VERSION}, "
+                f"but found {_haystack.__version__}"
+            )
+    except Exception:
+        _LOGGER.warning(
+            "haystack may not be installed. it can be installed via "
+            "`pip install "
+            f"farm-haystack{_HAYSTACK_EXTRAS}=={_HAYSTACK_PREFERRED_VERSION} "
+            f"--no-dependencies -r {_HAYSTACK_REQS_PATH}`"
+        )
+
+
+_check_haystack_install()
+
 from .nodes import *
 from .pipeline import *
 from .helpers import *

--- a/src/deepsparse/transformers/haystack/haystack_reqs.txt
+++ b/src/deepsparse/transformers/haystack/haystack_reqs.txt
@@ -1,8 +1,8 @@
 # haystack_reqs.py
 #
-# This file lists the desired versions of farm-haystack[all]==1.4.0 dependencies
-# to be used by setup.py when installing with [haystack] extras. This is to prevent
-# farm-haystack from installing versions of dependencies that conflict with NM.
+# This file is used to control which dependencies are installed by
+# deepsparse/transformers/haystack/__init__.py. This is to prevent farm-haystack
+# from installing dependencies that conflict with NM.
 #
 # Lists all dependencies for farm-haystack[all]==1.4.0, excluding the following
 # which conflict with deepsparse dependencies:

--- a/tests/deepsparse/transformers/__init__.py
+++ b/tests/deepsparse/transformers/__init__.py
@@ -15,3 +15,4 @@
 # flake8: noqa
 # NOTE: including here to force auto install to happen
 from deepsparse import transformers as _transformers
+from deepsparse.transformers import haystack as _haystack


### PR DESCRIPTION
This PR reverts the changes made in https://github.com/neuralmagic/deepsparse/pull/532. It was found that installing Haystack dependencies through extras was not feasible. Haystack requires HF transformers as a dependency. However, having HF transformers breaks the auto install of NM transformers, as there is no good way to dynamically reload modules in python. There is also no good way to install Haystack in extras without installing its dependencies.

Given these blocks, reverting back to dynamical install fixes these issues by controlling which dependencies are need by Haystack through a requirements.txt file. We can then remove HF transformers from this dependency list, thus avoiding the issue of dynamic module reload.