### PR TITLE
Change time.time() -> time.perf_counter() for higher precision

### DIFF
--- a/examples/benchmark/run_benchmark.py
+++ b/examples/benchmark/run_benchmark.py
@@ -130,9 +130,9 @@ def main():
         for i in range(num_warmup_iterations):
             ort_network.run(output_names, inputs_dict)
         for i in range(num_iterations):
-            start = time.time()
+            start = time.perf_counter()
             output = ort_network.run(output_names, inputs_dict)
-            end = time.time()
+            end = time.perf_counter()
             ort_results.append_batch(
                 time_start=start, time_end=end, batch_size=batch_size, outputs=output
             )

--- a/src/deepsparse/benchmark/ort_engine.py
+++ b/src/deepsparse/benchmark/ort_engine.py
@@ -248,9 +248,9 @@ class ORTEngine(object):
             are setup correctly for inference.
         :return: The list of outputs from the model after executing over the inputs
         """
-        start = time.time()
+        start = time.perf_counter()
         out = self.run(inp, val_inp)
-        end = time.time()
+        end = time.perf_counter()
 
         return out, end - start
 

--- a/src/deepsparse/benchmark/stream_benchmark.py
+++ b/src/deepsparse/benchmark/stream_benchmark.py
@@ -26,9 +26,9 @@ __all__ = ["model_stream_benchmark"]
 
 
 def iteration(model: Engine, input: List[numpy.ndarray]):
-    start = time.time()
+    start = time.perf_counter()
     output = model.run(input, val_inp=False)
-    end = time.time()
+    end = time.perf_counter()
     return output, start, end
 
 
@@ -39,8 +39,8 @@ def singlestream_benchmark(
 ) -> List[float]:
     batch_times = []
 
-    stream_end_time = time.time() + seconds_to_run
-    while time.time() < stream_end_time:
+    stream_end_time = time.perf_counter() + seconds_to_run
+    while time.perf_counter() < stream_end_time:
         _, start, end = iteration(model, input_list)
         batch_times.append([start, end])
 
@@ -62,7 +62,7 @@ class EngineExecutorThread(threading.Thread):
         self._max_time = max_time
 
     def run(self):
-        while time.time() < self._max_time:
+        while time.perf_counter() < self._max_time:
             _, start, end = iteration(self._model, self._input_list)
             self._time_queue.put([start, end])
 
@@ -74,7 +74,7 @@ def multistream_benchmark(
     num_streams: int,
 ) -> List[float]:
     time_queue = queue.Queue()
-    max_time = time.time() + seconds_to_run
+    max_time = time.perf_counter() + seconds_to_run
     threads = []
 
     for thread in range(num_streams):

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -370,9 +370,9 @@ class Engine(object):
             are setup correctly for the DeepSparse Engine
         :return: The list of outputs from the model after executing over the inputs
         """
-        start = time.time()
+        start = time.perf_counter()
         out = self.run(inp, val_inp)
-        end = time.time()
+        end = time.perf_counter()
 
         return out, end - start
 
@@ -497,9 +497,9 @@ class Engine(object):
         while completed_iterations < num_warmup_iterations + num_iterations:
             for batch in loader:
                 # run benchmark
-                start = time.time()
+                start = time.perf_counter()
                 out = self.run(batch)
-                end = time.time()
+                end = time.perf_counter()
 
                 if completed_iterations >= num_warmup_iterations:
                     # update results if warmup iterations are completed

--- a/src/deepsparse/utils/annotate.py
+++ b/src/deepsparse/utils/annotate.py
@@ -363,12 +363,12 @@ def annotate(
         original_image = cv2.imread(image)
 
     if target_fps is None and calc_fps:
-        start = time.time()
+        start = time.perf_counter()
 
     pipeline_output = pipeline(images=[image])
 
     if target_fps is None and calc_fps:
-        target_fps = 1 / (time.time() - start)
+        target_fps = 1 / (time.perf_counter() - start)
 
     result = annotation_func(
         image=original_image,

--- a/src/deepsparse/yolo/utils/utils.py
+++ b/src/deepsparse/yolo/utils/utils.py
@@ -181,7 +181,7 @@ def _non_max_suppression(
     multi_label &= nc > 1  # multiple labels per box (adds 0.5ms/img)
     merge = False  # use merge-NMS
 
-    t = time.time()
+    t = time.perf_counter()
     output = [torch.zeros((0, 6), device=prediction.device)] * prediction.shape[0]
     for xi, x in enumerate(prediction):  # image index, image inference
         # Apply constraints
@@ -247,7 +247,7 @@ def _non_max_suppression(
                 i = i[iou.sum(1) > 1]  # require redundancy
 
         output[xi] = x[i]
-        if (time.time() - t) > time_limit:
+        if (time.perf_counter() - t) > time_limit:
             print(f"WARNING: NMS time limit {time_limit}s exceeded")
             break  # time limit exceeded
 


### PR DESCRIPTION
This PR replaces all calls to `time.time()` with calls to `time.perf_counter()`. `perf_counter()` provides a higher resolution time reading by using CPU counter relative time, rather than absolute time since UNIX epoch as is done by `time()`

**Testing**
Covered by existing tests