### PR TITLE
use default license config dir used when NM_CONFIG_DIR evals to False

### DIFF
--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -98,7 +98,9 @@ def validate_license(license_path: Optional[str] = None):
 def _get_license_file_path():
     # license file written to NM_CONFIG_DIR env var under license.txt
     # defaults to ~/.config/neuralmagic
-    config_dir = os.environ.get(NM_CONFIG_DIR, DEFAULT_CONFIG_DIR)
+    config_dir = os.environ.get(NM_CONFIG_DIR, None)
+    if not config_dir:
+        config_dir = DEFAULT_CONFIG_DIR
     os.makedirs(config_dir, exist_ok=True)
 
     return os.path.join(config_dir, LICENSE_FILE)


### PR DESCRIPTION
currently if a user sets `NM_CONFIG_DIR=""` `/` will be used as the config dir, similar unexpected behavior may happen for other improper ways of unsetting the env variable. This PR adds a quick fix to evaluate the `NM_CONFIG_DIR` value before assigning a default (`get` will only default the value if it is properly unset)

**test_plan**
license testing currently done internally