### PR TITLE
Adding licenses folder to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ _PACKAGE_NAME = (
 )
 
 # File regexes for binaries to include in package_data
-binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
+binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin", "licenses/*"]
 
 
 def _parse_requirements_file(file_path):


### PR DESCRIPTION
This ensures that the licenses included under deepsparse/src/deepsparse during build are included in the python package when it is built.