### PR TITLE
[Bugfix] Assume a batch of numpy arrays is of the correct input shape

### DIFF
--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -192,7 +192,9 @@ class YOLOPipeline(Pipeline):
                 image = cv2.imread(image)
 
             image = self._make_channels_last(image)
-            image = cv2.resize(image, dsize=tuple(reversed(self.image_size)))
+            if image.ndim < 4:
+                # Assume a batch is of the correct size already
+                image = cv2.resize(image, dsize=tuple(reversed(self.image_size)))
             image = self._make_channels_first(image)
             image_batch.append(image)
 

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -175,8 +175,8 @@ class YOLOPipeline(Pipeline):
         :return: inputs of this model processed into a list of numpy arrays that
             can be directly passed into the forward pass of the pipeline engine
         """
-        # Noting that if numpy arrays are passed in, we assume they are
-        # already the correct shape
+        # Noting that if a batch of numpy arrays are passed in, we assume they
+        # are already the correct shape
 
         if isinstance(inputs.images, (str, numpy.ndarray)):
             inputs.images = [inputs.images]


### PR DESCRIPTION
YOLO pipelines would fail when a batch of `numpy.ndarray` is passed as input;

The bug is caused due to line 195 `cv2.resize(...)`
cv2 can only resize one image at a time, this PR adds an assumption that a batch of `numpy` arrays always is of the correct input size (else they couldn't be stacked into a batch). 

The changes were tested with sparseml.yolov5.val_onnx and with a server locally as follows:

```bash
sparseml.yolov5.val_onnx --model_path /home/rahul/models/yolo/best.onnx --data coco128.yaml
val_onnx: data=../sparseml/src/sparseml/yolov5/data/coco128.yaml, model_path=/home/rahul/models/yolo/best.onnx, batch_size=32, imgsz=640, conf_thres=0.001, iou_thres=0.6, task=val, device=, workers=8, augment=False, verbose=False, save_txt=False, save_hybrid=False, save_conf=False, save_json=False, project=../sparseml/src/sparseml/yolov5/runs/val, name=exp, exist_ok=False, half=False, dnn=False, engine=deepsparse, num_cores=None
fatal: not a git repository (or any of the parent directories): .git
YOLOv5 🚀 2022-8-18 torch 1.9.1+cu102 CUDA:0 (NVIDIA TITAN RTX, 24218MiB)

DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 1.1.0.20220818 COMMUNITY EDITION (de8f991d) (release) (optimized) (system=avx512, binary=avx512)
val: Scanning 'datasets/coco128/labels/train2017.cache' images and labels... 128
               Class     Images     Labels          P          R     mAP@.5 mAP@
/home/rahul/projects/yolov5/utils/metrics.py:74: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  names = [v for k, v in names.items() if k in unique_classes]  # list: only classes that have data
                 all        128        929      0.624      0.595      0.644      0.401
Speed: 0.0ms pre-process, 23.2ms inference, 0.0ms NMS per image at shape (32, 3, 640, 640)
Results saved to ../sparseml/src/sparseml/yolov5/runs/val/exp13
```

With the server: 

Server command:
```bash
deepsparse.server --task yolo --model_path "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned_quant-aggressive_94" --port 5543
```

Client Code:
```bash
import requests

url = "http://0.0.0.0:5543/predict/from_files"
path = [
    "basilica.jpg",
]  # list of images for inference
files = [("request", open(img, "rb")) for img in path]
resp = requests.post(url=url, files=files)
annotations = resp.text  # dictionary of annotation results
print(annotations)
```

Output:
```bash
{"predictions":[[[365.1540222167969,389.8695983886719,392.8899841308594,413.7817077636719,0.8189773559570312,2.0],[177.08729553222656,471.71929931640625,344.1943359375,618.2107543945312,0.8114733695983887,3.0],[488.02947998046875,405.33917236328125,512.830078125,500.55999755859375,0.8095308542251587,0.0],[312.5378723144531,389.0389404296875,353.0178527832031,412.218505859375,0.7773508429527283,2.0],[207.41287231445312,396.69329833984375,241.64389038085938,440.78192138671875,0.7681789994239807,2.0],[37.9552001953125,408.99224853515625,66.92988586425781,503.58935546875,0.7615326642990112,0.0],[11.569220542907715,340.5566711425781,28.44192886352539,389.7497253417969,0.7522252798080444,9.0],[299.47210693359375,432.6941223144531,386.5230712890625,540.8733520507812,0.7216042280197144,3.0],[216.8148193359375,394.778564453125,299.3529052734375,592.8782958984375,0.7058807611465454,0.0],[436.01971435546875,400.51373291015625,461.3634033203125,500.33349609375,0.6867731213569641,0.0],[66.94375610351562,384.4931945800781,89.83090209960938,465.4990539550781,0.6826549768447876,0.0],[529.6423950195312,388.042724609375,573.4396362304688,496.0799560546875,0.6475707292556763,0.0],[103.84114074707031,387.77117919921875,126.69877624511719,477.712158203125,0.5969333052635193,0.0],[472.5570983886719,401.2966613769531,493.8448181152344,479.9734802246094,0.5721787214279175,0.0],[615.2486572265625,402.618408203125,640.787109375,479.51800537109375,0.4973568320274353,2.0],[130.7674560546875,386.91375732421875,150.8126220703125,443.1575927734375,0.47501909732818604,0.0],[510.4071960449219,395.2115478515625,542.2781372070312,440.27667236328125,0.4579818844795227,2.0]]],"boxes":[[[365.1540222167969,389.8695983886719,392.8899841308594,413.7817077636719],[177.08729553222656,471.71929931640625,344.1943359375,618.2107543945312],[488.02947998046875,405.33917236328125,512.830078125,500.55999755859375],[312.5378723144531,389.0389404296875,353.0178527832031,412.218505859375],[207.41287231445312,396.69329833984375,241.64389038085938,440.78192138671875],[37.9552001953125,408.99224853515625,66.92988586425781,503.58935546875],[11.569220542907715,340.5566711425781,28.44192886352539,389.7497253417969],[299.47210693359375,432.6941223144531,386.5230712890625,540.8733520507812],[216.8148193359375,394.778564453125,299.3529052734375,592.8782958984375],[436.01971435546875,400.51373291015625,461.3634033203125,500.33349609375],[66.94375610351562,384.4931945800781,89.83090209960938,465.4990539550781],[529.6423950195312,388.042724609375,573.4396362304688,496.0799560546875],[103.84114074707031,387.77117919921875,126.69877624511719,477.712158203125],[472.5570983886719,401.2966613769531,493.8448181152344,479.9734802246094],[615.2486572265625,402.618408203125,640.787109375,479.51800537109375],[130.7674560546875,386.91375732421875,150.8126220703125,443.1575927734375],[510.4071960449219,395.2115478515625,542.2781372070312,440.27667236328125]]],"scores":[[0.8189773559570312,0.8114733695983887,0.8095308542251587,0.7773508429527283,0.7681789994239807,0.7615326642990112,0.7522252798080444,0.7216042280197144,0.7058807611465454,0.6867731213569641,0.6826549768447876,0.6475707292556763,0.5969333052635193,0.5721787214279175,0.4973568320274353,0.47501909732818604,0.4579818844795227]],"labels":[["2.0","3.0","0.0","2.0","2.0","0.0","9.0","3.0","0.0","0.0","0.0","0.0","0.0","0.0","2.0","0.0","2.0"]]}

```