### PR TITLE
[Cherry pick] Moving licenses from setup.py to setup.cfg (#738)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+license_files = licenses/* src/deepsparse/licenses/*
+
 [isort]
 profile = black
 default_section = FIRSTPARTY

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if is_enterprise:
     os.remove(license_nm_path)
 
 # File regexes for binaries to include in package_data
-binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin", "licenses/*"]
+binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
 
 def _parse_requirements_file(file_path):


### PR DESCRIPTION
* Moving licenses from setup.py to setup.cfg

* Adding src/deepsparse/licenses/* to setup.cfg