### PR TITLE
Removing predictions from YOLOOutput

### DIFF
--- a/src/deepsparse/yolo/README.md
+++ b/src/deepsparse/yolo/README.md
@@ -134,7 +134,7 @@ path = ['basilica.jpg'] # list of images for inference
 files = [('request', open(img, 'rb')) for img in path]
 resp = requests.post(url=url, files=files)
 annotations = json.loads(resp.text) # dictionary of annotation results
-bounding_boxes = annotations["predictions"]
+bounding_boxes = annotations["boxes"]
 labels = annotations["labels"]
 ```
 

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -239,10 +239,9 @@ class YOLOPipeline(Pipeline):
             conf_thres=kwargs.get("conf_thres", 0.45),
         )
 
-        batch_predictions, batch_boxes, batch_scores, batch_labels = [], [], [], []
+        batch_boxes, batch_scores, batch_labels = [], [], []
 
         for image_output in batch_output:
-            batch_predictions.append(image_output.tolist())
             batch_boxes.append(image_output[:, 0:4].tolist())
             batch_scores.append(image_output[:, 4].tolist())
             batch_labels.append(image_output[:, 5].tolist())
@@ -257,7 +256,6 @@ class YOLOPipeline(Pipeline):
                 batch_labels[-1] = batch_class_names
 
         return YOLOOutput(
-            predictions=batch_predictions,
             boxes=batch_boxes,
             scores=batch_scores,
             labels=batch_labels,

--- a/src/deepsparse/yolo/schemas.py
+++ b/src/deepsparse/yolo/schemas.py
@@ -30,9 +30,7 @@ __all__ = [
     "YOLOInput",
 ]
 
-_YOLOImageOutput = namedtuple(
-    "_YOLOImageOutput", ["predictions", "boxes", "scores", "labels"]
-)
+_YOLOImageOutput = namedtuple("_YOLOImageOutput", ["boxes", "scores", "labels"])
 
 
 class YOLOInput(ComputerVisionSchema):

--- a/src/deepsparse/yolo/schemas.py
+++ b/src/deepsparse/yolo/schemas.py
@@ -55,7 +55,6 @@ class YOLOOutput(BaseModel):
     Output model for object detection
     """
 
-    predictions: List[List[List[float]]] = Field(description="List of predictions")
     boxes: List[List[List[float]]] = Field(
         description="List of bounding boxes, one for each prediction"
     )
@@ -67,16 +66,15 @@ class YOLOOutput(BaseModel):
     )
 
     def __getitem__(self, index):
-        if index >= len(self.predictions):
+        if index >= len(self.boxes):
             raise IndexError("Index out of range")
 
         return _YOLOImageOutput(
-            self.predictions[index],
             self.boxes[index],
             self.scores[index],
             self.labels[index],
         )
 
     def __iter__(self):
-        for index in range(len(self.predictions)):
+        for index in range(len(self.boxes)):
             yield self[index]


### PR DESCRIPTION
This field just contains what all the other fields in the output contains, so its very redundant. 

Unit tested and searched codebase for any use of "predictions"