### PR TITLE
Make YOLACT return masks by default

### DIFF
--- a/src/deepsparse/yolact/schemas.py
+++ b/src/deepsparse/yolact/schemas.py
@@ -69,7 +69,7 @@ class YOLACTInputSchema(ComputerVisionSchema, Splittable):
         "`postprocess` step (optional)",
     )
     return_masks: bool = Field(
-        default=False,
+        default=True,
         description="Controls whether the pipeline should additionally "
         "return segmentation masks",
     )


### PR DESCRIPTION
The user expects to receive masks by default, the code should reflect it. This patch also makes annotation for YOLACT work again.