### PR TITLE
Adding `@mock_engine()` to avoid compiling models in tests

### DIFF
--- a/tests/deepsparse/image_classification/test_pipelines.py
+++ b/tests/deepsparse/image_classification/test_pipelines.py
@@ -23,6 +23,7 @@ from deepsparse.image_classification.constants import (
 )
 from sparsezoo import Model
 from sparsezoo.utils import load_numpy_list
+from tests.utils import mock_engine
 
 
 from PIL import Image  # isort:skip
@@ -41,7 +42,10 @@ from torchvision import transforms  # isort:skip
     ],
 )
 @pytest.mark.smoke
-def test_image_classification_pipeline_preprocessing(zoo_stub, image_size, num_samples):
+@mock_engine(rng_seed=0)
+def test_image_classification_pipeline_preprocessing(
+    engine, zoo_stub, image_size, num_samples
+):
     non_rand_resize_scale = 256.0 / 224.0  # standard used
     standard_imagenet_transforms = transforms.Compose(
         [

--- a/tests/deepsparse/pipelines/test_async_pipeline.py
+++ b/tests/deepsparse/pipelines/test_async_pipeline.py
@@ -17,6 +17,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 
 import pytest
 from deepsparse import Pipeline
+from tests.utils import mock_engine
 
 
 @pytest.fixture(scope="module")
@@ -24,7 +25,8 @@ def pipeline():
     """
     Auto-del fixture for Sequential Pipeline
     """
-    yield Pipeline.create(task="question-answering")
+    with mock_engine(rng_seed=0):
+        yield Pipeline.create(task="question-answering")
 
 
 @pytest.fixture(scope="module")
@@ -40,7 +42,8 @@ def threaded_pipeline(executor):
     """
     Auto-del fixture for Threaded Pipeline
     """
-    yield Pipeline.create(task="question-answering", executor=executor)
+    with mock_engine(rng_seed=0):
+        yield Pipeline.create(task="question-answering", executor=executor)
 
 
 @pytest.fixture(scope="module")

--- a/tests/deepsparse/pipelines/test_custom_pipeline.py
+++ b/tests/deepsparse/pipelines/test_custom_pipeline.py
@@ -24,6 +24,7 @@ from deepsparse.image_classification import (
 from deepsparse.pipeline import Pipeline
 from deepsparse.pipelines.custom_pipeline import CustomTaskPipeline
 from deepsparse.utils.onnx import model_to_path
+from tests.utils import mock_engine
 
 
 # NOTE: these need to be placed after the other imports bc of a dependency chain issue
@@ -55,7 +56,8 @@ def test_custom_pipeline_task_names(task_name):
     assert cls == CustomTaskPipeline
 
 
-def test_no_input_call(model_path):
+@mock_engine(rng_seed=0)
+def test_no_input_call(engine, model_path):
     pipeline = Pipeline.create(task="custom", model_path=model_path)
     assert isinstance(pipeline, CustomTaskPipeline)
 
@@ -73,7 +75,8 @@ def test_no_input_call(model_path):
     assert len(output) == 2
 
 
-def test_custom_pipeline_as_image_classifier(model_path):
+@mock_engine(rng_seed=0)
+def test_custom_pipeline_as_image_classifier(engine, model_path):
     image_size = 224
     non_rand_resize_scale = 256.0 / 224.0  # standard used
     standard_imagenet_transforms = transforms.Compose(

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -18,6 +18,7 @@ import numpy
 
 import pytest
 from deepsparse import Pipeline
+from tests.utils import SampleMode, mock_engine
 
 from .data_helpers import create_test_inputs
 
@@ -30,9 +31,7 @@ _SUPPORTED_TASKS = [
     "yolact",
 ]
 
-_BATCH_SIZES = [
-    2,
-]
+_BATCH_SIZES = [2, 4, 8]
 
 
 def compare(expected, actual):
@@ -52,7 +51,8 @@ def compare(expected, actual):
 
 
 @pytest.mark.parametrize("task", _SUPPORTED_TASKS)
-def test_dynamic_is_same_as_static(task):
+@mock_engine(rng_seed=0, mode=SampleMode.zeros)
+def test_dynamic_is_same_as_static(engine, task):
     executor = ThreadPoolExecutor()
 
     # NOTE: re-use the same dynamic pipeline for different batch sizes

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .engine_mocking import SampleMode, mock_engine  # noqa

--- a/tests/utils/engine_mocking.py
+++ b/tests/utils/engine_mocking.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+from enum import Enum
+from pathlib import Path
+from typing import Any, List, Type
+from unittest import mock
+
+import numpy
+import onnx
+import onnxruntime as ort
+
+
+class SampleMode(str, Enum):
+    """
+    How to sample outputs generated from the mocked engine.
+    """
+
+    zeros = "zeros"
+    rand = "rand"
+
+
+def mock_engine(*, rng_seed: int, mode: SampleMode = SampleMode.rand, **kwargs):
+    """
+    Intended to create a fake engine instead of compiling the model.
+
+    This patches the `LIB.deepsparse_engine()` that is used in deepsparse.Engine
+    with `_FakeDeepsparseLibEngine`.
+
+    Use like you would a regular `unittest.mock.patch`
+    ```python
+    @mock_engine(rng_seed=0)
+    def test_something(engine):
+        ...
+    ```
+
+    If you want the arrays to be zeros instead of random data:
+    ```python
+    @mock_engine(rng_seed=0, model=SampleMode.zeros)
+    def test_something(engine):
+        ...
+    ```
+    """
+
+    def deepsparse_engine(*args, **kwargs):
+        return _FakeDeepsparseLibEngine(*args, **kwargs, rng_seed=rng_seed, mode=mode)
+
+    return mock.patch(
+        "deepsparse.engine.LIB.deepsparse_engine",
+        side_effect=deepsparse_engine,
+        **kwargs,
+    )
+
+
+class _FakeDeepsparseLibEngine:
+    def __init__(
+        self,
+        model_path: str,
+        batch_size: int,
+        num_cores: int,
+        num_streams: int,
+        scheduler_value: Any,
+        context_value: Any,
+        *,
+        # NOTE: the following are not actual deepsparse engine arguments
+        rng_seed: int,
+        mode: SampleMode,
+    ):
+        self.model_path = model_path
+        self.batch_size = batch_size
+        self.num_cores = num_cores
+        self.num_streams = num_streams
+        self.scheduler_value = scheduler_value
+        self.context_value = context_value
+        self.rng_seed = rng_seed
+        self.mode = mode
+
+        # override batch dimension in inputs & outputs
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = onnx.load(self.model_path)
+            inputs = model.graph.input
+            initializer_names = [node.name for node in model.graph.initializer]
+            # remove initializer nodes from inputs
+            inputs = [input for input in inputs if input.name not in initializer_names]
+
+            # This is done because not all `.onnx` files passed in will
+            # conform to expected `batch_size`.
+            #
+            # By overriding the batch size in the inputs, and loading this
+            # model with the onnxruntime, onnxruntime will automatically
+            # fix the batch dimension in outputs.
+            #
+            # Assumes the first dimension is batch dimension!!
+            # However in general we cannot assume that all outputs have
+            # a batch dimension, that's why we need onnxruntime here.
+            for input in inputs:
+                input.type.tensor_type.shape.dim[0].dim_value = batch_size
+
+            batched_model_path = str(Path(tmp_dir) / "batched_model.onnx")
+            onnx.save(model, batched_model_path)
+
+            session = ort.InferenceSession(batched_model_path)
+            self.input_descriptors = list(map(_to_descriptor, session.get_inputs()))
+            self.output_descriptors = list(map(_to_descriptor, session.get_outputs()))
+
+    def execute(self, inputs):
+        raise NotImplementedError("mapped_run not supported with mocked engine")
+
+    def execute_list_out(self, inputs: List[numpy.ndarray]) -> List[numpy.ndarray]:
+        # validate all the inputs are the correct type
+        assert len(inputs) == len(self.input_descriptors)
+        for descriptor, input in zip(self.input_descriptors, inputs):
+            descriptor.check(input)
+
+        # NOTE: we construct the rng here because this function may
+        # be called from different threads, and rng's are not
+        # thread safe.
+        rng = numpy.random.default_rng(self.rng_seed)
+
+        outputs = [d.sample(rng, self.mode) for d in self.output_descriptors]
+
+        assert len(outputs) == len(self.output_descriptors)
+        for descriptor, output in zip(self.output_descriptors, outputs):
+            descriptor.check(output)
+        return outputs
+
+
+def _to_descriptor(node: ort.NodeArg) -> "_NumpyDescriptor":
+    to_numpy_dtype = {
+        "tensor(float)": numpy.float32,
+        "tensor(double)": numpy.float64,
+        "tensor(uint8)": numpy.uint8,
+        "tensor(int64)": numpy.int64,
+    }
+    return _NumpyDescriptor(shape=node.shape, dtype=to_numpy_dtype[node.type])
+
+
+class _NumpyDescriptor:
+    def __init__(self, *, shape: List[int], dtype: Type):
+        self.shape = shape
+        self.dtype = dtype
+
+    def check(self, a: numpy.ndarray):
+        assert isinstance(a, numpy.ndarray)
+        assert a.shape == tuple(self.shape), f"Expected {self} found shape={a.shape}"
+        assert a.dtype == self.dtype, f"Expected {self} found dtype={a.dtype}"
+
+    def sample(self, rng: numpy.random.Generator, mode: SampleMode) -> numpy.ndarray:
+        if mode == SampleMode.zeros:
+            return numpy.zeros(self.shape, dtype=self.dtype)
+        elif mode == SampleMode.rand:
+            return rng.random(size=self.shape).astype(self.dtype)
+        else:
+            raise ValueError(f"invalid sample mode {mode}")
+
+    def __repr__(self) -> str:
+        return f"_NumpyDescriptor(shape={self.shape}, dtype={self.dtype})"

--- a/tests/utils/engine_mocking.py
+++ b/tests/utils/engine_mocking.py
@@ -16,10 +16,10 @@ from enum import Enum
 from typing import Any, List, Type
 from unittest import mock
 
-from deepsparse.utils import override_onnx_batch_size
-
 import numpy
 import onnxruntime as ort
+
+from deepsparse.utils import override_onnx_batch_size
 
 
 class SampleMode(str, Enum):

--- a/tests/utils/test_engine_mocking.py
+++ b/tests/utils/test_engine_mocking.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from unittest.mock import MagicMock
+
+import numpy
+
+import pytest
+from deepsparse import Context, Pipeline
+from tests.utils.engine_mocking import SampleMode, _FakeDeepsparseLibEngine, mock_engine
+
+
+@mock_engine(rng_seed=0)
+def test_mock_engine_fakes_engine(engine_mock):
+    pipeline = Pipeline.create("image_classification")
+    assert isinstance(pipeline.engine._eng_net, _FakeDeepsparseLibEngine)
+
+
+@mock_engine(rng_seed=0)
+def test_mock_engine_calls(engine_mock: MagicMock):
+    engine_mock.assert_not_called()
+    # with pytest.raises(ValueError):
+    context = Context(num_cores=1, num_streams=1)
+    Pipeline.create("image_classification", batch_size=3, context=context)
+    engine_mock.assert_called_once_with(
+        os.path.join(
+            os.path.expanduser("~"),
+            ".cache/sparsezoo/84774c96-ab7d-4b3b-ab8c-2509d7bfcb09/model.onnx",
+        ),
+        3,
+        1,
+        1,
+        "elastic",
+        context.value,
+    )
+
+
+@mock_engine(rng_seed=0)
+def test_mock_engine_checks_inputs_list(engine_mock: MagicMock):
+    pipeline = Pipeline.create("image_classification")
+    with pytest.raises(
+        ValueError,
+        match=re.escape("inp must be a list, given <class 'numpy.ndarray'>"),
+    ):
+        pipeline.engine(numpy.zeros((1, 3, 550, 550)))
+
+
+@mock_engine(rng_seed=0)
+def test_mock_engine_checks_inputs_dtype(engine_mock: MagicMock):
+    pipeline = Pipeline.create("image_classification")
+    with pytest.raises(
+        AssertionError,
+        match=re.escape("Expected <class 'numpy.float32'> found dtype=float64"),
+    ):
+        pipeline.engine([numpy.zeros((1, 3, 224, 224), dtype=numpy.float64)])
+
+
+@mock_engine(rng_seed=0)
+def test_mock_engine_checks_inputs_shape(engine_mock: MagicMock):
+    pipeline = Pipeline.create("image_classification")
+    with pytest.raises(
+        AssertionError,
+        match=re.escape("Expected [1, 3, 224, 224] found shape=(1, 3, 550, 550)"),
+    ):
+        pipeline.engine([numpy.zeros((1, 3, 550, 550))])
+
+
+@mock_engine(rng_seed=0)
+def test_mock_engine_outputs_rand(engine_mock: MagicMock):
+    pipeline = Pipeline.create("image_classification")
+    outputs = pipeline.engine([numpy.zeros((1, 3, 224, 224), dtype=numpy.float32)])
+    assert len(outputs) == 2
+    rng = numpy.random.default_rng(0)
+    for out in outputs:
+        assert numpy.all(out == rng.random(size=out.shape).astype(out.dtype))
+
+
+@mock_engine(rng_seed=0, mode=SampleMode.zeros)
+def test_mock_engine_outputs_zeros(engine_mock: MagicMock):
+    pipeline = Pipeline.create("image_classification")
+    outputs = pipeline.engine([numpy.zeros((1, 3, 224, 224), dtype=numpy.float32)])
+    assert len(outputs) == 2
+    for out in outputs:
+        assert numpy.all(out == numpy.zeros(out.shape, dtype=out.dtype))


### PR DESCRIPTION
This adds a feature to patch `LIB.deepsparse_engine()` with our own fake class that reads onnx models and returns numpy arrays in the expected shape.

This will enable unit tests to avoid expensive compiles, however they will still download the `.onnx` files.