### PR TITLE
deepsparse.license script - add commercial license file from jwt token

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -237,6 +237,7 @@ def _setup_entry_points() -> Dict:
             "deepsparse.image_classification.annotate=deepsparse.image_classification.annotate:main",  # noqa E501
             "deepsparse.instance_segmentation.annotate=deepsparse.yolact.annotate:main",
             f"deepsparse.image_classification.eval={ic_eval}",
+            "deepsparse.license=deepsparse.license::main",
         ]
     }
 

--- a/setup.py
+++ b/setup.py
@@ -237,7 +237,7 @@ def _setup_entry_points() -> Dict:
             "deepsparse.image_classification.annotate=deepsparse.image_classification.annotate:main",  # noqa E501
             "deepsparse.instance_segmentation.annotate=deepsparse.yolact.annotate:main",
             f"deepsparse.image_classification.eval={ic_eval}",
-            "deepsparse.license=deepsparse.license::main",
+            "deepsparse.license=deepsparse.license:main",
         ]
     }
 

--- a/src/deepsparse/lib.py
+++ b/src/deepsparse/lib.py
@@ -27,11 +27,21 @@ except ImportError:
 CORES_PER_SOCKET, AVX_TYPE, VNNI = cpu_details()
 
 
+__all__ = [
+    "get_neuralmagic_binaries_dir",
+    "init_deepsparse_lib",
+]
+
+
+def get_neuralmagic_binaries_dir():
+    nm_package_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(nm_package_dir, AVX_TYPE)
+
+
 def init_deepsparse_lib():
     try:
