### PR TITLE
Adding thread pinning and torch.set_num_threads to ServerConfig

### DIFF
--- a/src/deepsparse/server/config.py
+++ b/src/deepsparse/server/config.py
@@ -120,16 +120,19 @@ class ServerConfig(BaseModel):
         description="The kind of integration to use. local|sagemaker",
     )
 
-    engine_thread_pinning: bool = Field(
-        default=True,
-        description="Whether to pin engine threads to cores.",
+    engine_thread_pinning: str = Field(
+        default="core",
+        description=(
+            "Enable binding threads to cores ('core' the default), "
+            "threads to cores on sockets ('numa'), or disable ('none')"
+        ),
     )
 
     pytorch_num_threads: Optional[int] = Field(
         default=1,
         description=(
-            "Configures number of threads that pytorch is allowed to use. "
-            "Useful to reduce resource contention. "
+            "Configures number of threads that pytorch is allowed to use during"
+            "pre and post-processing. Useful to reduce resource contention. "
             "Set to `None` to place no restrictions on pytorch."
         ),
     )

--- a/src/deepsparse/server/config.py
+++ b/src/deepsparse/server/config.py
@@ -120,6 +120,20 @@ class ServerConfig(BaseModel):
         description="The kind of integration to use. local|sagemaker",
     )
 
+    engine_thread_pinning: bool = Field(
+        default=True,
+        description="Whether to pin engine threads to cores.",
+    )
+
+    pytorch_num_threads: Optional[int] = Field(
+        default=1,
+        description=(
+            "Configures number of threads that pytorch is allowed to use. "
+            "Useful to reduce resource contention. "
+            "Set to `None` to place no restrictions on pytorch."
+        ),
+    )
+
     endpoints: List[EndpointConfig] = Field(description="The models to serve.")
 
 

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -168,28 +168,25 @@ def _set_pytorch_num_threads(server_config: ServerConfig):
 
 
 _CORES = "NM_BIND_THREADS_TO_CORES"
-_SOCKETS = "NM_BIND_THREADS_TO_SOCKETS"
+_SOCKS = "NM_BIND_THREADS_TO_SOCKETS"
 
 
 def _set_thread_pinning(server_config: ServerConfig):
-    if server_config.engine_thread_pinning == "core":
-        os.environ[_CORES] = "1"
-        os.environ[_SOCKETS] = "0"
-    elif server_config.engine_thread_pinning == "numa":
-        os.environ[_CORES] = "0"
-        os.environ[_SOCKETS] = "1"
-    elif server_config.engine_thread_pinning == "none":
-        os.environ[_CORES] = "0"
-        os.environ[_SOCKETS] = "0"
-    else:
+    pinning = {"core": ("1", "0"), "numa": ("0", "1"), "none": ("0", "0")}
+
+    if server_config.engine_thread_pinning not in pinning:
         raise ValueError(
             "Invalid value for engine_thread_pinning. "
             'Expected one of {"core","numa","none"}. Found '
             f"{server_config.engine_thread_pinning}"
         )
 
+    os.environ[_CORES], os.environ[_SOCKS] = pinning[
+        server_config.engine_thread_pinning
+    ]
+
     _LOGGER.info(f"{_CORES} {os.environ[_CORES]}")
-    _LOGGER.info(f"{_SOCKETS} {os.environ[_SOCKETS]}")
+    _LOGGER.info(f"{_SOCKS} {os.environ[_SOCKS]}")
 
 
 def _add_endpoint(

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -177,16 +177,12 @@ def _set_thread_pinning(server_config: ServerConfig):
             f"{server_config.engine_thread_pinning}"
         )
 
-    # environment variable names
-    _CORES = "NM_BIND_THREADS_TO_CORES"
-    _SOCKS = "NM_BIND_THREADS_TO_SOCKETS"
+    cores, socks = pinning[server_config.engine_thread_pinning]
+    os.environ["NM_BIND_THREADS_TO_CORES"] = cores
+    os.environ["NM_BIND_THREADS_TO_SOCKETS"] = socks
 
