### PR TITLE
[deepsparse.server] utility functions for instantiating loggers

### DIFF
--- a/src/deepsparse/loggers/prometheus_logger.py
+++ b/src/deepsparse/loggers/prometheus_logger.py
@@ -64,6 +64,13 @@ class PrometheusLogger(BaseLogger):
 
         super().__init__()
 
+    def __str__(self):
+        return (
+            f"{self.__class__.__name__}(port={self.port}, text_log_save_dir="
+            f"{self.text_log_save_dir}, text_log_save_freq={self.text_log_save_freq}, "
+            f"text_log_file_name={self.text_log_file_name})"
+        )
+
     @property
     def identifier(self) -> str:
         return "prometheus"

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -39,7 +39,9 @@ def default_logger_manager() -> ManagerLogger:
     :return: default ManagerLogger object for the deployment scenario
     """
     # always return prometheus logger for now
-    return ManagerLogger(PrometheusLogger())
+    logger = PrometheusLogger()
+    _LOGGER.info(f"Created default logger {logger}")
+    return ManagerLogger(logger)
 
 
 def logger_manager_from_config(config_path: str) -> ManagerLogger:

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helper functions for deepsparse.server
+"""
+
+
+import logging
+
+import yaml
+
+from deepsparse.loggers import ManagerLogger, PrometheusLogger
+
+
+__all__ = [
+    "default_logger_manager",
+    "logger_manager_from_config",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+_SUPPORTED_LOGGERS = {"prometheus": PrometheusLogger}
+
+
+def default_logger_manager() -> ManagerLogger:
+    """
+    :return: default ManagerLogger object for the deployment scenario
+    """
+    # always return prometheus logger for now
+    return ManagerLogger(PrometheusLogger())
+
+
+def logger_manager_from_config(config_path: str) -> ManagerLogger:
+    """
+    Initializes a ManagerLogger from loggers defined by a yaml config file
+
+    Config should be a logger integration name, followed by its initialization
+    kwargs as a dict
+
+    supported logger integrations:
+    ["prometheus"]
+
+    example config:
+
+    ```yaml
+    prometheus:
+        port: 8001
+        text_log_save_dir: /home/deepsparse-server/prometheus
+        text_log_save_freq: 30
+    ```
+
+    :param config_path: path to YAML config file
+    :return: constructed ManagerLogger object
+    """
+    with open(config_path) as config:
+        loggers_config = yaml.safe_load(config)
+
+    if not isinstance(loggers_config, dict):
+        raise ValueError(
+            "Loggers config must be a yaml dict, loaded object of "
+            f"type {type(loggers_config)}"
+        )
+
+    loggers = []
+
+    for integration, logger_kwargs in loggers_config.items():
+        logger_class = _SUPPORTED_LOGGERS.get(integration.lower())
+        if logger_class is None:
+            raise ValueError(
+                f"Unknown logger integration {integration}. Supported integrations: "
+                f"{list(_SUPPORTED_LOGGERS)}"
+            )
+        logger = logger_class(**logger_kwargs)
+        _LOGGER.info(f"Created logger {logger}")
+        loggers.append(logger)
+
+    return ManagerLogger(loggers=loggers)

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -18,6 +18,7 @@ Helper functions for deepsparse.server
 
 
 import logging
+from typing import Any, Dict, Union
 
 import yaml
 
@@ -44,9 +45,12 @@ def default_logger_manager() -> ManagerLogger:
     return ManagerLogger(logger)
 
 
-def logger_manager_from_config(config_path: str) -> ManagerLogger:
+def logger_manager_from_config(
+    config: Union[str, Dict[str, Dict[str, Any]]]
+) -> ManagerLogger:
     """
     Initializes a ManagerLogger from loggers defined by a yaml config file
+    or loaded dictionary
 
     Config should be a logger integration name, followed by its initialization
     kwargs as a dict
@@ -63,21 +67,22 @@ def logger_manager_from_config(config_path: str) -> ManagerLogger:
         text_log_save_freq: 30
     ```
 
-    :param config_path: path to YAML config file
+    :param config: path to YAML config file or dictionary config
     :return: constructed ManagerLogger object
     """
-    with open(config_path) as config:
-        loggers_config = yaml.safe_load(config)
+    if isinstance(config, str):
+        with open(config) as config_reader:
+            config = yaml.safe_load(config_reader)
 
-    if not isinstance(loggers_config, dict):
-        raise ValueError(
-            "Loggers config must be a yaml dict, loaded object of "
-            f"type {type(loggers_config)}"
-        )
+        if not isinstance(config, dict):
+            raise ValueError(
+                "Loggers config must be a yaml dict, loaded object of "
+                f"type {type(config)}"
+            )
 
     loggers = []
 
-    for integration, logger_kwargs in loggers_config.items():
+    for integration, logger_kwargs in config.items():
         logger_class = _SUPPORTED_LOGGERS.get(integration.lower())
         if logger_class is None:
             raise ValueError(

--- a/tests/server/test_helpers.py
+++ b/tests/server/test_helpers.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+from deepsparse.loggers import ManagerLogger, PrometheusLogger
+from deepsparse.server.helpers import logger_manager_from_config
+
+
+@mock.patch.object(PrometheusLogger, "_setup_client", lambda _: None)
+def test_logger_manager_from_config():
+    port = 8001
+    text_log_save_dir = "/home/deepsparse-server/prometheus"
+    text_log_save_freq = 30
+
+    yaml_str = f"""
+    prometheus:
+        port: {port}
+        text_log_save_dir: {text_log_save_dir}
+        text_log_save_freq: {text_log_save_freq}
+    """
+    config_file = NamedTemporaryFile()
+    with open(config_file.name, "w") as config_writer:
+        config_writer.write(yaml_str)
+
+    logger_manager = logger_manager_from_config(config_file.name)
+    assert isinstance(logger_manager, ManagerLogger)
+
+    loggers = logger_manager.loggers
+    assert len(loggers) == 1
+    assert "prometheus" in loggers
+    logger = loggers["prometheus"]
+    assert isinstance(logger, PrometheusLogger)
+    assert logger.port == port
+    assert logger.text_log_save_dir == text_log_save_dir
+    assert logger.text_log_save_freq == text_log_save_freq

--- a/tests/server/test_helpers.py
+++ b/tests/server/test_helpers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from tempfile import NamedTemporaryFile
 from unittest import mock
 
 from deepsparse.loggers import ManagerLogger, PrometheusLogger
@@ -21,7 +20,7 @@ from deepsparse.server.helpers import logger_manager_from_config
 
 
 @mock.patch.object(PrometheusLogger, "_setup_client", lambda _: None)
-def test_logger_manager_from_config():
+def test_logger_manager_from_config(tmp_path):
     port = 8001
     text_log_save_dir = "/home/deepsparse-server/prometheus"
     text_log_save_freq = 30
@@ -32,11 +31,11 @@ def test_logger_manager_from_config():
         text_log_save_dir: {text_log_save_dir}
         text_log_save_freq: {text_log_save_freq}
     """
-    config_file = NamedTemporaryFile()
-    with open(config_file.name, "w") as config_writer:
+    config_path = tmp_path / "loggers.yaml"
+    with open(config_path, "w") as config_writer:
         config_writer.write(yaml_str)
 
-    logger_manager = logger_manager_from_config(config_file.name)
+    logger_manager = logger_manager_from_config(str(config_path))
     assert isinstance(logger_manager, ManagerLogger)
 
     loggers = logger_manager.loggers


### PR DESCRIPTION
utility functions for instantiating loggers - main contribution is the ability to specify and instantiate loggers from a simple yaml config. yaml config should be the integration name followed by it's init kwargs

example config:
```yaml
prometheus:
        port: 8001
        text_log_save_dir: /home/deepsparse-server/prometheus
        text_log_save_freq: 30
```

**test_plan:**
pytest included