### PR TITLE
Remove import deepsparse/utils/annotate.py from utils/__init__.py

### DIFF
--- a/src/deepsparse/image_classification/annotate.py
+++ b/src/deepsparse/image_classification/annotate.py
@@ -73,7 +73,7 @@ import cv2
 from deepsparse.image_classification.constants import IMAGENET_LABELS
 from deepsparse.image_classification.utils import annotate_image
 from deepsparse.pipeline import Pipeline
-from deepsparse.utils import (
+from deepsparse.utils.annotate import (
     annotate,
     get_annotations_save_dir,
     get_image_loader_and_saver,

--- a/src/deepsparse/utils/__init__.py
+++ b/src/deepsparse/utils/__init__.py
@@ -14,6 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .annotate import *
 from .data import *
 from .onnx import *

--- a/src/deepsparse/yolact/annotate.py
+++ b/src/deepsparse/yolact/annotate.py
@@ -70,7 +70,7 @@ import click
 
 import cv2
 from deepsparse.pipeline import Pipeline
-from deepsparse.utils import (
+from deepsparse.utils.annotate import (
     annotate,
     get_annotations_save_dir,
     get_image_loader_and_saver,

--- a/src/deepsparse/yolo/annotate.py
+++ b/src/deepsparse/yolo/annotate.py
@@ -71,7 +71,7 @@ import click
 
 import cv2
 from deepsparse.pipeline import Pipeline
-from deepsparse.utils import (
+from deepsparse.utils.annotate import (
     annotate,
     get_annotations_save_dir,
     get_image_loader_and_saver,


### PR DESCRIPTION
By default we don't install opencv, so right now anything that imports from utils will try to import opencv and fail.

This will result in errors like:
```
numactl -N0 -m0 -C0-7 deepsparse.benchmark zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/pruned95_obs_quant-none -s sync
Traceback (most recent call last):
  File ".../nm-dev/bin/deepsparse.benchmark", line 5, in <module>
    from deepsparse.benchmark.benchmark_model import main
  File ".../nm-dev/lib/python3.9/site-packages/deepsparse/__init__.py", line 33, in <module>
    from .engine import *
  File ".../nm-dev/lib/python3.9/site-packages/deepsparse/engine.py", line 27, in <module>
    from deepsparse.benchmark import BenchmarkResults
  File ".../nm-dev/lib/python3.9/site-packages/deepsparse/benchmark/__init__.py", line 17, in <module>
    from .ort_engine import *
  File ".../nm-dev/lib/python3.9/site-packages/deepsparse/benchmark/ort_engine.py", line 20, in <module>
    from deepsparse.utils import (
  File ".../nm-dev/lib/python3.9/site-packages/deepsparse/utils/__init__.py", line 17, in <module>
    from .annotate import *
  File ".../nm-dev/lib/python3.9/site-packages/deepsparse/utils/annotate.py", line 32, in <module>
    import cv2
  File ".../nm-dev/lib/python3.9/site-packages/cv2/__init__.py", line 181, in <module>
    bootstrap()
  File ".../nm-dev/lib/python3.9/site-packages/cv2/__init__.py", line 153, in bootstrap
    native_module = importlib.import_module("cv2")
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```

This PR just removes the annotate file from the `__init__.py` file, meaning users specifically have to import from annotate now