### PR TITLE
Setting all ports to dynamic ports in unit tests

### DIFF
--- a/tests/deepsparse/loggers/test_prometheus_logger.py
+++ b/tests/deepsparse/loggers/test_prometheus_logger.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import os
-import socket
 
 import requests
 
 import pytest
 from deepsparse.loggers.prometheus_logger import PrometheusLogger
 from deepsparse.timing.timing_schema import InferenceTimingSchema
+from tests.helpers import find_free_port
 
 
 class Pipeline:
@@ -37,16 +37,6 @@ class Pipeline:
         return results, timings, data
 
 
-def _find_free_port():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(("0.0.0.0", 0))
-    portnum = s.getsockname()[1]
-    s.close()
-
-    return portnum
-
-
 @pytest.mark.parametrize(
     "no_iterations, pipeline_names",
     [(6, ["earth", "namek"]), (10, ["moon"])],
@@ -55,7 +45,7 @@ def _find_free_port():
 class TestPrometheusPipelineLogger:
     @pytest.fixture()
     def setup(self, tmp_path_factory, no_iterations, pipeline_names):
-        port = _find_free_port()
+        port = find_free_port()
         logger = PrometheusLogger(
             text_log_save_dir=tmp_path_factory.mktemp("logs"),
             # logs for each pipeline will be dumped after

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -74,3 +74,15 @@ def predownload_stub(stub: str, copy_framework_files: bool = False) -> Model:
         shutil.copy(tokenizer_config_path, model_path)
 
     return model
+
+
+def find_free_port():
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(("0.0.0.0", 0))
+    portnum = s.getsockname()[1]
+    s.close()
+
+    return portnum

--- a/tests/server/test_helpers.py
+++ b/tests/server/test_helpers.py
@@ -17,11 +17,12 @@ from unittest import mock
 
 from deepsparse.loggers import ManagerLogger, PrometheusLogger
 from deepsparse.server.helpers import logger_manager_from_config
+from tests.helpers import find_free_port
 
 
 @mock.patch.object(PrometheusLogger, "_setup_client", lambda _: None)
 def test_logger_manager_from_config(tmp_path):
-    port = 8001
+    port = find_free_port()
     text_log_save_dir = "/home/deepsparse-server/prometheus"
     text_log_save_freq = 30
 

--- a/tests/server/test_prometheus.py
+++ b/tests/server/test_prometheus.py
@@ -15,19 +15,8 @@
 from deepsparse.server.config import EndpointConfig, ServerConfig
 from deepsparse.server.server import _build_app
 from fastapi.testclient import TestClient
+from tests.helpers import find_free_port
 from tests.utils import mock_engine
-
-
-def _find_free_port():
-    import socket
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(("0.0.0.0", 0))
-    portnum = s.getsockname()[1]
-    s.close()
-
-    return portnum
 
 
 @mock_engine(rng_seed=0)
@@ -38,7 +27,7 @@ def test_instantiate_prometheus(tmp_path):
                 endpoints=[EndpointConfig(task="text_classification", model="default")],
                 loggers=dict(
                     prometheus={
-                        "port": _find_free_port(),
+                        "port": find_free_port(),
                         "text_log_save_dir": str(tmp_path),
                         "text_log_save_freq": 30,
                     }


### PR DESCRIPTION
This fixes port in use errors during the unit tests cause by fixed port numbers.

Test plan: unit tests