### PR TITLE
Remove: `numpy.ndarray` from ImageClassification schema

### DIFF
--- a/src/deepsparse/image_classification/schemas.py
+++ b/src/deepsparse/image_classification/schemas.py
@@ -34,7 +34,7 @@ class ImageClassificationInput(BaseModel, Splittable):
     Input model for image classification
     """
 
-    images: Union[str, List[str], List[Any], numpy.ndarray] = Field(
+    images: Union[str, List[str], List[Any]] = Field(
         description="List of Images to process"
     )
 


### PR DESCRIPTION
Remove: `numpy.ndarray` from ImageClassification schema to work with `deepsparse.server` cause they aren't json serializable


Tests:

```
deepsparse.server --task image_classification --model_path "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned85_quant-none-vnni"
```


Docs:
![Screen Shot 2022-08-11 at 2 43 47 PM](https://user-images.githubusercontent.com/25380596/184215584-d9519053-04c9-4e4c-bbda-b2bbde9a5526.png)

