### PR TITLE
Using executor in cv pipeline preprocessing

### DIFF
--- a/src/deepsparse/image_classification/pipelines.py
+++ b/src/deepsparse/image_classification/pipelines.py
@@ -151,7 +151,7 @@ class ImageClassificationPipeline(Pipeline):
             if isinstance(inputs.images, str):
                 inputs.images = [inputs.images]
 
-            image_batch = list(self.executor.map(self._preproess_image, inputs.images))
+            image_batch = list(self.executor.map(self._preprocess_image, inputs.images))
 
             # build batch
             image_batch = numpy.stack(image_batch, axis=0)

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -181,22 +181,7 @@ class YOLOPipeline(Pipeline):
         if isinstance(inputs.images, (str, numpy.ndarray)):
             inputs.images = [inputs.images]
 
-        image_batch = []
-
-        for image in inputs.images:
-            if isinstance(image, list):
-                # image consists of floats or ints
-                image = numpy.asarray(image)
-
-            if isinstance(image, str):
-                image = cv2.imread(image)
-
-            image = self._make_channels_last(image)
-            if image.ndim < 4:
-                # Assume a batch is of the correct size already
-                image = cv2.resize(image, dsize=tuple(reversed(self.image_size)))
-            image = self._make_channels_first(image)
-            image_batch.append(image)
+        image_batch = list(self.executor.map(self._preproess_image, inputs.images))
 
         image_batch = self._make_batch(image_batch)
         image_batch = numpy.ascontiguousarray(
@@ -211,6 +196,21 @@ class YOLOPipeline(Pipeline):
             conf_thres=inputs.conf_thres,
         )
         return [image_batch], postprocessing_kwargs
+
+    def _preprocess_image(self, image) -> numpy.ndarray:
+        if isinstance(image, list):
+            # image consists of floats or ints
+            image = numpy.asarray(image)
+
+        if isinstance(image, str):
+            image = cv2.imread(image)
+
+        image = self._make_channels_last(image)
+        if image.ndim < 4:
+            # Assume a batch is of the correct size already
+            image = cv2.resize(image, dsize=tuple(reversed(self.image_size)))
+        image = self._make_channels_first(image)
+        return image
 
     def process_engine_outputs(
         self,

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -181,7 +181,7 @@ class YOLOPipeline(Pipeline):
         if isinstance(inputs.images, (str, numpy.ndarray)):
             inputs.images = [inputs.images]
 
-        image_batch = list(self.executor.map(self._preproess_image, inputs.images))
+        image_batch = list(self.executor.map(self._preprocess_image, inputs.images))
 
         image_batch = self._make_batch(image_batch)
         image_batch = numpy.ascontiguousarray(


### PR DESCRIPTION
As part of #604, preprocessing was moved out of async threadpool execution. This PR changes the CV pipelines (image classification, yolo, yolact), to use `Pipeline.executor` in their preprocessing scripts. This is a performance improvement for static batch, because previously async preprocessing was not done for static batch.

Note: This only makes a difference when the pipelines need to load images. If pipelines receive all numpy arrays, then there is no performance gain when using async preprocessing.
