### PR TITLE
force download of tokenizer_config.json when available

### DIFF
--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -45,6 +45,7 @@ _LOGGER = get_main_logger()
 _MODEL_DIR_ONNX_NAME = "model.onnx"
 _MODEL_DIR_CONFIG_NAME = "config.json"
 _MODEL_DIR_TOKENIZER_NAME = "tokenizer.json"
+_MODEL_DIR_TOKENIZER_CONFIG_NAME = "tokenizer_config.json"
 
 
 def get_onnx_path_and_configs(
@@ -109,6 +110,11 @@ def get_onnx_path_and_configs(
         tokenizer_path = _get_file_parent(
             zoo_model.deployment.default.get_file(_MODEL_DIR_TOKENIZER_NAME).path
         )
+        tokenizer_config_path = zoo_model.deployment.default.get_file(
+            _MODEL_DIR_TOKENIZER_CONFIG_NAME
+        )
+        if tokenizer_config_path is not None:
+            tokenizer_config_path.path  # trigger download of tokenizer_config
     elif require_configs and (config_path is None or tokenizer_path is None):
         raise RuntimeError(
             f"Unable to find model and tokenizer config for model_path {model_path}. "

--- a/tests/deepsparse/transformers/test_helpers.py
+++ b/tests/deepsparse/transformers/test_helpers.py
@@ -12,14 +12,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import onnx
 
 import pytest
 from deepsparse.transformers.helpers import (
+    get_onnx_path_and_configs,
     get_transformer_layer_init_names,
     truncate_transformer_onnx_model,
 )
 from sparsezoo import Model
+
+
+@pytest.mark.parametrize(
+    "stub",
+    [
+        (
+            "zoo:nlp/text_classification/distilbert-none/pytorch/huggingface/"
+            "mnli/pruned80_quant-none-vnni"
+        ),
+    ],
+)
+def test_get_onnx_path_and_configs_from_stub(stub):
+    onnx_path, config_dir, tokenizer_dir = get_onnx_path_and_configs(stub)
+
+    assert onnx_path.endswith("model.onnx")
+    assert os.path.exists(onnx_path)
+
+    config_dir_files = os.listdir(config_dir)
+    assert "config.json" in config_dir_files
+
+    tokenizer_dir_files = os.listdir(tokenizer_dir)
+    assert "tokenizer.json" in tokenizer_dir_files
+    # make assert optional if stubs added for models with no known tokenizer_config
+    assert "tokenizer_config.json" in tokenizer_dir_files
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
tokenizer_config.json is needed to define special characters in the tokenizer (as opposed to tokenizer.json used for determining tokenizer class).  future refactor will make deployment directory a first class citizen across all pipelines without casework for any files. This PR adds support for downloading the tokenizer_config file in the manual parsing of the deployment directory

**test_plan:**
tested manually with https://github.com/neuralmagic/sparsezoo/pull/215 in env. all 3 deployment files correctly downloaded and used to load tokenizer