### PR TITLE
Remove: `numpy.ndarray` ImageClassification schema 

### DIFF
--- a/src/deepsparse/image_classification/schemas.py
+++ b/src/deepsparse/image_classification/schemas.py
@@ -34,7 +34,7 @@ class ImageClassificationInput(BaseModel, Splittable):
     Input model for image classification
     """
 
-    images: Union[str, List[str], List[Any], numpy.ndarray] = Field(
+    images: Union[str, List[str], List[Any]] = Field(
         description="List of Images to process"
     )
 


### PR DESCRIPTION
Cherry Pick for PR #560 

Remove: `numpy.ndarray` ImageClassification schema to work with `deepsparse.server`