### PR TITLE
Updating default embedding extraction stub

### DIFF
--- a/src/deepsparse/transformers/pipelines/embedding_extraction.py
+++ b/src/deepsparse/transformers/pipelines/embedding_extraction.py
@@ -100,7 +100,7 @@ class ExtractionStrategy(str, Enum):
     task_aliases=[],
     default_model_path=(
         "zoo:nlp/masked_language_modeling/bert-base/pytorch/huggingface/"
-        "wikipedia_bookcorpus/12layer_pruned80_quant-none-vnni"
+        "wikipedia_bookcorpus/pruned80_quant-none-vnni"
     ),
 )
 class EmbeddingExtractionPipeline(TransformersPipeline):


### PR DESCRIPTION
This is because the stub was updated to have 12layer removed