### PR TITLE
Cherry pick 1.1 remove haystack install test

### DIFF
--- a/tests/deepsparse/transformers/__init__.py
+++ b/tests/deepsparse/transformers/__init__.py
@@ -15,4 +15,3 @@
 # flake8: noqa
 # NOTE: including here to force auto install to happen
 from deepsparse import transformers as _transformers
-from deepsparse.transformers import haystack as _haystack


### PR DESCRIPTION
Haystack auto-install was causing failing tests due to a missing torch dependency.

https://github.com/neuralmagic/deepsparse/pull/581