### PR TITLE
[YoloV5] Expose multi_label control for Pipeline

### DIFF
--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import numpy
 import onnx
@@ -168,7 +168,9 @@ class YOLOPipeline(Pipeline):
             )
         return model_path
 
-    def process_inputs(self, inputs: YOLOInput) -> List[numpy.ndarray]:
+    def process_inputs(
+        self, inputs: YOLOInput
+    ) -> Tuple[List[numpy.ndarray], Dict[str, Any]]:
         """
         :param inputs: inputs to the pipeline. Must be the type of the `input_schema`
             of this pipeline
@@ -194,6 +196,7 @@ class YOLOPipeline(Pipeline):
         postprocessing_kwargs = dict(
             iou_thres=inputs.iou_thres,
             conf_thres=inputs.conf_thres,
+            multi_label=inputs.multi_label,
         )
         return [image_batch], postprocessing_kwargs
 
@@ -237,6 +240,7 @@ class YOLOPipeline(Pipeline):
             batch_output,
             iou_thres=kwargs.get("iou_thres", 0.25),
             conf_thres=kwargs.get("conf_thres", 0.45),
+            multi_label=kwargs.get("multi_label", False),
         )
 
         batch_boxes, batch_scores, batch_labels = [], [], []

--- a/src/deepsparse/yolo/schemas.py
+++ b/src/deepsparse/yolo/schemas.py
@@ -46,6 +46,10 @@ class YOLOInput(ComputerVisionSchema):
         default=0.45,
         description="minimum confidence score for a prediction to be valid",
     )
+    multi_label: bool = Field(
+        default=False,
+        description="when true, allow multi-label assignment to each detected object",
+    )
 
 
 class YOLOOutput(BaseModel):

--- a/src/deepsparse/yolo/schemas.py
+++ b/src/deepsparse/yolo/schemas.py
@@ -48,7 +48,11 @@ class YOLOInput(ComputerVisionSchema):
     )
     multi_label: bool = Field(
         default=False,
-        description="when true, allow multi-label assignment to each detected object",
+        description=(
+            "when true, allow multi-label assignment to each detected object. Defaults "
+            "to False to mimic yolov5 detection pathway. Note that yolov5 validation "
+            "pathway by default run with multi_label on"
+        ),
     )
 
 

--- a/src/deepsparse/yolo/utils/utils.py
+++ b/src/deepsparse/yolo/utils/utils.py
@@ -133,6 +133,7 @@ def postprocess_nms(
     outputs: Union[torch.Tensor, numpy.ndarray],
     iou_thres: float = 0.25,
     conf_thres: float = 0.45,
+    multi_label: bool = False,
 ) -> List[numpy.ndarray]:
     """
     :param outputs: Tensor of post-processed model outputs
@@ -144,7 +145,7 @@ def postprocess_nms(
     if isinstance(outputs, numpy.ndarray):
         outputs = torch.from_numpy(outputs)
     nms_outputs = _non_max_suppression(
-        outputs, conf_thres=conf_thres, iou_thres=iou_thres
+        outputs, conf_thres=conf_thres, iou_thres=iou_thres, multi_label=multi_label
     )
     return [output.cpu().numpy() for output in nms_outputs]
 


### PR DESCRIPTION
This PR adds support for multi-label inference with Pipelines by exposing the `multi_label` kwargs

**Testing**
```python
from deepsparse import Pipeline

images = ["basilica.jpg"]
pipeline = Pipeline(task="yolo")

outputs_implicit_sl = pipeline(images=images, iou_thres=0.6, conf_thres=0.001)[0]
outputs_explicit_sl = pipeline(images=images, iou_thres=0.6, conf_thres=0.001, multi_label=False)[0]
outputs_ml = pipeline(images=images, iou_thres=0.6, conf_thres=0.001, multi_label=True)[0]

assert all(out1 == out2 for out1, out2 in zip(outputs_implicit_sl, outputs_explicit_sl))
assert any(out1 != out2 for out1, out2 in zip(outputs_explicit_sl, outputs_ml))
```