### PR TITLE
Adding kwargs into EndpointConfig

### DIFF
--- a/src/deepsparse/server/config.py
+++ b/src/deepsparse/server/config.py
@@ -84,8 +84,14 @@ class EndpointConfig(BaseModel):
         ),
     )
 
+    kwargs: Dict[str, Any] = Field(
+        default={}, description="Additional arguments to pass to the Pipeline"
+    )
+
     def to_pipeline_config(self) -> PipelineConfig:
         input_shapes, kwargs = _unpack_bucketing(self.task, self.bucketing)
+
+        kwargs.update(self.kwargs)
 
         return PipelineConfig(
             task=self.task,


### PR DESCRIPTION
This was missing from the new EndpointConfig. The kwargs are basically just passed to PipelineConfig.kwargs