-        nm_package_dir = os.path.dirname(os.path.abspath(__file__))
         onnxruntime_neuralmagic_so_path = os.path.join(
-            nm_package_dir, AVX_TYPE, "deepsparse_engine.so"
+            get_neuralmagic_binaries_dir(), "deepsparse_engine.so"
         )
         spec = importlib.util.spec_from_file_location(
             "deepsparse.{}.deepsparse_engine".format(AVX_TYPE),

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -19,6 +19,11 @@ Usage: deepsparse.license [OPTIONS] TOKEN_OR_PATH
   Validates a token for a DeepSparse enterprise license and creates a token
   file to be read for future use
 
+  Token file by default will be written to license.txt in
+  ~/.config/neuralmagic. This directory may be overwritten by setting the
+  NM_CONFIG_DIR environment variable - this variable should then be set as
+  well in any subsequent uses of the deepsparse engine
+
   TOKEN_OR_PATH raw token or path to a text file containing one
 
 Options:
@@ -88,6 +93,11 @@ def main(token_or_path: str):
     """
     Validates a token for a DeepSparse enterprise license and creates
     a token file to be read for future use
+
+    Token file by default will be written to license.txt in
+    ~/.config/neuralmagic. This directory may be overwritten by setting
+    the NM_CONFIG_DIR environment variable - this variable should then
+    be set as well in any subsequent uses of the deepsparse engine
 
     TOKEN_OR_PATH raw token or path to a text file containing one
     """

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -28,6 +28,7 @@ Options:
 
 import logging
 import os
+import sys
 
 import click
 
@@ -45,7 +46,8 @@ def add_deepsparse_license(token_or_path):
         with open(token_or_path) as token_file:
             token = token_file.read()
 
-    _validate_token(token)
+    _validate_license(token)
+    _LOGGER.info("DeepSparse license successfully validated")
 
     # write to {LICENSE_FILE} in same directory as NM engine binaries
     license_file_path = os.path.join(get_neuralmagic_binaries_dir(), LICENSE_FILE)
@@ -55,12 +57,16 @@ def add_deepsparse_license(token_or_path):
     _LOGGER.info(f"DeepSparse license file written to {license_file_path}")
 
 
-def _validate_token(token):
+def _validate_license(token):
     deepsparse_lib = init_deepsparse_lib()
 
     # nothing happens if token is valid
     # if token is invalid, deepsparse_lib will raise appropriate error response
-    deepsparse_lib.validate_token(token)
+    try:
+        deepsparse_lib.validate_license(token)
+    except RuntimeError:
+        # deepsparse_lib handles error messaging, exit after message
+        sys.exit(0)
 
 
 @click.command()

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -84,6 +84,10 @@ def _get_license_file_path():
     # license file written to NM_CONFIG_DIR env var under license.txt
     # defaults to ~/.config/neuralmagic
     config_dir = os.environ.get(NM_CONFIG_DIR, DEFAULT_CONFIG_DIR)
+
+    if not os.path.exists(config_dir):
+        os.makedirs(config_dir)
+
     return os.path.join(config_dir, LICENSE_FILE)
 
 

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Usage: deepsparse.license [OPTIONS] TOKEN_OR_PATH
+
+  Validates a token for a DeepSparse enterprise license and creates a token
+  file to be read for future use
+
+  TOKEN_OR_PATH raw token or path to a text file containing one
+
+Options:
+  --help  Show this message and exit.
+"""
+
+
+import logging
+import os
+
+import click
+
+from deepsparse.lib import get_neuralmagic_binaries_dir
+
+
+LICENSE_FILE = "license.txt"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def add_deepsparse_license(token_or_path):
+    token = token_or_path
+    if os.path.exists(token_or_path):
+        with open(token_or_path) as token_file:
+            token = token_file.read()
+
+    _validate_token(token)
+
+    # write to {LICENSE_FILE} in same directory as NM engine binaries
+    license_file_path = os.path.join(get_neuralmagic_binaries_dir(), LICENSE_FILE)
+    with open(license_file_path, "w") as license_file:
+        license_file.write(token)
+
+    _LOGGER.info(f"DeepSparse license file written to {license_file_path}")
+
+
+def _validate_token(token):
+    if not token:  # TODO: propagate validation from engine
+        raise ValueError(
+            "Sorry, it does not seem as if you have an active "
+            "enterprise license for DeepSparse. If you believe "
+            "this is a mistake, please reach out to license@neuralmagic.com "
+            "for help."
+        )
+
+
+@click.command()
+@click.argument("token_or_path", type=str)
+def main(token_or_path: str):
+    """
+    Validates a token for a DeepSparse enterprise license and creates
+    a token file to be read for future use
+
+    TOKEN_OR_PATH raw token or path to a text file containing one
+    """
+    add_deepsparse_license(token_or_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -84,9 +84,7 @@ def _get_license_file_path():
     # license file written to NM_CONFIG_DIR env var under license.txt
     # defaults to ~/.config/neuralmagic
     config_dir = os.environ.get(NM_CONFIG_DIR, DEFAULT_CONFIG_DIR)
-
-    if not os.path.exists(config_dir):
-        os.makedirs(config_dir)
+    os.makedirs(config_dir, exist_ok=True)
 
     return os.path.join(config_dir, LICENSE_FILE)
 

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -31,7 +31,7 @@ import os
 
 import click
 
-from deepsparse.lib import get_neuralmagic_binaries_dir
+from deepsparse.lib import get_neuralmagic_binaries_dir, init_deepsparse_lib
 
 
 LICENSE_FILE = "license.txt"
@@ -56,13 +56,11 @@ def add_deepsparse_license(token_or_path):
 
 
 def _validate_token(token):
-    if not token:  # TODO: propagate validation from engine
-        raise ValueError(
-            "Sorry, it does not seem as if you have an active "
-            "enterprise license for DeepSparse. If you believe "
-            "this is a mistake, please reach out to license@neuralmagic.com "
-            "for help."
-        )
+    deepsparse_lib = init_deepsparse_lib()
+
+    # nothing happens if token is valid
+    # if token is invalid, deepsparse_lib will raise appropriate error response
+    deepsparse_lib.validate_token(token)
 
 
 @click.command()

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -58,6 +58,10 @@ def add_deepsparse_license(token_or_path):
     license_file_path = os.path.join(get_neuralmagic_binaries_dir(), LICENSE_FILE)
     shutil.copy(candidate_license_file_path, license_file_path)
     _LOGGER.info(f"DeepSparse license file written to {license_file_path}")
+    _LOGGER.info(
+        "To run DeepSparse in enterprise mode, run the following command "
+        f"`export NM_LICENSE={license_file_path}`"
+    )
 
 
 def _validate_license(token):

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -30,13 +30,16 @@ import logging
 import os
 import shutil
 import sys
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import click
 
-from deepsparse.lib import get_neuralmagic_binaries_dir, init_deepsparse_lib
+from deepsparse.lib import init_deepsparse_lib
 
 
+NM_CONFIG_DIR = "NM_CONFIG_DIR"
+DEFAULT_CONFIG_DIR = os.path.join(Path.home(), ".config", "neuralmagic")
 LICENSE_FILE = "license.txt"
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,13 +58,9 @@ def add_deepsparse_license(token_or_path):
     _LOGGER.info("DeepSparse license successfully validated")
 
     # copy candidate file to {LICENSE_FILE} in same directory as NM engine binaries
-    license_file_path = os.path.join(get_neuralmagic_binaries_dir(), LICENSE_FILE)
+    license_file_path = _get_license_file_path()
     shutil.copy(candidate_license_file_path, license_file_path)
     _LOGGER.info(f"DeepSparse license file written to {license_file_path}")
-    _LOGGER.info(
-        "To run DeepSparse in enterprise mode, run the following command "
-        f"`export NM_LICENSE={license_file_path}`"
-    )
 
 
 def _validate_license(token):
@@ -74,6 +73,13 @@ def _validate_license(token):
     except RuntimeError:
         # deepsparse_lib handles error messaging, exit after message
         sys.exit(0)
+
+
+def _get_license_file_path():
+    # license file written to NM_CONFIG_DIR env var under license.txt
+    # defaults to ~/.config/neuralmagic
+    config_dir = os.environ.get(NM_CONFIG_DIR, DEFAULT_CONFIG_DIR)
+    return os.path.join(config_dir, LICENSE_FILE)
 
 
 @click.command()


### PR DESCRIPTION
script for validating a deepsparse commercial license

documentation included in #647

tested by @tlrmchlsmth  - valid license write to default config dir, invalid license errors out, valid license write to env var overwritten config dir, `compile_model` splash message displays enterprise info for valid written license

**example success**
```bash
$ deepsparse.license valid-license.txt
2022-09-15 10:30:08 __main__     INFO     DeepSparse license successfully validated
2022-09-15 10:30:08 __main__     INFO     DeepSparse license file written to /home/benjamin/.config/neuralmagic/license.txt
```

we verify that enterprise edition is enabled with the splash message below:
```python
>>> from deepsparse import image_classification_pipeline
>>> pipeline = image_classification_pipeline()
DeepSparse Engine, Copyright 2021-present / Neuralmagic, Inc. version: 1.2.0.20220913 ENTERPRISE EDITION (9ec6f6de) (release) (optimized) (system=avx512, binary=avx512) | licensed to tyler by Neural Magic, Inc. for 128 Cores | Exp: 2023-01-08, 00:00:00 UTC
```

**example failure**
```bash
$ deepsparse.license invalid-license.txt
Error: 1110
Sorry, your enterprise license for DeepSparse cannot be validated. If you believe this is a mistake, please make sure your license key string or path_to_license is correct.

Please reach out to license@neuralmagic.com for help.
```