### PR TITLE
Adding backwards compatibility for server cli

### DIFF
--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -164,17 +164,17 @@ def main(
     """
     Start a DeepSparse inference server for serving the models and pipelines.
 
-        1. `deepsparse.server config [OPTIONS] <config path>`
+        1. `deepsparse.server --config_file <config path> [OPTIONS]`
 
-        2. `deepsparse.server task [OPTIONS] <task>
+        2. `deepsparse.server --task <task> [OPTIONS]`
 
     Examples for using the server:
 
-        `deepsparse.server config server-config.yaml`
+        `deepsparse.server --config_file server-config.yaml`
 
-        `deepsparse.server task question_answering --batch-size 2`
+        `deepsparse.server --task question_answering --batch-size 2`
 
-        `deepsparse.server task question_answering --host "0.0.0.0"`
+        `deepsparse.server --task question_answering --host "0.0.0.0"`
 
     Example config.yaml for serving:
 

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -206,6 +206,7 @@ def main(
     if task is None and config_file is None:
         raise ValueError("Must specify either --task or --config_file. Found neither")
 
+    warnings.simplefilter("always", DeprecationWarning)
     warnings.warn(
         "Invoking using --task or --config_file is deprecated. "
         "Use the task and config subcommands instead.",

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -206,13 +206,6 @@ def main(
     if task is None and config_file is None:
         raise ValueError("Must specify either --task or --config_file. Found neither")
 
-    warnings.simplefilter("always", DeprecationWarning)
-    warnings.warn(
-        "Invoking using --task or --config_file is deprecated. "
-        "Use the task and config subcommands instead.",
-        category=DeprecationWarning,
-    )
-
     if task is not None:
         cfg = ServerConfig(
             num_cores=num_cores,
@@ -253,7 +246,13 @@ def main(
 def config(
     config_path: str, host: str, port: int, log_level: str, hot_reload_config: bool
 ):
-    "Run the server using configuration from a .yaml file."
+    "[DEPRECATED] Run the server using configuration from a .yaml file."
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(
+        "Using the `config` sub command is deprecated. "
+        "Use the `--config_file` argument instead.",
+        category=DeprecationWarning,
+    )
     start_server(
         config_path, host, port, log_level, hot_reload_config=hot_reload_config
     )
@@ -300,9 +299,17 @@ def task(
     no_loggers: bool,
 ):
     """
-    Run the server using configuration with CLI options,
+    [DEPRECATED] Run the server using configuration with CLI options,
     which can only serve a single model.
     """
+
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.warn(
+        "Using the `task` sub command is deprecated. "
+        "Use the `--task` argument instead.",
+        category=DeprecationWarning,
+    )
+
     cfg = ServerConfig(
         num_cores=num_cores,
         num_workers=num_workers,

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -119,7 +119,12 @@ INTEGRATION_OPTION = click.option(
 )
 
 
-@click.group(invoke_without_command=True)
+@click.group(
+    invoke_without_command=True,
+    context_settings=dict(
+        token_normalize_func=lambda x: x.replace("-", "_"), show_default=True
+    ),
+)
 @click.option(
     "--config_file",
     type=str,
@@ -237,7 +242,11 @@ def main(
         )
 
 
-@main.command(context_settings=dict(show_default=True))
+@main.command(
+    context_settings=dict(
+        token_normalize_func=lambda x: x.replace("-", "_"), show_default=True
+    ),
+)
 @click.argument("config-path", type=str)
 @HOST_OPTION
 @PORT_OPTION

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -20,9 +20,9 @@ There are two sub-commands for the server:
 """
 
 import os
+import warnings
 from tempfile import TemporaryDirectory
 from typing import Optional
-import warnings
 
 import click
 import yaml


### PR DESCRIPTION
This adds support for using the old version of deepsparse.server cli with a deprecation message:

```
deepsparse.server --task qa
deepsparse.server task qa
deepsparse.server --config_file /some/path
deepsparse.server config /some/path
```

Test plan:
- Since this is not replacing the new way of the api, none of the QA or unit tests need to be updated
- Unit tests
- Manual cli testing