### PR TITLE
Zscp: Full dynamic batch, remove batch size checks

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -1326,7 +1326,6 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
     ```python
     zero_shot_text_classifier = Pipeline.create(
         task="zero_shot_text_classification",
-        batch_size=3,
         model_scheme="mnli",
         model_config={"hypothesis_template": "This text is related to {}"},
         model_path="mnli_model_dir/",
@@ -1351,12 +1350,8 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
         directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
-    :param batch_size: if static labels are given, then batch_size must be
-        num_sequences * num_labels. Otherwise, batch_size must be 1. Default is 1
-    :param sequence_length: sequence length to compile model and tokenizer for.
-        If a list of lengths is provided, then for each length, a model and
-        tokenizer will be compiled capable of handling that sequence length
-        (also known as a bucket). Default is 128
+    :param batch_size: batch size must divide sequences * labels, regardless of
+        whether using dynamic or static labels. Default is 1
     :param num_cores: number of CPU cores to allocate for inference engine. None
         specifies all available cores. Default is None
     :param scheduler: (deepsparse only) kind of scheduler to execute with.
@@ -1365,6 +1360,10 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
         to use model as-is. Default is None
     :param alias: optional name to give this pipeline instance, useful when
         inferencing with multiple models. Default is None
+    :param sequence_length: sequence length to compile model and tokenizer for.
+        If a list of lengths is provided, then for each length, a model and
+        tokenizer will be compiled capable of handling that sequence length
+        (also known as a bucket). Default is 128
     :param default_model_name: huggingface transformers model name to use to
         load a tokenizer and model config when none are provided in the `model_path`.
         Default is "bert-base-uncased"

--- a/src/deepsparse/transformers/pipelines/mnli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/mnli_text_classification.py
@@ -112,6 +112,18 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
         self._config = self.parse_config(model_config)
         self._labels = self.parse_labels(labels)
 
+        if (
+            self._config.hypothesis_template is not None
+            and self._config.hypothesis_template.format("sample_label")
+            == self._config.hypothesis_template
+        ):
+            raise ValueError(
+                "The provided hypothesis_template "
+                f"`{self._config.hypothesis_template}` was not able to be formatted. "
+                "Make sure the passed template includes formatting syntax such "
+                "as `{}` where the label should go."
+            )
+
         if self._config.entailment_index == self._config.contradiction_index:
             raise ValueError("entailment_index must differ from contradiction_index")
 

--- a/src/deepsparse/transformers/pipelines/mnli_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/mnli_text_classification.py
@@ -105,37 +105,12 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
     def __init__(
         self,
         model_path: str,
-        batch_size: int = 1,
         model_config: Optional[Union[MnliTextClassificationConfig, dict]] = None,
         labels: Optional[List] = None,
         **kwargs,
     ):
         self._config = self.parse_config(model_config)
         self._labels = self.parse_labels(labels)
-
-        if self._labels and batch_size % len(self._labels) != 0:
-            raise ValueError(
-                f"if static labels are provided then batch_size {batch_size} must "
-                f"be divisible by the number of labels {len(self._labels)}"
-            )
-
-        # will add support for batch_size == None when dynamic batch lands
-        if not self._labels and batch_size != 1:
-            raise ValueError(
-                "if no static labels are provided then batch_size must be set to 1"
-            )
-
-        if (
-            self._config.hypothesis_template is not None
-            and self._config.hypothesis_template.format("sample_label")
-            == self._config.hypothesis_template
-        ):
-            raise ValueError(
-                "The provided hypothesis_template "
-                f"`{self._config.hypothesis_template}` was not able to be formatted. "
-                "Make sure the passed template includes formatting syntax such "
-                "as `{}` where the label should go."
-            )
 
         if self._config.entailment_index == self._config.contradiction_index:
             raise ValueError("entailment_index must differ from contradiction_index")
@@ -146,7 +121,6 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
         if self._config.contradiction_index > 2:
             raise ValueError("contradiction_index must be less than or equal to 2")
 
-        kwargs.update({"batch_size": batch_size})
         super().__init__(model_path=model_path, **kwargs)
 
     @property
@@ -201,12 +175,12 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
                 "must provide only one"
             )
 
-        # check for correct size if static labels
-        if self._labels and len(sequences) != self._batch_size // len(self._labels):
+        # check batch size divides sequences * labels
+        if (len(labels) * len(sequences)) % self._batch_size != 0:
             raise ValueError(
-                "If static labels are provided, then the number of sequences "
-                f"{len(sequences)} must match batch_size divided by the number of "
-                f"labels {self._batch_size // len(self._labels)}"
+                "The number of sequences times the number of labels "
+                f"({len(labels) * len(sequences)}) must be divisible by batch_size "
+                f"{self._batch_size}"
             )
 
         # check for invalid hypothesis template
@@ -229,9 +203,8 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
             add_special_tokens=True,
             return_tensors="np",
             padding=PaddingStrategy.MAX_LENGTH.value,
-            # tokenize only_first so that hypothesis (label) is not truncated
             truncation=TruncationStrategy.ONLY_FIRST.value,
-        )
+        )  # tokenize only_first so that hypothesis (label) is not truncated
 
         postprocessing_kwargs = dict(
             sequences=inputs.sequences,  # do not include list wrapping
@@ -240,23 +213,6 @@ class MnliTextClassificationPipeline(ZeroShotTextClassificationPipelineBase):
         )
 
         return self.tokens_to_engine_input(tokens), postprocessing_kwargs
-
-    def engine_forward(self, engine_inputs: List[numpy.ndarray]) -> List[numpy.ndarray]:
-        """
-        :param engine_inputs: list of numpy inputs to Pipeline engine forward pass
-        :return: result of forward pass to Pipeline engine
-        """
-        engine_inputs_numpy = numpy.array(engine_inputs)
-        if self._labels is None:
-            engine_outputs = []
-            for sample_i in range(engine_inputs_numpy.shape[1]):
-                engine_input = engine_inputs_numpy[:, sample_i : (sample_i + 1), :]
-                engine_input = [input for input in engine_input]
-                engine_output = self.engine(engine_input)
-                engine_outputs.append(engine_output)
-            return engine_outputs
-        else:
-            return self.engine(engine_inputs)
 
     def process_engine_outputs(
         self,

--- a/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
@@ -128,7 +128,6 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
     ```python
     zero_shot_text_classifier = Pipeline.create(
         task="zero_shot_text_classification",
-        batch_size=3,
         model_scheme="mnli",
         model_config={"hypothesis_template": "This text is related to {}"},
         model_path="mnli_model_dir/",
@@ -149,14 +148,12 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
     Note that if a hypothesis_template is provided at inference time, then it
     will override the value provided during model instantiation
 
-    :param model_path: sparsezoo stub to a transformers model, an ONNX file, or
-        (preferred) a directory containing a model.onnx, tokenizer config, and model
-        config. If no tokenizer and/or model config(s) are found, then they will be
-        loaded from huggingface transformers using the `default_model_name` key
+    :param model_path: sparsezoo stub to a transformers model or (preferred) a
+        directory containing a model.onnx, tokenizer config, and model config
     :param engine_type: inference engine to use. Currently supported values include
         'deepsparse' and 'onnxruntime'. Default is 'deepsparse'
-    :param batch_size: if static labels are given, then batch_size must be
-        num_sequences * num_labels. Otherwise, batch_size must be 1. Default is 1
+    :param batch_size: batch size must divide sequences * labels, regardless of
+        whether using dynamic or static labels. Default is 1
     :param num_cores: number of CPU cores to allocate for inference engine. None
         specifies all available cores. Default is None
     :param scheduler: (deepsparse only) kind of scheduler to execute with.

--- a/tests/deepsparse/transformers/pipelines/test_mnli_text_classification.py
+++ b/tests/deepsparse/transformers/pipelines/test_mnli_text_classification.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import suppress as do_not_raise
+
+import pytest
+from deepsparse import Pipeline
+from tests.utils import mock_engine
+
+
+@pytest.fixture(scope="session")
+def model_stub():
+    return (
+        "zoo:nlp/text_classification/distilbert-none/pytorch/huggingface/"
+        "mnli/pruned80_quant-none-vnni"
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "batch_size,num_static_labels,num_sequences,num_labels,"
+        "creation_expectation,inference_expectation"
+    ),
+    [
+        (None, 1, 1, 1, do_not_raise(), pytest.raises(ValueError)),
+        (None, 1, 1, None, do_not_raise(), do_not_raise()),
+        (1, 1, 1, 1, do_not_raise(), pytest.raises(ValueError)),
+        (1, 1, 1, None, do_not_raise(), do_not_raise()),
+        (7, 13, 7, None, do_not_raise(), do_not_raise()),
+        (13, None, 7, 13, do_not_raise(), do_not_raise()),
+        (2, 13, 7, None, do_not_raise(), pytest.raises(ValueError)),
+        (2, None, 7, 13, do_not_raise(), pytest.raises(ValueError)),
+    ],
+)
+@pytest.mark.smoke
+@mock_engine(rng_seed=0)
+def test_zscp_pipeline(
+    engine,
+    batch_size,
+    num_static_labels,
+    num_sequences,
+    num_labels,
+    creation_expectation,
+    inference_expectation,
+    model_stub,
+):
+    static_labels = _generate_texts(num_static_labels)
+    sequences = _generate_texts(num_sequences)
+    labels = _generate_texts(num_labels)
+
+    with creation_expectation:
+        pipeline = Pipeline.create(
+            "zero_shot_text_classification",
+            model_path=model_stub,
+            batch_size=batch_size,
+            labels=static_labels,
+        )
+
+    with inference_expectation:
+        pipeline(sequences=sequences, labels=labels)
+
+
+def _generate_texts(num_texts):
+    return ["sample_text"] * num_texts if num_texts else None


### PR DESCRIPTION
This PR updates the zscp pipeline to account for new [dynamic batch](https://github.com/neuralmagic/deepsparse/pull/604). This includes
* Removing now unnecessarily error checks that constrain acceptable batch sizes
* Removing engine_forward logic that groups inferences by label
* Adding a check for divisible batch sizes (a little redundant given that the pipeline base class has a similar error, but this one makes it explicitly clear that the number of samples is the product of num_labels and num_sequences
* Adding tests to check correct pipeline instantiation

I've validated using the aformentioned tests as well as `eval_downstream` on sst2.

``` bash
deepsparse.transformers.eval_downstream zoo:nlp/text_classification/bert-base/pytorch/huggingface/mnli/12layer_pruned90-none -d sst2 --zero-shot True
```
sst2_zero_shot eval results: {'accuracy': 0.7798165137614679}
Expected: 0.779 (https://github.com/neuralmagic/deepsparse/pull/369)
