### PR TITLE
Fixing seq length calculation for transformers and testing

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -742,13 +742,17 @@ class BucketingPipeline(object):
         self._pipeline_class = pipelines[0].__class__
         self._validate_pipeline_class()
 
-    def __call__(self, **inputs):
-        parsed_inputs = self._pipelines[-1].parse_inputs(**inputs)
-        pipeline = self._pipeline_class.route_input_to_bucket(
+    def __call__(self, *args, **kwargs):
+        bucket, parsed_inputs = self._choose_bucket(*args, **kwargs)
+        return bucket(parsed_inputs)
+
+    def _choose_bucket(self, *args, **kwargs):
+        parsed_inputs = self._pipelines[-1].parse_inputs(*args, **kwargs)
+        bucket = self._pipeline_class.route_input_to_bucket(
             input_schema=parsed_inputs,
             pipelines=self._pipelines,
         )
-        return pipeline(parsed_inputs)
+        return bucket, parsed_inputs
 
     def __getattr__(self, item):
         value = getattr(self._pipelines[0].__class__, item)

--- a/src/deepsparse/transformers/pipelines/embedding_extraction.py
+++ b/src/deepsparse/transformers/pipelines/embedding_extraction.py
@@ -330,18 +330,14 @@ class EmbeddingExtractionPipeline(TransformersPipeline):
         """
         tokenizer = pipelines[0].tokenizer
         tokens = tokenizer(
-            " ".join(input_schema.inputs),
+            input_schema.inputs,
             add_special_tokens=True,
             return_tensors="np",
             padding=False,
             truncation=False,
         )
-        current_seq_len = len(tokens)
-
-        for pipeline in pipelines:
-            if pipeline.sequence_length > current_seq_len:
-                return pipeline
-        return pipelines[-1]
+        input_seq_len = max(map(len, tokens["input_ids"]))
+        return TransformersPipeline.select_bucket_by_seq_len(input_seq_len, pipelines)
 
     def _remove_1d_mask(
         self, array: numpy.ndarray, mask: numpy.ndarray

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -180,20 +180,12 @@ class TransformersPipeline(Pipeline, Bucketable):
             length. If no pipeline fits the input, the pipeline with the largest
             sequence length is returned
         """
-        # select pipeline with the minimal sequence length to fit the input
-        selected_pipeline = buckets[0]
-        for pipeline in buckets:
-            seq_len = pipeline.sequence_length
-            if input_seq_len <= seq_len < selected_pipeline.sequence_length:
-                selected_pipeline = pipeline
-
-        # if no pipeline fits the input, select the pipeline with maximal length
-        if input_seq_len > selected_pipeline.sequence_length:
-            selected_pipeline = max(
-                buckets, key=lambda pipeline: pipeline.sequence_length
-            )
-
-        return selected_pipeline
+        valid_pipelines = [
+            bucket for bucket in buckets if bucket.sequence_length >= input_seq_len
+        ]
+        if len(valid_pipelines) == 0:
+            return max(buckets, key=lambda bucket: bucket.sequence_length)
+        return min(valid_pipelines, key=lambda bucket: bucket.sequence_length)
 
 
 def pipeline(

--- a/src/deepsparse/transformers/pipelines/question_answering.py
+++ b/src/deepsparse/transformers/pipelines/question_answering.py
@@ -509,8 +509,7 @@ class QuestionAnsweringPipeline(TransformersPipeline):
             padding=False,
             truncation=False,
         )
-
-        input_seq_len = len(tokens)
+        input_seq_len = max(map(len, tokens["input_ids"]))
         return TransformersPipeline.select_bucket_by_seq_len(input_seq_len, pipelines)
 
     def _tokenize(self, example: SquadExample, *args):

--- a/src/deepsparse/transformers/pipelines/text_classification.py
+++ b/src/deepsparse/transformers/pipelines/text_classification.py
@@ -313,5 +313,5 @@ class TextClassificationPipeline(TransformersPipeline):
             padding=False,
             truncation=False,
         )
