### PR TITLE
Adding GKE to examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,8 @@ Open a Pull Request to [contribute](https://github.com/neuralmagic/deepsparse/bl
 | [Image Classification](https://github.com/neuralmagic/deepsparse/tree/main/examples/classification/)  | How to use image classification models from SparseZoo to perform inference and benchmarking with the DeepSparse Engine  |
 | [Object Detection](https://github.com/neuralmagic/deepsparse/tree/main/examples/detection/)  | How to use object detection models from SparseZoo to perform inference and benchmarking with the DeepSparse Engine  |
 | [Instance Segmentation](https://github.com/neuralmagic/deepsparse/tree/main/examples/dbolya-yolact/)  | How to use an optimized YOLACT model and the DeepSparse Engine to perform real-time instance segmentation. |
-| [AWS Sagemaker Integration](https://github.com/neuralmagic/deepsparse/tree/main/examples/aws-sagemaker/)  | How to deploy a DeepSparse inference server on SageMaker |
+| [AWS Sagemaker Integration](https://github.com/neuralmagic/deepsparse/tree/main/examples/google-kubernetes-engine/)  | How to deploy a DeepSparse inference server on SageMaker |
+| [Google Kubernetes Engine]() | How to deploy a DeepSparse inference server on GKE |
 | [SparseServer.UI](https://github.com/neuralmagic/deepsparse/tree/main/examples/sparseserver-ui/)  | A Streamlit app for deploying the DeepSparse Server to compare the latency and accuracy of sparse BERT models |
 | [Twitter Sentiment Analysis](https://github.com/neuralmagic/deepsparse/tree/main/examples/twitter-nlp/)  | Example of scraping, processing, and classifying Twitter data using the DeepSparse Engine for 10x faster performance on CPUs |
 | [Flask Model Server](https://github.com/neuralmagic/deepsparse/tree/main/examples/flask/)  | Simple model server and client example, showing how to use the DeepSparse Engine as an inference backend for a real-time inference server |

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,8 +32,8 @@ Open a Pull Request to [contribute](https://github.com/neuralmagic/deepsparse/bl
 | [Image Classification](https://github.com/neuralmagic/deepsparse/tree/main/examples/classification/)  | How to use image classification models from SparseZoo to perform inference and benchmarking with the DeepSparse Engine  |
 | [Object Detection](https://github.com/neuralmagic/deepsparse/tree/main/examples/detection/)  | How to use object detection models from SparseZoo to perform inference and benchmarking with the DeepSparse Engine  |
 | [Instance Segmentation](https://github.com/neuralmagic/deepsparse/tree/main/examples/dbolya-yolact/)  | How to use an optimized YOLACT model and the DeepSparse Engine to perform real-time instance segmentation. |
-| [AWS Sagemaker Integration](https://github.com/neuralmagic/deepsparse/tree/main/examples/google-kubernetes-engine/)  | How to deploy a DeepSparse inference server on SageMaker |
-| [Google Kubernetes Engine]() | How to deploy a DeepSparse inference server on GKE |
+| [AWS Sagemaker Integration](https://github.com/neuralmagic/deepsparse/tree/main/examples/aws-sagemaker/)  | How to deploy a DeepSparse inference server on SageMaker |
+| [Google Kubernetes Engine](https://github.com/neuralmagic/deepsparse/tree/main/examples/google-kubernetes-engine/) | How to deploy a DeepSparse inference server on GKE |
 | [SparseServer.UI](https://github.com/neuralmagic/deepsparse/tree/main/examples/sparseserver-ui/)  | A Streamlit app for deploying the DeepSparse Server to compare the latency and accuracy of sparse BERT models |
 | [Twitter Sentiment Analysis](https://github.com/neuralmagic/deepsparse/tree/main/examples/twitter-nlp/)  | Example of scraping, processing, and classifying Twitter data using the DeepSparse Engine for 10x faster performance on CPUs |
 | [Flask Model Server](https://github.com/neuralmagic/deepsparse/tree/main/examples/flask/)  | Simple model server and client example, showing how to use the DeepSparse Engine as an inference backend for a real-time inference server |

--- a/examples/google-kubernetes-engine/Dockerfile
+++ b/examples/google-kubernetes-engine/Dockerfile
@@ -4,5 +4,6 @@ ARG GIT_BRANCH=main
 RUN git clone https://github.com/neuralmagic/deepsparse.git --depth 1 -b $GIT_BRANCH
 RUN pip3 install --no-cache-dir --upgrade -e "./deepsparse[server]"
 
-COPY ./server-config.yaml /server-config.yaml
+ARG CONFIG=./server-config.yaml
+COPY $CONFIG /server-config.yaml
 ENTRYPOINT ["deepsparse.server", "config", "--port", "8080", "/server-config.yaml"]

--- a/examples/google-kubernetes-engine/Dockerfile
+++ b/examples/google-kubernetes-engine/Dockerfile
@@ -4,6 +4,6 @@ ARG GIT_BRANCH=main
 RUN git clone https://github.com/neuralmagic/deepsparse.git --depth 1 -b $GIT_BRANCH
 RUN pip3 install --no-cache-dir --upgrade -e "./deepsparse[server]"
 
-ARG CONFIG=./server-config.yaml
+ARG CONFIG=./sample-config.yaml
 COPY $CONFIG /server-config.yaml
 ENTRYPOINT ["deepsparse.server", "config", "--port", "8080", "/server-config.yaml"]

--- a/examples/google-kubernetes-engine/Dockerfile
+++ b/examples/google-kubernetes-engine/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9
+
+ARG GIT_BRANCH=main
+RUN git clone https://github.com/neuralmagic/deepsparse.git --depth 1 -b $GIT_BRANCH
+RUN pip3 install --no-cache-dir --upgrade -e "./deepsparse[server]"
+
+COPY ./server-config.yaml /server-config.yaml
+ENTRYPOINT ["deepsparse.server", "config", "--port", "8080", "/server-config.yaml"]

--- a/examples/google-kubernetes-engine/README.md
+++ b/examples/google-kubernetes-engine/README.md
@@ -1,0 +1,14 @@
+# Deploying DeepSparse on Google Kubernetes Engine (GKE)
+
+See [GKE documentation](https://cloud.google.com/kubernetes-engine) for more info on GKE.
+
+## Deploying to GKE
+
+Follow the steps at https://cloud.google.com/kubernetes-engine/docs/tutorials/hello-app
+to deploy the `Dockerfile` in this directory to GKE.
+
+## Testing `Dockerfile` Locally
+
+1. `docker build -t qa .`
+2. `docker run --rm -p 8080:8080 qa`
+3. `curl http://localhost:8080`

--- a/examples/google-kubernetes-engine/README.md
+++ b/examples/google-kubernetes-engine/README.md
@@ -23,6 +23,10 @@ See [GKE documentation](https://cloud.google.com/kubernetes-engine) for more inf
 Follow the steps at https://cloud.google.com/kubernetes-engine/docs/tutorials/hello-app
 to deploy the `Dockerfile` in this directory to GKE.
 
+## Sending a request to GKE
+
+After following the tutorial, your web server will be exposed just like a normal web server. You can interact with it just like you would if you ran the docker image locally (e.g. visit the swagger api with a browser or send requests using curl).
+
 ## Testing `Dockerfile` Locally
 
 1. `docker build -t qa .`

--- a/examples/google-kubernetes-engine/README.md
+++ b/examples/google-kubernetes-engine/README.md
@@ -1,3 +1,19 @@
+<!--
+Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Deploying DeepSparse on Google Kubernetes Engine (GKE)
 
 See [GKE documentation](https://cloud.google.com/kubernetes-engine) for more info on GKE.

--- a/examples/google-kubernetes-engine/README.md
+++ b/examples/google-kubernetes-engine/README.md
@@ -25,7 +25,7 @@ to deploy the `Dockerfile` in this directory to GKE.
 
 ## Sending a request to GKE
 
-After following the tutorial, your web server will be exposed just like a normal web server. You can interact with it just like you would if you ran the docker image locally (e.g. visit the swagger api with a browser or send requests using curl).
+After following the tutorial, your web server will be exposed just like a normal web server. You can interact with it just like you would if you ran the docker image locally (e.g. visit the swagger documentation UI with a browser at `/docs` or send requests using curl).  See more information on [interacting with the DeepSparse server here](https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/server).
 
 ## Testing `Dockerfile` Locally
 

--- a/examples/google-kubernetes-engine/sample-config.yaml
+++ b/examples/google-kubernetes-engine/sample-config.yaml
@@ -1,3 +1,4 @@
+# NOTE: this is a sample configuration file for a question-answering server
 num_cores: 1
 num_workers: 1
 endpoints:

--- a/examples/google-kubernetes-engine/sample-config.yaml
+++ b/examples/google-kubernetes-engine/sample-config.yaml
@@ -1,6 +1,4 @@
 # NOTE: this is a sample configuration file for a question-answering server
-num_cores: 1
-num_workers: 1
 endpoints:
     - task: question-answering
       route: /predict

--- a/examples/google-kubernetes-engine/server-config.yaml
+++ b/examples/google-kubernetes-engine/server-config.yaml
@@ -1,0 +1,6 @@
+num_cores: 1
+num_workers: 1
+endpoints:
+    - task: question-answering
+      route: /predict
+      model: zoo:nlp/question_answering/distilbert-none/pytorch/huggingface/squad/pruned80_quant-none-vnni


### PR DESCRIPTION
Adds link to GKE tutorial on how to deploy a dockerized web server to GKE. I don't think we should duplicate this information in our repo's readme because:
1. The GKE tutorial has a TON of useful commands/help.
2. It makes it explicit that we don't require anything special to run on GKE. This means users with GKE experience already don't need to read through our README just to find out that we are using normal GKE commands.
3. Any docs duplicated here may become out of date.

test plan: built and ran docker image locally