### PR TITLE
Using py37 compatible call args in unit tests

### DIFF
--- a/tests/server/test_hot_reloading.py
+++ b/tests/server/test_hot_reloading.py
@@ -191,11 +191,13 @@ def test_task_cli_hot_reload(start_server):
 
     # no flag sets hot_reload_config to False
     runner.invoke(task, ["qa"])
-    assert start_server.call_args.kwargs["hot_reload_config"] is False
+    _, kwargs = start_server.call_args
+    assert kwargs["hot_reload_config"] is False
 
     # using flag sets hot_reload_config to True
     runner.invoke(task, ["qa", "--hot-reload-config"])
-    assert start_server.call_args.kwargs["hot_reload_config"] is True
+    _, kwargs = start_server.call_args
+    assert kwargs["hot_reload_config"] is True
 
 
 @mock.patch("deepsparse.server.cli.start_server")
@@ -204,8 +206,10 @@ def test_config_cli_hot_reload(start_server, tmp_path: Path):
 
     # no flag sets hot_reload_config to False
     runner.invoke(config, [str(tmp_path)])
-    assert start_server.call_args.kwargs["hot_reload_config"] is False
+    _, kwargs = start_server.call_args
+    assert kwargs["hot_reload_config"] is False
 
     # using flag sets hot_reload_config to True
     runner.invoke(config, [str(tmp_path), "--hot-reload-config"])
-    assert start_server.call_args.kwargs["hot_reload_config"] is True
+    _, kwargs = start_server.call_args
+    assert kwargs["hot_reload_config"] is True


### PR DESCRIPTION
In python 3.7 MagicMock.call_args is a tuple (https://docs.python.org/3.7/library/unittest.mock.html#unittest.mock.Mock.call_args)

In python 3.8+ call_args had .args and .kwargs introduced, but also supports tuple destructuring. (https://docs.python.org/3.8/library/unittest.mock.html#unittest.mock.Mock.call_args)

This PR reverts usage of call args back to 3.7 compatible version