### PR TITLE
[license] support for non-throwing license_status call

### DIFF
--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -78,7 +78,7 @@ def add_deepsparse_license(token_or_path):
 def license_status(license_path: Optional[str] = None) -> Tuple[bool, str, str]:
     """
     Returns the status of a license as tuple of 
-    (is_exception, error/warning, display message)
+    (is_exception, error/warning, splash message)
     
     License should be passed as a text file containing only the JWT. If no path is
     provided the expected file path of the token will be validated. Default
@@ -86,7 +86,7 @@ def license_status(license_path: Optional[str] = None) -> Tuple[bool, str, str]:
 
     :param license_path: file path to text file of token to check status of.
         Default is None, expected token path will be validated
-    :return: tuple of (is_exception, error/warning, display message)
+    :return: tuple of (is_exception, error/warning, splash message)
     """
     deepsparse_lib = init_deepsparse_lib()
     return (
@@ -117,7 +117,7 @@ def validate_license(
 
     if is_exception:
         # exception would be raised on compilation with license_path, raise
-        raise ValueError(splash_message)
+        raise ValueError(error_message)
     elif print_warning and error_message:
         # no exception would be raised but message displayed, assume warning
         print(error_message)

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -34,7 +34,6 @@ Options:
 import logging
 import os
 import shutil
-import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Optional, Tuple

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -78,7 +78,7 @@ def add_deepsparse_license(token_or_path):
 def license_status(license_path: Optional[str] = None) -> Tuple[bool, str, str]:
     """
     Returns the status of a license as tuple of 
-    (is_exception, error/warning, splash message)
+    (is_exception, error/warning, display message)
     
     License should be passed as a text file containing only the JWT. If no path is
     provided the expected file path of the token will be validated. Default
@@ -86,7 +86,7 @@ def license_status(license_path: Optional[str] = None) -> Tuple[bool, str, str]:
 
     :param license_path: file path to text file of token to check status of.
         Default is None, expected token path will be validated
-    :return: tuple of (is_exception, error/warning, splash message)
+    :return: tuple of (is_exception, error/warning, display message)
     """
     deepsparse_lib = init_deepsparse_lib()
     return (
@@ -117,7 +117,7 @@ def validate_license(
 
     if is_exception:
         # exception would be raised on compilation with license_path, raise
-        raise ValueError(error_message)
+        raise ValueError(splash_message)
     elif print_warning and error_message:
         # no exception would be raised but message displayed, assume warning
         print(error_message)

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -77,9 +77,9 @@ def add_deepsparse_license(token_or_path):
 
 def license_status(license_path: Optional[str] = None) -> Tuple[bool, str, str]:
     """
-    Returns the status of a license as tuple of 
+    Returns the status of a license as tuple of
     (is_exception, error/warning, splash message)
-    
+
     License should be passed as a text file containing only the JWT. If no path is
     provided the expected file path of the token will be validated. Default
     path is ~/.config/neuralmagic/license.txt
@@ -94,6 +94,7 @@ def license_status(license_path: Optional[str] = None) -> Tuple[bool, str, str]:
         if license_path is None
         else deepsparse_lib.license_status(license_path)
     )
+
 
 def validate_license(
     license_path: Optional[str] = None,

--- a/src/deepsparse/license.py
+++ b/src/deepsparse/license.py
@@ -90,9 +90,9 @@ def license_status(license_path: Optional[str] = None) -> Tuple[bool, str, str]:
     """
     deepsparse_lib = init_deepsparse_lib()
     return (
-        deepsparse_lib.validate_license()
+        deepsparse_lib.license_status()
         if license_path is None
-        else deepsparse_lib.validate_license(license_path)
+        else deepsparse_lib.license_status(license_path)
     )
 
 def validate_license(


### PR DESCRIPTION
changes:
* adds python API wrapper for `license_status`
* updates `validate_license` to call into `license_status` as source of truth
* warning messages no longer displayed on first call to validate for `deepsparse.license`


**test_plan**
manual from QA after engine build/cherry-pick