### PR TITLE
DRAFT: Replacing server/config.py with commerical server config

### DIFF
--- a/src/deepsparse/server/config.py
+++ b/src/deepsparse/server/config.py
@@ -12,152 +12,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Configurations for serving models in the DeepSparse inference server
-"""
 
-import json
-import os
-from functools import lru_cache
-from typing import List
+from typing import List, Optional, Tuple, Union
 
-import yaml
 from pydantic import BaseModel, Field
-
-from deepsparse import PipelineConfig
-from deepsparse.cpu import cpu_architecture
 
 
 __all__ = [
-    "ENV_DEEPSPARSE_SERVER_CONFIG",
-    "ENV_SINGLE_PREFIX",
     "ServerConfig",
+    "EndpointConfig",
+    "SequenceLengthsConfig",
+    "ImageSizesConfig",
 ]
 
 
-ENV_DEEPSPARSE_SERVER_CONFIG = "DEEPSPARSE_SERVER_CONFIG"
-ENV_SINGLE_PREFIX = "DEEPSPARSE_SINGLE_MODEL:"
+class SequenceLengthsConfig(BaseModel):
+    sequence_lengths: List[int] = Field(
+        description="The sequence lengths the model should accept"
+    )
+
+
+class ImageSizesConfig(BaseModel):
+    image_sizes: List[Tuple[int, int]] = Field(
+        description="The list of image sizes the model should accept"
+    )
+
+
+class EndpointConfig(BaseModel):
+    name: str = Field(
+        description="Name of the model used for logging & metric purposes."
+    )
+
+    endpoint: str = Field(
+        description="The path to use for this endpoint. E.g. '/predict'."
+    )
+
+    task: str = Field(description="Task this endpoint performers")
+
+    model: str = Field(description="Location of the underlying model to use.")
+
+    batch_size: int = Field(description="The batch size to compile the model for.")
+
+    accept_multiples_of_batch_size: bool = Field(
+        description="""
+Whether to accept any request with a batch size that is a multiple of `batch_size`.
+
+E.g. if batch_size is 1 and this field is True,
+then the model can accept any batch size.
+    """,
+    )
+
+    bucketing: Optional[Union[ImageSizesConfig, SequenceLengthsConfig]] = Field(
+        default=None,
+        description="What input shapes this model can accept. Must specify at least 1",
+    )
 
 
 class ServerConfig(BaseModel):
-    """
-    A configuration for serving models in the DeepSparse inference server
-    """
-
-    models: List[PipelineConfig] = Field(
-        default=[],
-        description=(
-            "The models to serve in the server defined by PipelineConfig objects"
-        ),
-    )
-    workers: str = Field(
-        default=max(1, cpu_architecture().num_available_physical_cores // 2),
-        description=(
-            "The number of maximum workers to use for processing pipeline requests. "
-            "Defaults to the number of physical cores on the device."
-        ),
-    )
-    integration: str = Field(
-        default="default",
-        description=(
-            "Name of deployment integration that this server will be deployed to "
-            "Currently supported options are None for default inference and "
-            "'sagemaker' for inference deployment with AWS Sagemaker"
-        ),
+    num_cores: int = Field(
+        description="The number of cores available for model execution. "
+        "Defaults to all available cores.",
     )
 
+    num_concurrent_batches: int = Field(
+        description="""
+The number of times to partition the available cores. Each batch will have access to
+`num_cores / num_concurrent_batches` cores.
+""",
+    )
 
-@lru_cache()
-def server_config_from_env(env_key: str = ENV_DEEPSPARSE_SERVER_CONFIG):
-    """
-    Load a server configuration from the targeted environment variable given by env_key.
-
-    :param env_key: the environment variable to load the configuration from.
-        Defaults to ENV_DEEPSPARSE_SERVER_CONFIG
-    :return: the loaded configuration file
-    """
-    config_file = os.environ[env_key]
-
-    if not config_file:
-        raise ValueError(
-            "environment variable for deepsparse server config not found at "
-            f"{env_key}"
-        )
-
-    if config_file.startswith(ENV_SINGLE_PREFIX):
-        config_dict = json.loads(config_file.replace(ENV_SINGLE_PREFIX, ""))
-        config = ServerConfig()
-        config.models.append(
-            PipelineConfig(
-                task=config_dict["task"],
-                model_path=config_dict["model_path"],
-                batch_size=config_dict["batch_size"],
-            )
-        )
-    else:
-        with open(config_file) as file:
-            config_dict = yaml.safe_load(file.read())
-        config_dict["models"] = (
-            [PipelineConfig(**model) for model in config_dict["models"]]
-            if "models" in config_dict
-            else []
-        )
-        config = ServerConfig(**config_dict)
-
-    if len(config.models) == 0:
-        raise ValueError(
-            "There must be at least one model to serve in the configuration "
-            "for the deepsparse inference server"
-        )
-
-    return config
-
-
-def server_config_to_env(
-    config_file: str,
-    task: str,
-    model_path: str,
-    batch_size: int,
-    integration: str,
-    env_key: str = ENV_DEEPSPARSE_SERVER_CONFIG,
-):
-    """
-    Put a server configuration in an environment variable given by env_key.
-    If config_file is given, ignores task, model_path, and batch_size.
-    Otherwise, creates a configuration file from task, model_path, and batch_size
-    for serving a single model.
-
-    :param config_file: the path to the config file to store in the environment
-    :param task: the task the model_path is serving such as question_answering.
-        If config_file is supplied, this is ignored.
-    :param model_path: the path to a model.onnx file, a model folder containing
-        the model.onnx and supporting files, or a SparseZoo model stub.
-        If config_file is supplied, this is ignored.
-    :param batch_size: the batch size to serve the model from model_path with.
-        If config_file is supplied, this is ignored.
-    :param integration: name of deployment integration that this server will be
-        deployed to. Supported options include None for default inference and
-        sagemaker for inference deployment on AWS Sagemaker
-    :param env_key: the environment variable to set the configuration in.
-        Defaults to ENV_DEEPSPARSE_SERVER_CONFIG
-    """
-    if config_file is not None:
-        config = config_file
-    else:
-        if task is None or model_path is None:
-            raise ValueError(
-                "config_file not given, model_path and task both must be supplied "
-                "for serving"
-            )
-
-        single_str = json.dumps(
-            {
-                "task": task,
-                "model_path": model_path,
-                "batch_size": batch_size,
-                "integration": integration,
-            }
-        )
-        config = f"{ENV_SINGLE_PREFIX}{single_str}"
-
-    os.environ[env_key] = config
+    endpoints: List[EndpointConfig] = Field(description="The models to serve.")


### PR DESCRIPTION
This is just to illustrate differences in config. The full set of changes can be found in #601 