### PR TITLE
[Cherry Pick] Do not include the `LICENSE-NEURALMAGIC` file in the `deepsparse-ent` installation folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,14 @@ _PACKAGE_NAME = (
     else "deepsparse-nightly"
 )
 
+if is_enterprise:
+    # do not include the LICENSE-NEURALMAGIC file
+    # in the deepsparse-ent installation folder
+    license_nm_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "LICENSE-NEURALMAGIC"
+    )
+    os.remove(license_nm_path)
+
 # File regexes for binaries to include in package_data
 binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 


### PR DESCRIPTION
Cherry Pick for https://github.com/neuralmagic/deepsparse/pull/730