-        input_seq_len = len(tokens)
+        input_seq_len = max(map(len, tokens["input_ids"]))
         return TransformersPipeline.select_bucket_by_seq_len(input_seq_len, pipelines)

--- a/src/deepsparse/transformers/pipelines/token_classification.py
+++ b/src/deepsparse/transformers/pipelines/token_classification.py
@@ -413,7 +413,7 @@ class TokenClassificationPipeline(TransformersPipeline):
             padding=False,
             truncation=False,
         )
-        input_seq_len = len(tokens)
+        input_seq_len = max(map(len, tokens["input_ids"]))
         return TransformersPipeline.select_bucket_by_seq_len(input_seq_len, pipelines)
 
     # utilities below adapted from transformers

--- a/tests/deepsparse/pipelines/test_bucketing.py
+++ b/tests/deepsparse/pipelines/test_bucketing.py
@@ -1,0 +1,48 @@
+from deepsparse import Pipeline, BucketingPipeline
+import pytest
+from tests.utils import mock_engine
+
+
+@mock_engine(rng_seed=0)
+def test_question_answering_choose_bucket(engine_mock):
+    pipeline20 = Pipeline.create("question_answering", sequence_length=20)
+    pipeline50 = Pipeline.create("question_answering", sequence_length=50)
+
+    pipeline = BucketingPipeline([pipeline20, pipeline50])
+
+    # this should have token length == 14 and should be routed to pipeline20
+    bucket, _ = pipeline._choose_bucket(question="a " * 5, context="b " * 5)
+    assert bucket is pipeline20
+
+    # should should have token length 44, and should be routed to pipeline50
+    bucket, _ = pipeline._choose_bucket(question="a " * 20, context="b " * 20)
+    assert bucket is pipeline50
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        "text_classification",
+        "token_classification",
+        "embedding_extraction",
+        "zero_shot_text_classification",
+    ],
+)
+@mock_engine(rng_seed=0)
+def test_text_choose_bucket(engine_mock, task):
+    pipeline20 = Pipeline.create(task, sequence_length=20)
+    pipeline50 = Pipeline.create(task, sequence_length=50)
+
+    pipeline = BucketingPipeline([pipeline20, pipeline50])
+
+    bucket, _ = pipeline._choose_bucket("a " * 10)
+    assert bucket is pipeline20
+
+    bucket, _ = pipeline._choose_bucket("a " * 35)
+    assert bucket is pipeline50
+
+    bucket, _ = pipeline._choose_bucket(["a " * 10, "a " * 35])
+    assert bucket is pipeline50
+
+    bucket, _ = pipeline._choose_bucket(["a " * 10, "a " * 12])
+    assert bucket is pipeline20

--- a/tests/deepsparse/pipelines/test_bucketing.py
+++ b/tests/deepsparse/pipelines/test_bucketing.py
@@ -1,5 +1,19 @@
-from deepsparse import Pipeline, BucketingPipeline
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
+from deepsparse import BucketingPipeline, Pipeline
 from tests.utils import mock_engine
 
 


### PR DESCRIPTION
Previously transformer models calculated the input sequence length based on the direct output of tokenizers. However the output of tokenizers is a dict that looks like this:
```python
>>> p.tokenizer(["hello", "hello my name is", "test one two three, this is a long one"], add_special_tokens=True, return_tensors="np", padding=False, truncation=False)
{'input_ids': array([list([101, 7592, 102]), list([101, 7592, 2026, 2171, 2003, 102]),
       list([101, 3231, 2028, 2048, 2093, 1010, 2023, 2003, 1037, 2146, 2028, 102])],
      dtype=object), 'token_type_ids': array([list([0, 0, 0]), list([0, 0, 0, 0, 0, 0]),
       list([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])], dtype=object), 'attention_mask': array([list([1, 1, 1]), list([1, 1, 1, 1, 1, 1]),
       list([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])], dtype=object)}
```

This means the sequence length was always being calculated as 3.

This PR changes so it takes the max length of the `input_ids` field from above, where input_ids is a list for each item in the input.

This has been tested using unit tests for single inputs and multiple inputs for all transformer pipelines