### PR TITLE
Moving licenses from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_files = licenses/*
+
 [isort]
 profile = black
 default_section = FIRSTPARTY

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_files = licenses/*
+license_files = licenses/* src/deepsparse/licenses/*
 
 [isort]
 profile = black

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ _PACKAGE_NAME = (
 )
 
 # File regexes for binaries to include in package_data
-binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin", "licenses/*"]
+binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
 
 def _parse_requirements_file(file_path):


### PR DESCRIPTION
Since licenses will be at top level instead of src/deepsparse level, this adds support for copying all licenses into <package>-dist-info directory when installed.

I.e. this is the contents of the dist info directory after install:
```bash
lib/python3.9/site-packages/deepsparse_nightly-1.2.0.20221101.dist-info/
total 124
drwxrwsr-x  2 corey corey  4096 Nov  1 15:20 ./
drwxrwsr-x 43 corey corey  4096 Nov  1 15:20 ../
-rwxrwxr-x  1 corey corey  1338 Nov  1 15:20 boost.license*
-rw-rw-r--  1 corey corey   856 Nov  1 15:20 entry_points.txt
-rwxrwxr-x  1 corey corey  1461 Nov  1 15:20 fmath.license*
-rw-rw-r--  1 corey corey     4 Nov  1 15:20 INSTALLER
-rwxrwxr-x  1 corey corey  1076 Nov  1 15:20 json.license*
-rwxrwxr-x  1 corey corey  1075 Nov  1 15:20 jwt-cpp.license*
-rwxrwxr-x  1 corey corey  1057 Nov  1 15:20 libnpy.license*
-rwxrwxr-x  1 corey corey  3305 Nov  1 15:20 libstdc++.license*
-rw-rw-r--  1 corey corey 22842 Nov  1 15:20 METADATA
-rwxrwxr-x  1 corey corey  1098 Nov  1 15:20 onnx.license*
-rwxrwxr-x  1 corey corey  1078 Nov  1 15:20 onnx-runtime.license*
-rwxrwxr-x  1 corey corey  1732 Nov  1 15:20 protobuf.license*
-rwxrwxr-x  1 corey corey  1684 Nov  1 15:20 pybind11.license*
-rw-rw-r--  1 corey corey 16871 Nov  1 15:20 RECORD
-rwxrwxr-x  1 corey corey   550 Nov  1 15:20 spookyhash.license*
-rwxrwxr-x  1 corey corey  1384 Nov  1 15:20 tinyformat.license*
-rw-rw-r--  1 corey corey    11 Nov  1 15:20 top_level.txt
-rw-rw-r--  1 corey corey    92 Nov  1 15:20 WHEEL
-rwxrwxr-x  1 corey corey  3446 Nov  1 15:20 xbyak.license*
-rwxrwxr-x  1 corey corey  1284 Nov  1 15:20 zlib.license*
```