### PR TITLE
always print splash message for deepsparse.validate_license_cli regardless of input

### DIFF
--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -60,17 +60,21 @@ def add_deepsparse_license(token_or_path):
         with open(candidate_license_file_path, "w") as token_file:
             token_file.write(token_or_path)
 
-    validate_license(candidate_license_file_path)
+    # do not print splash message on successful validation
+    # only print on re-validation after license file copy
+    validate_license(candidate_license_file_path, print_splash=False)
     _LOGGER.info("DeepSparse license successfully validated")
 
     # copy candidate file to {LICENSE_FILE} in same directory as NM engine binaries
     license_file_path = _get_license_file_path()
     shutil.copy(candidate_license_file_path, license_file_path)
     _LOGGER.info(f"DeepSparse license file written to {license_file_path}")
+
+    # re-validate and print message now that licensee is copied to expected location
     validate_license()
 
 
-def validate_license(license_path: Optional[str] = None):
+def validate_license(license_path: Optional[str] = None, print_splash: bool = True):
     """
     Validates a candidate license token (JWT). Should be passed
     as a text file containing only the JWT. If no path is provided
@@ -79,17 +83,21 @@ def validate_license(license_path: Optional[str] = None):
 
     :param license_path: file path to text file of token to validate.
         Default is None, expected token path will be validated
+    :param print_splash: set False to not print splash message on
+        successful validation. Default True
     """
 
     deepsparse_lib = init_deepsparse_lib()
 
     # if token is invalid, deepsparse_lib will raise appropriate error response
     try:
-        if license_path is None:
-            splash_message = deepsparse_lib.validate_license()
+        splash_message = (
+            deepsparse_lib.validate_license()
+            if license_path is None
+            else deepsparse_lib.validate_license(license_path)
+        )
+        if print_splash:
             print(splash_message)
-            return
-        deepsparse_lib.validate_license(license_path)
     except RuntimeError:
         # deepsparse_lib handles error messaging, exit after message
         sys.exit(1)
@@ -118,7 +126,7 @@ def validate_license_cli(license_path: Optional[str] = None):
     :param license_path: file path to text file of token to validate.
         Default is None, expected token path will be validated
     """
-    validate_license(license_path)
+    validate_license(license_path, print_splash=True)
 
 
 @click.command()


### PR DESCRIPTION
**test_plan**
QA to check this passes expected flow