### PR TITLE
multi label support for text classification pipeline

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_classification.py
+++ b/src/deepsparse/transformers/pipelines/text_classification.py
@@ -42,6 +42,7 @@ from pydantic import BaseModel, Field
 from transformers.tokenization_utils_base import PaddingStrategy, TruncationStrategy
 
 from deepsparse import Pipeline
+from deepsparse.log import get_main_logger
 from deepsparse.transformers.pipelines import TransformersPipeline
 
 
@@ -50,6 +51,9 @@ __all__ = [
     "TextClassificationOutput",
     "TextClassificationPipeline",
 ]
+
+
+_LOGGER = get_main_logger()
 
 
 class TextClassificationInput(BaseModel):
@@ -86,7 +90,10 @@ class TextClassificationOutput(BaseModel):
 )
 class TextClassificationPipeline(TransformersPipeline):
     """
-    transformers text classification pipeline
+    transformers text classification pipeline.
+    Scores are returned as sigmoid over logits if one label is given or
+    the model config is set to "multi_label_classification". Softmax
+    returned otherwise
 
     example instantiation:
     ```python
@@ -132,7 +139,9 @@ class TextClassificationPipeline(TransformersPipeline):
         If a list of lengths is provided, then for each length, a model and
         tokenizer will be compiled capable of handling that sequence length
         (also known as a bucket). Default is 128
-    :param return_all_scores: if True, instead of returning the prediction as the
+    :param top_k: number of labels with the highest score to return. Default is 1
+    :param return_all_scores: [DEPRECATED] set top_k to desired value instead.
+        If True, instead of returning the prediction as the
         argmax of model class predictions, will return all scores and labels as
         a list for each result in the batch. Default is False
     """
@@ -140,12 +149,21 @@ class TextClassificationPipeline(TransformersPipeline):
     def __init__(
         self,
         *,
+        top_k: int = 1,
         return_all_scores: bool = False,
         **kwargs,
     ):
+        super().__init__(**kwargs)
+
+        self._top_k = _get_top_k(top_k, return_all_scores, self.config.num_labels)
         self._return_all_scores = return_all_scores
 
-        super().__init__(**kwargs)
+    @property
+    def top_k(self) -> int:
+        """
+        :return: number of labels with the highest score to return
+        """
+        return self._top_k
 
     @property
     def return_all_scores(self) -> str:
@@ -223,25 +241,30 @@ class TextClassificationPipeline(TransformersPipeline):
         if isinstance(outputs, list):
             outputs = outputs[0]
 
+        use_sigmoid = self.config.num_labels == 1 or (
+            self.config.problem_type == "multi_label_classification"
+        )
         scores = (
             1.0 / (1.0 + numpy.exp(-outputs))
-            if self.config.num_labels == 1
+            if use_sigmoid
             else numpy.exp(outputs) / numpy.exp(outputs).sum(-1, keepdims=True)
         )
 
-        if not self._return_all_scores:
-            # return only argmax of scores for each item in batch
-            labels = []
-            label_scores = []
-            for score in scores:
+        labels = []
+        label_scores = []
+        for score in scores:
+            if self._top_k == 1:
                 labels.append(self.config.id2label[score.argmax()])
                 label_scores.append(score.max().item())
-        else:
-            # return all scores and labels for each item in batch
-            labels = [
-                [self.config.id2label[idx] for idx in range(scores.shape[1])]
-            ] * len(scores)
-            label_scores = [score.reshape(-1).tolist() for score in scores]
+            else:
+                score = score.reshape(-1).tolist()
+                ranked_idxs = sorted(
+                    range(len(score)), reverse=True, key=lambda idx: score[idx]
+                )
+                labels.append(
+                    [self.config.id2label[idx] for idx in ranked_idxs[: self._top_k]]
+                )
+                label_scores.append([score[idx] for idx in ranked_idxs[: self._top_k]])
 
         return self.output_schema(
             labels=labels,
@@ -267,3 +290,26 @@ class TextClassificationPipeline(TransformersPipeline):
         )
         input_seq_len = max(map(len, tokens["input_ids"]))
         return TransformersPipeline.select_bucket_by_seq_len(input_seq_len, pipelines)
+
+
+def _get_top_k(top_k: int, return_all_scores: bool, num_labels: int) -> int:
+    if top_k <= 0:
+        raise ValueError(f"text_classification top_k must be > 0. found {top_k}")
+    if return_all_scores and top_k not in [1, num_labels]:
+        # top_k is not set to default, but does not match num_labels
+        # for return_all_scores
+        raise ValueError(
+            f"Mismatch: return_all_scores set to {return_all_scores} with "
+            f"{num_labels} in model config, but top_k set to {top_k}. "
+            "return_all_scores is deprecated, set top_k instead"
+        )
+
+    if top_k == 1 and return_all_scores:
+        # set top_k to num_labels from config and warn
+        _LOGGER.warn(
+            f"return_all_scores deprecated, set {top_k} instead. setting "
+            f"top_k to num_lables from config: {num_labels}"
+        )
+        top_k = num_labels
+
+    return top_k

--- a/src/deepsparse/transformers/pipelines/text_classification.py
+++ b/src/deepsparse/transformers/pipelines/text_classification.py
@@ -293,6 +293,7 @@ class TextClassificationPipeline(TransformersPipeline):
 
 
 def _get_top_k(top_k: int, return_all_scores: bool, num_labels: int) -> int:
+    # handle deprecations of return_all_scores
     if top_k <= 0:
         raise ValueError(f"text_classification top_k must be > 0. found {top_k}")
     if return_all_scores and top_k not in [1, num_labels]:


### PR DESCRIPTION
adds support for multi label text classification inference with the following changes (matching transformers repo pipeline)
* adds a `top_k` arg for specifying number of labels to return
* adds logic to deprecate `return_all_scores`
* runs sigmoid instead of softmax when model config is set to `multi_label_classification` mode

**test_plan**
manual for now, further testing to be added in pipelines unit tests work. ran eval_downstream against existing qqp and sst2 models, verified expected number of outputs returns for various top_k values