### PR TITLE
Update NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -9,7 +9,9 @@ Version 2.0, an Apache-compatible license.
 * For a copy of the Apache License Version 2.0, please see LICENSE
   as included in the top-level directory of the deepsparse GitHub repository.
 
-* For a copy of the Neural Magic Engine License (which governs the DeepSparse Community Edition only), please see LICENSE-NEURALMAGIC as included in the top-level directory of the deepsparse GitHub repository.
+The Community Edition of the project's binary containing the DeepSparse Engine is licensed under the Neural Magic Engine License (https://github.com/neuralmagic/deepsparse/blob/main/LICENSE-NEURALMAGIC). Example files and scripts included in the deepsparse GitHub repository are licensed under the Apache License Version 2.0 (https://github.com/neuralmagic/deepsparse/blob/main/LICENSE) as noted.
+
+The Enterprise Edition of the DeepSparse Engine (https://docs.neuralmagic.com/products/deepsparse-ent) requires a Trial License or can be fully licensed (https://neuralmagic.com/legal/master-software-license-and-service-agreement/) for production, commercial applications.
 
 * For a copy of all other Apache-compatible licenses and notices,
   they will be referenced below.

--- a/NOTICE
+++ b/NOTICE
@@ -3,13 +3,13 @@ Copyright 2021 - present / Neuralmagic, Inc. All Rights Reserved.
 
 This product includes software developed at Neuralmagic, Inc. (https://www.neuralmagic.com).
 
-Source code in this repository is variously licensed under the Apache License
+Source code in the deepsparse GitHub repository is variously licensed under the Apache License
 Version 2.0, an Apache-compatible license.
 
 * For a copy of the Apache License Version 2.0, please see LICENSE
-  as included in this repository's top-level directory.
+  as included in the top-level directory of the deepsparse GitHub repository.
 
-* For a copy of the Neural Magic Engine License, please see LICENSE-NEURALMAGIC as included in this repository's top-level directory.
+* For a copy of the Neural Magic Engine License (which governs the DeepSparse Community Edition only), please see LICENSE-NEURALMAGIC as included in the top-level directory of the deepsparse GitHub repository.
 
 * For a copy of all other Apache-compatible licenses and notices,
   they will be referenced below.
@@ -18,11 +18,11 @@ Version 2.0, an Apache-compatible license.
 NOTICES
 ========================================================================
 
-All implementations in this repository are subject to Neural Magic's Legal Policies
+All implementations in this repository or directory are subject to Neural Magic's Legal Policies
 https://www.neuralmagic.com/legal
 
-Package dependencies are defined in the Python setup.py file in this repository's top-level directory and have their own Apache-compatible licenses and terms.
+Package dependencies are defined in the Python setup.py file in the top-level directory of the deepsparse GitHub repository and have their own Apache-compatible licenses and terms.
 
 ONNX License https://github.com/onnx/onnx/blob/main/LICENSE
 
-Other external dependencies, if referenced in this repository's various subdirectories, are subject to their associated licenses and terms.
+Other external dependencies, if referenced in the various subdirectories, are subject to their associated licenses and terms.


### PR DESCRIPTION
If this were downloaded to either community edition or enterprise edition through PyPI, it'd still be correct in both cases and should have us covered. 

To be revisited in the future, to update licenses and such down the line. This is a shorter term fix.

We will get Judson to review from the legal side. 