### PR TITLE
Moving PIL and opencv-python to install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ _deps = [
     "tqdm>=4.0.0",
     "protobuf>=3.12.2,<4",
     "click~=8.0.0",
+    "Pillow>=8.3.2",
+    "opencv-python",
 ]
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_base}"]
 _dev_deps = [
@@ -84,7 +86,6 @@ _dev_deps = [
     "onnxruntime>=1.7.0",
     "flask>=1.0.0",
     "flask-cors>=3.0.0",
-    "Pillow>=8.3.2",
 ]
 _server_deps = [
     "uvicorn>=0.15.0",
@@ -99,7 +100,6 @@ _onnxruntime_deps = [
 ]
 _yolo_integration_deps = [
     "torchvision>=0.3.0,<=0.12.0",
-    "opencv-python",
 ]
 # haystack dependencies are installed from a requirements file to avoid
 # conflicting versions with NM's deepsparse/transformers

--- a/src/deepsparse/pipelines/computer_vision.py
+++ b/src/deepsparse/pipelines/computer_vision.py
@@ -15,15 +15,7 @@
 from typing import Any, Iterable, List, TextIO, Union
 
 import numpy
-
-
-try:
-    from PIL import Image
-
-    pil_import_error = None
-except Exception as import_error:
-    Image, pil_import_error = None, import_error
-
+from PIL import Image
 from pydantic import BaseModel, Field
 
 
@@ -58,11 +50,5 @@ class ComputerVisionSchema(BaseModel):
         :param files: Iterable of file pointers to create ImageClassificationInput from
         :return: ImageClassificationInput constructed from files
         """
-        if pil_import_error is not None:
-            raise ImportError(
-                "PIL is a requirement for Computer Vision pipeline schemas,"
-                f" but was not found. Error:\n{pil_import_error}, "
-                "try `pip install Pillow`"
-            )
         images = [numpy.asarray(Image.open(file)) for file in files]
         return cls(*args, images=images, **kwargs)

--- a/src/deepsparse/utils/annotate.py
+++ b/src/deepsparse/utils/annotate.py
@@ -25,16 +25,9 @@ from typing import Any, Callable, Iterable, Iterator, List, Optional, Tuple, Uni
 
 import numpy
 
+import cv2
 from sparsezoo.utils import create_dirs
 
-
-try:
-    import cv2
-
-    cv2_error = None
-except ModuleNotFoundError as cv2_import_error:
-    cv2 = None
-    cv2_error = cv2_import_error
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/deepsparse/yolact/pipelines.py
+++ b/src/deepsparse/yolact/pipelines.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Tuple, Type, Union
 
 import numpy
 
+import cv2
 import torch
 from deepsparse import Pipeline
 from deepsparse.utils import model_to_path
@@ -24,14 +25,6 @@ from deepsparse.yolact.schemas import YOLACTInputSchema, YOLACTOutputSchema
 from deepsparse.yolact.utils import decode, detect, postprocess, preprocess_array
 from deepsparse.yolo.utils import COCO_CLASSES
 
-
-try:
-    import cv2
-
-    cv2_error = None
-except ModuleNotFoundError as cv2_import_error:
-    cv2 = None
-    cv2_error = cv2_import_error
 
 __all__ = ["YOLACTPipeline"]
 

--- a/src/deepsparse/yolact/utils/utils.py
+++ b/src/deepsparse/yolact/utils/utils.py
@@ -19,16 +19,8 @@ from typing import Dict, Tuple
 
 import numpy
 
+import cv2
 import torch
-
-
-try:
-    import cv2
-
-    cv2_error = None
-except ModuleNotFoundError as cv2_import_error:
-    cv2 = None
-    cv2_error = cv2_import_error
 
 
 _all__ = ["detect", "decode", "postprocess", "preprocess_array"]

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Optional, Tuple, Type, Union
 import numpy
 import onnx
 
+import cv2
 from deepsparse.pipeline import Pipeline
 from deepsparse.utils import model_to_path
 from deepsparse.yolo.schemas import YOLOInput, YOLOOutput
@@ -30,14 +31,6 @@ from deepsparse.yolo.utils import (
     yolo_onnx_has_postprocessing,
 )
 
-
-try:
-    import cv2
-
-    cv2_error = None
-except ModuleNotFoundError as cv2_import_error:
-    cv2 = None
-    cv2_error = cv2_import_error
 
 __all__ = ["YOLOPipeline"]
 

--- a/src/deepsparse/yolo/utils/utils.py
+++ b/src/deepsparse/yolo/utils/utils.py
@@ -28,17 +28,10 @@ import onnx
 import torchvision
 import yaml
 
+import cv2
 import torch
 from deepsparse.yolo.schemas import YOLOOutput
 
-
-try:
-    import cv2
-
-    cv2_error = None
-except ModuleNotFoundError as cv2_import_error:
-    cv2 = None
-    cv2_error = cv2_import_error
 
 _YOLO_CLASS_COLORS = list(itertools.product([0, 255, 128, 64, 192], repeat=3))
 _YOLO_CLASS_COLORS.remove((255, 255, 255))  # remove white from possible colors


### PR DESCRIPTION
This moves PIL and cv2 to required dependencies to install deepsparse. They are used in multiple pipelines and the server.

test plan: unit tests