### PR TITLE
Removing nullcontext from tests

### DIFF
--- a/tests/deepsparse/transformers/pipelines/test_mnli_text_classification.py
+++ b/tests/deepsparse/transformers/pipelines/test_mnli_text_classification.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import nullcontext
-
 import numpy
 
 import pytest
@@ -78,7 +76,10 @@ def test_batch_size(
         labels=static_labels,
     )
 
-    with pytest.raises(inference_error) if inference_error else nullcontext():
+    if inference_error:
+        with pytest.raises(inference_error):
+            pipeline(sequences=sequences, labels=dynamic_labels)
+    else:
         pipeline(sequences=sequences, labels=dynamic_labels)
 
 


### PR DESCRIPTION
nullcontext doesn't exist in python 3.6