### PR TITLE
Sparsestream quick fix

### DIFF
--- a/examples/sparsestream/README.md
+++ b/examples/sparsestream/README.md
@@ -15,26 +15,22 @@ limitations under the License.
 -->
 
 
-                ____  ___   ____  ____  ____  ____  ____  ___  ____  ____  ____  _  _ 
-                [__   |__]  |__|  |__/  [__   |___  [__    |   |__/  |___  |__|  |\/| 
-                ___]  |     |  |  |  \  ___]  |___  ___]   |   |  \  |___  |  |  |  | 
-                                                                                            
+               ____  ___   ____  ____  ____  ____  ____  ___  ____  ____  ____  _  _ 
+               [__   |__]  |__|  |__/  [__   |___  [__    |   |__/  |___  |__|  |\/| 
+               ___]  |     |  |  |  \  ___]  |___  ___]   |   |  \  |___  |  |  |  | 
+                                                                                          
       *** SparseStream classifies the sentiment and topic of finance-related tweets in a real-time stream. ***
 
 
-## <div>`INTRO`</div>
+## `INTRO`
 
-<samp>
-
-<div>
 The purpose of this app is for you to familiarize yourself with the high performance inference speeds of sparse models in a streaming environment. You will be able to use this app to classify tweets in a real-time stream.
-</div>
 
 <br />
 
 [Getting Started with the DeepSparse Engine](https://github.com/neuralmagic/deepsparse)
 
-## <div>`INSTALL`</div>
+## `INSTALL`
 
 Supports Python >= 3.7
 
@@ -43,6 +39,11 @@ git clone https://github.com/neuralmagic/deepsparse.git
 cd deepsparse/examples/sparsestream
 pip install -r requirements.txt
 ```
+
+## `Config`
+
+In order to connect with the Twitter streaming API, you will need to get access to the `consumer key`, `consumer secret`, `access token` and `access token secret` which you’ll receive after applying for a Twitter app via the [Twitter developer site](https://developer.twitter.com/en). Access to these tokens are free and the only requirement one needs is to own a Twitter account. After getting approved by Twitter for your app, generate and paste the 4 tokens to the `config.yaml` file.
+
 ## <div>`START STREAM`</div>
 
 In a terminal, start a Twitter stream with:

--- a/examples/sparsestream/README.md
+++ b/examples/sparsestream/README.md
@@ -42,7 +42,7 @@ pip install -r requirements.txt
 
 ## `CONFIGURING API`
 
-In order to connect with the Twitter streaming API, you will need to get access to the `consumer key`, `consumer secret`, `access token` and `access token secret` which you’ll receive after applying for a Twitter app via the [Twitter developer site](https://developer.twitter.com/en). You'll get access to these tokens after your app is approved by Twitter. Afterwards, add these four tokens to the `config.yaml` file before starting your stream.
+In order to connect with the Twitter streaming API, access to the `consumer key`, `consumer secret`, `access token` and `access token secret` is required before getting started. These tokens will be available after applying for a Twitter app via the [Twitter developer site](https://developer.twitter.com/en). Afterwards, add these four tokens to the `config.yaml` file before starting the stream.
 
 ## `START STREAM`
 

--- a/examples/sparsestream/README.md
+++ b/examples/sparsestream/README.md
@@ -40,11 +40,11 @@ cd deepsparse/examples/sparsestream
 pip install -r requirements.txt
 ```
 
-## `Config`
+## `CONFIGURING API`
 
-In order to connect with the Twitter streaming API, you will need to get access to the `consumer key`, `consumer secret`, `access token` and `access token secret` which you’ll receive after applying for a Twitter app via the [Twitter developer site](https://developer.twitter.com/en). Access to these tokens are free and the only requirement one needs is to own a Twitter account. After getting approved by Twitter for your app, generate and paste the 4 tokens to the `config.yaml` file.
+In order to connect with the Twitter streaming API, you will need to get access to the `consumer key`, `consumer secret`, `access token` and `access token secret` which you’ll receive after applying for a Twitter app via the [Twitter developer site](https://developer.twitter.com/en). You'll get access to these tokens after your app is approved by Twitter. Afterwards, add these four tokens to the `config.yaml` file before starting your stream.
 
-## <div>`START STREAM`</div>
+## `START STREAM`
 
 In a terminal, start a Twitter stream with:
 ```bash
@@ -53,7 +53,7 @@ python stream.py
 
 This will download sparse-optimized models and initialize two NLP inference pipelines for the financial text classification task: one pipeline for sentiment classification and the other for topic classification.
 
-## <div>`STREAM WHILE YOU EAT SOME POPCORN 🍿`</div>
+## `STREAM WHILE YOU EAT SOME POPCORN 🍿`
 
 Tweets should now be streaming in you terminal, and you should see three objects per tweet:
 

--- a/examples/sparsestream/README.md
+++ b/examples/sparsestream/README.md
@@ -55,7 +55,7 @@ This will download sparse-optimized models and initialize two NLP inference pipe
 
 ## `STREAM WHILE YOU EAT SOME POPCORN 🍿`
 
-Tweets should now be streaming in you terminal, and you should see three objects per tweet:
+Tweets should now be streaming in your terminal, and you should see three objects per tweet:
 
 - `tweet`: The tweet received from the Twitter API.
 - `sentiment`: The tweet's sentiment: `Bullish` or `Bearish` or `Neutral`


### PR DESCRIPTION
adding context to the README highlighting to users that they need to add their own API tokens to the config file.