### PR TITLE
Relax click dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ _deps = [
     "requests>=2.0.0",
     "tqdm>=4.0.0",
     "protobuf>=3.12.2,<4",
-    "click==8.0",
+    "click~=8.0.0",
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_base}"]
 _dev_deps = [


### PR DESCRIPTION
Because click~=8.0.0 is explicitly not allowed by wandb, this PR allows minor version updates to click.

Tested by installing with dev dependencies (black). Because there are no click commands in deepsparse, there were no commands to test.