### PR TITLE
Move farm-haystack deps to deepsparse[haystack] (#597)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,13 @@ _PACKAGE_NAME = "deepsparse" if is_release else "deepsparse-nightly"
 binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
 
+def _parse_requirements_file(file_path):
+    with open(file_path, "r") as requirements_file:
+        lines = requirements_file.read().splitlines()
+
+    return [line for line in lines if len(line) > 0 and line[0] != "#"]
+
+
 _deps = [
     "numpy>=1.16.3",
     "onnx>=1.5.0,<=1.12.0",
@@ -93,6 +100,17 @@ _yolo_integration_deps = [
     "torchvision>=0.3.0,<=0.12.0",
     "opencv-python",
 ]
+# haystack dependencies are installed from a requirements file to avoid
+# conflicting versions with NM's deepsparse/transformers
+_haystack_requirements_file_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "src",
+    "deepsparse",
+    "transformers",
+    "haystack",
+    "haystack_reqs.txt",
+)
+_haystack_integration_deps = _parse_requirements_file(_haystack_requirements_file_path)
 
 
 def _check_supported_system():
@@ -197,6 +215,7 @@ def _setup_extras() -> Dict:
         "server": _server_deps,
         "onnxruntime": _onnxruntime_deps,
         "yolo": _yolo_integration_deps,
+        "haystack": _haystack_integration_deps,
     }
 
 

--- a/src/deepsparse/transformers/haystack/__init__.py
+++ b/src/deepsparse/transformers/haystack/__init__.py
@@ -28,7 +28,6 @@ import deepsparse as _deepsparse
 
 _HAYSTACK_PREFERRED_VERSION = "1.4.0"
 _HAYSTACK_EXTRAS = "[all]"
-_HAYSTACK_REQS_PATH = _os.path.join(_os.path.dirname(__file__), "haystack_reqs.txt")
 
 
 # check haystack installation
@@ -60,8 +59,6 @@ def _install_haystack_and_deps():
                 "install",
                 f"farm-haystack{_HAYSTACK_EXTRAS}=={_HAYSTACK_PREFERRED_VERSION}",
                 "--no-dependencies",
-                "-r",
-                _HAYSTACK_REQS_PATH,
             ]
         )
 
@@ -72,9 +69,9 @@ def _install_haystack_and_deps():
         raise ValueError(
             "Unable to install and import haystack dependencies. Check "
             "that haystack is installed, if not, install via "
-            "`pip install "
+            "`pip install deepsparse[haystack]` and `pip install "
             f"farm-haystack{_HAYSTACK_EXTRAS}=={_HAYSTACK_PREFERRED_VERSION} "
-            f"--no-dependencies -r {_HAYSTACK_REQS_PATH}`"
+            "--no-dependencies`"
         )
 
 
@@ -109,10 +106,10 @@ def _check_haystack_install():
             )
     except Exception:
         _LOGGER.warning(
-            "haystack may not be installed. it can be installed via "
-            "`pip install "
+            "haystack and its dependencies may not be installed. They can be installed "
+            "via `pip install deepsparse[haystack]` and `pip install "
             f"farm-haystack{_HAYSTACK_EXTRAS}=={_HAYSTACK_PREFERRED_VERSION} "
-            f"--no-dependencies -r {_HAYSTACK_REQS_PATH}`"
+            "--no-dependencies`"
         )
 
 

--- a/src/deepsparse/transformers/haystack/haystack_reqs.txt
+++ b/src/deepsparse/transformers/haystack/haystack_reqs.txt
@@ -1,15 +1,19 @@
 # haystack_reqs.py
 #
 # This file is used to control which dependencies are installed by
-# deepsparse/transformers/haystack/__init__.py. This is to prevent farm-haystack
-# from installing dependencies that conflict with NM.
+# deepsparse[haystack]. This is done to ensure that farm-haystack has all of its
+# dependencies without installing dependencies that conflict with NM.
 #
-# Lists all dependencies for farm-haystack[all]==1.4.0, excluding the following
+# This file lists dependencies for farm-haystack[all]==1.4.0, excluding the following
 # which conflict with deepsparse dependencies:
-# [transformers, torch]
-# the following version requirements have been updated to match deepsparse versioning
-# [onnx, onnxruntime, numpy, torchvision, tokenizers]
+# [transformers]
+# the following versions have been updated to match deepsparse and sparseml versioning
+# [onnx, onnxruntime, numpy, torch, torchvision]
 # you can see their haystack versions as comments in this file
+#
+# because haystack cannot be included in setup.py without its inclusion also causing
+# an installation of huggingface/transformers, it will be auto installed through
+# deepsparse/transformers/haystack/__init__.py
 
 aiohttp==3.8.1
 aiorwlock==1.3.0
@@ -244,12 +248,12 @@ threadpoolctl==3.1.0
 tika==1.24
 tinycss2==1.1.1
 tokenize-rt==4.2.1
-#tokenizers==0.12.1
-tokenizers==0.10.3
+tokenizers==0.12.1
 toml==0.10.2
 tomli==2.0.1
 tomlkit==0.11.1
 #torch==1.12.0
+torch==1.9.1
 torch-complex==0.4.3
 #torchvision==0.13.0
 torchvision>=0.3.0,<=0.10.1


### PR DESCRIPTION
This PR moves all farm-haystack dependencies to setup.py under deepsparse[haystack]

https://github.com/neuralmagic/deepsparse/pull/597