### PR TITLE
Updated bert unit tests (#571)

### DIFF
--- a/tests/deepsparse/transformers/test_helpers.py
+++ b/tests/deepsparse/transformers/test_helpers.py
@@ -130,10 +130,10 @@ def test_get_transformer_layer_init_names(
 @pytest.mark.parametrize(
     "model_name,emb_extraction_layer,expected_final_node_name",
     [
-        ("bert", -1, "Add_2544"),
-        ("bert", 5, "Add_1296"),
-        ("bert", 0, "Add_256"),
-        ("bert", "Add_256", "Add_256"),
+        ("bert", -1, "Add_2616"),
+        ("bert", 5, "Add_1332"),
+        ("bert", 0, "Add_262"),
+        ("bert", "Add_262", "Add_262"),
         ("distilbert", -1, "Add_515"),
         ("distilbert", 2, "Add_269"),
         ("distilbert", 0, "Add_105"),


### PR DESCRIPTION
A bert model that was being used for unit testing got updated, so the onnx node names have changed. https://github.com/neuralmagic/zoomodels/pull/425. This is confirmed to happen for minor changes to onnx models.

https://github.com/neuralmagic/deepsparse/pull/571