### PR TITLE
Enabling hyphenated task names in deepsparse.server

### DIFF
--- a/src/deepsparse/server/main.py
+++ b/src/deepsparse/server/main.py
@@ -239,7 +239,9 @@ def server_app_factory():
     return app
 
 
-@click.command()
+@click.command(
+    context_settings=dict(token_normalize_func=lambda x: x.replace("-", "_"))
+)
 @click.option(
     "--host",
     type=str,
@@ -276,7 +278,7 @@ def server_app_factory():
 )
 @click.option(
     "--task",
-    type=click.Choice(SupportedTasks.task_names()),
+    type=click.Choice(SupportedTasks.task_names(), case_sensitive=False),
     default=None,
     help="The task the model_path is serving.",
 )


### PR DESCRIPTION
Tested:

- `deepsparse.server --task question_answering`
- `deepsparse.server --task question-answering`
- `deepsparse.server --task Question_Answering`
- `deepsparse.server --task Question-Answering`