### PR TITLE
[image-classification] fix IC eval script bug for batch size > 0

### DIFF
--- a/src/deepsparse/image_classification/validation_script.py
+++ b/src/deepsparse/image_classification/validation_script.py
@@ -204,6 +204,8 @@ def main(
 
         for actual, predicted in zip(actual_labels, predicted_labels):
             total += 1
+            if isinstance(predicted, list):
+                predicted = predicted[0]  # unwrap label returned as list
             if isinstance(predicted, str):
                 predicted = int(predicted)
             if actual.item() == predicted:


### PR DESCRIPTION
currently, the eval script is missing a call to unwrap the inner layer of a batch prediction for IC eval. Can look into unwrapping this list at pipeline level later.

This caused accuracy to crash to 0 for runs with batch size > 0. after this fix running accuracy returns to expected:
```
$ deepsparse.image_classification.eval --model-path zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/base-none --dataset-path /home/benjamin/data/imagenet/val --batch-size 64

  2%|█▎                                                                  | 15/781 [00:08<07:05,  1.80it/s, Running Accuracy=89.27%]
```