### PR TITLE
Add embed_title arg to DPR (#544)

### DIFF
--- a/src/deepsparse/transformers/pipelines/embedding_extraction.py
+++ b/src/deepsparse/transformers/pipelines/embedding_extraction.py
@@ -251,12 +251,13 @@ class EmbeddingExtractionPipeline(TransformersPipeline):
         if isinstance(inputs.inputs, str):
             inputs.inputs = [inputs.inputs]
 
+        # tokenization matches https://github.com/texttron/tevatron
         tokens = self.tokenizer(
             inputs.inputs,
             add_special_tokens=True,
-            return_tensors="np",
             padding=PaddingStrategy.MAX_LENGTH.value,
             truncation=TruncationStrategy.LONGEST_FIRST.value,
+            return_tensors="np",
         )
 
         # mask padding and cls_token


### PR DESCRIPTION
It was noticed that Tevatron embeds the passage title into the raw text input. This PR adds that functionality to the DeepSparseDensePassageRetriever as an argument embed_title, which allows a user to generate passage embeddings with embedded titles. This argument is also implemented in the Haystack version of this class.

https://github.com/neuralmagic/deepsparse/pull/544