### PR TITLE
Install server dependencies before running GHA tests

### DIFF
--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
       - name: ⚙️ Install dependencies
-        run: pip3 install .[dev, server] opencv-python
+        run: pip3 install .[dev,server] opencv-python
       - name: Run base tests
         run: make test
   cli-smoke-tests:

--- a/.github/workflows/test-check.yaml
+++ b/.github/workflows/test-check.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: "Clean sparsezoo directory"
         run: rm -r sparsezoo/
       - name: ⚙️ Install dependencies
-        run: pip3 install .[dev] opencv-python
+        run: pip3 install .[dev, server] opencv-python
       - name: Run base tests
         run: make test
   cli-smoke-tests:


### PR DESCRIPTION
Since I and @corey-nm are now working on the server, more and more unit tests start covering this part of the code repository.  For that reason, we need, at least temporarily, also include `server` dependencies when running GHA tests.

This patch essentially accelerates a change that would come from @corey-nm 's inference server v2 PR:
<img width="797" alt="image" src="https://user-images.githubusercontent.com/97082108/187427889-7fc525c9-fd8c-48c9-9c84-4d620ff6fc62.png">

I see this as a temporary fix. I am quite confident that soon we should start treating `server` as a sub-repository of `DeepSparse` and have a separate set of tests for this particular functionality.