-    os.environ[_CORES], os.environ[_SOCKS] = pinning[
-        server_config.engine_thread_pinning
-    ]
-
-    _LOGGER.info(f"{_CORES} {os.environ[_CORES]}")
-    _LOGGER.info(f"{_SOCKS} {os.environ[_SOCKS]}")
+    _LOGGER.info(f"NM_BIND_THREADS_TO_CORES={cores}")
+    _LOGGER.info(f"NM_BIND_THREADS_TO_SOCKETS={socks}")
 
 
 def _add_endpoint(

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -62,21 +62,6 @@ def start_server(
     server_config = ServerConfig(**obj)
     _LOGGER.info(f"Using config: {repr(server_config)}")
 
-    if server_config.pytorch_num_threads is not None:
-        try:
-            import torch
-
-            torch.set_num_threads(server_config.pytorch_num_threads)
-            _LOGGER.info(f"torch.set_num_threads({server_config.pytorch_num_threads})")
-        except ImportError:
-            _LOGGER.debug(
-                "pytorch not installed, skipping pytorch_num_threads configuration"
-            )
-
-    if server_config.engine_thread_pinning:
-        os.environ["NM_BIND_THREADS_TO_CORES"] = "1"
-        _LOGGER.info("NM_BIND_THREADS_TO_CORES=1")
-
     app = _build_app(server_config)
 
     uvicorn.run(
@@ -108,6 +93,21 @@ def _build_app(server_config: ServerConfig) -> FastAPI:
             f"Unknown integration field {server_config.integration}. "
             f"Expected one of {INTEGRATIONS}"
         )
+
+    if server_config.pytorch_num_threads is not None:
+        try:
+            import torch
+
+            torch.set_num_threads(server_config.pytorch_num_threads)
+            _LOGGER.info(f"torch.set_num_threads({server_config.pytorch_num_threads})")
+        except ImportError:
+            _LOGGER.debug(
+                "pytorch not installed, skipping pytorch_num_threads configuration"
+            )
+
+    if server_config.engine_thread_pinning:
+        os.environ["NM_BIND_THREADS_TO_CORES"] = "1"
+        _LOGGER.info("NM_BIND_THREADS_TO_CORES=1")
 
     context = Context(
         num_cores=server_config.num_cores,

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -167,10 +167,6 @@ def _set_pytorch_num_threads(server_config: ServerConfig):
             )
 
 
-_CORES = "NM_BIND_THREADS_TO_CORES"
-_SOCKS = "NM_BIND_THREADS_TO_SOCKETS"
-
-
 def _set_thread_pinning(server_config: ServerConfig):
     pinning = {"core": ("1", "0"), "numa": ("0", "1"), "none": ("0", "0")}
 
@@ -180,6 +176,10 @@ def _set_thread_pinning(server_config: ServerConfig):
             'Expected one of {"core","numa","none"}. Found '
             f"{server_config.engine_thread_pinning}"
         )
+
+    # environment variable names
+    _CORES = "NM_BIND_THREADS_TO_CORES"
+    _SOCKS = "NM_BIND_THREADS_TO_SOCKETS"
 
     os.environ[_CORES], os.environ[_SOCKS] = pinning[
         server_config.engine_thread_pinning

--- a/tests/server/test_endpoints.py
+++ b/tests/server/test_endpoints.py
@@ -298,25 +298,18 @@ def test_dynamic_add_and_remove_endpoint(engine_mock):
 
 
 def test_pytorch_num_threads():
-    try:
-        import torch
+    torch = pytest.importorskip("torch")
 
-        orig_num_threads = torch.get_num_threads()
-        _build_app(
-            ServerConfig(
-                num_cores=1, num_workers=1, pytorch_num_threads=None, endpoints=[]
-            )
-        )
-        assert torch.get_num_threads() == orig_num_threads
+    orig_num_threads = torch.get_num_threads()
+    _build_app(
+        ServerConfig(num_cores=1, num_workers=1, pytorch_num_threads=None, endpoints=[])
+    )
+    assert torch.get_num_threads() == orig_num_threads
 
-        _build_app(
-            ServerConfig(
-                num_cores=1, num_workers=1, pytorch_num_threads=1, endpoints=[]
-            )
-        )
-        assert torch.get_num_threads() == 1
-    except ImportError:
-        ...
+    _build_app(
+        ServerConfig(num_cores=1, num_workers=1, pytorch_num_threads=1, endpoints=[])
+    )
+    assert torch.get_num_threads() == 1
 
 
 @patch.dict(os.environ, deepcopy(os.environ))


### PR DESCRIPTION
Both of these values are very useful to tuning server performance. torch.set_num_threads(1) is a good default to make sure torch isn't contending with engine. threading pinning to cores for engine is enabled by default as well.

Tested with unit tests.