### PR TITLE
[license] fix - move validate_license cli to its own function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ def _setup_entry_points() -> Dict:
             "deepsparse.instance_segmentation.annotate=deepsparse.yolact.annotate:main",
             f"deepsparse.image_classification.eval={ic_eval}",
             "deepsparse.license=deepsparse.license:main",
-            "deepsparse.validate_license=deepsparse.license:validate_license",
+            "deepsparse.validate_license=deepsparse.license:validate_license_cli",
         ]
     }
 

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -70,8 +70,6 @@ def add_deepsparse_license(token_or_path):
     validate_license()
 
 
-@click.command()
-@click.option("--license_path", type=str, default=None)
 def validate_license(license_path: Optional[str] = None):
     """
     Validates a candidate license token (JWT). Should be passed
@@ -104,6 +102,21 @@ def _get_license_file_path():
     os.makedirs(config_dir, exist_ok=True)
 
     return os.path.join(config_dir, LICENSE_FILE)
+
+
+@click.command()
+@click.option("--license_path", type=str, default=None)
+def validate_license_cli(license_path: Optional[str] = None):
+    """
+    Validates a candidate license token (JWT). Should be passed
+    as a text file containing only the JWT. If no path is provided
+    the expected file path of the token will be validated. Default
+    path is ~/.config/neuralmagic/license.txt
+
+    :param license_path: file path to text file of token to validate.
+        Default is None, expected token path will be validated
+    """
+    validate_license(license_path)
 
 
 @click.command()


### PR DESCRIPTION
validate_license included click decorators to expose it as a top level deepsparse cli, however this makes use of it less flexible when called via python API (ie in the license script) as click type checking is added (currently causes issues with tempfiles).
this PR adds a simple fix to move out the cli entrypoint to its own function keeping the helper standalone.

**test_plan**
license functionality internally tested by QA