### PR TITLE
Add fraction_of_supported_ops property to Engine

### DIFF
--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -291,6 +291,13 @@ class Engine(object):
         return self._scheduler
 
     @property
+    def fraction_of_supported_ops(self) -> float:
+        """
+        :return: The portion of the network supported by optimized runtime.
+        """
+        return round(self._eng_net.fraction_of_supported_ops(), 4)
+
+    @property
     def cpu_avx_type(self) -> str:
         """
         :return: The detected cpu avx type that neural magic is running with.
@@ -590,6 +597,7 @@ class Engine(object):
             "num_cores": self.num_cores,
             "num_streams": self.num_streams,
             "scheduler": self.scheduler,
+            "fraction_of_supported_ops": self.fraction_of_supported_ops,
             "cpu_avx_type": self.cpu_avx_type,
             "cpu_vnni": self.cpu_vnni,
         }


### PR DESCRIPTION
Exposes a function that contains the portion of model operations that are supported by DeepSparse's sparse execution. Also puts this in the Engine properties so it is printed alongside other details.

Before
```
deepsparse.benchmark.benchmark_model INFO     deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/15a1359c-6389-4ffd-ab06-d44a945159c2/model.onnx
        batch_size: 1
        num_cores: 8
        num_streams: 1
        scheduler: Scheduler.default
        cpu_avx_type: avx512
        cpu_vnni: False
```

After
```
deepsparse.benchmark.benchmark_model INFO     deepsparse.engine.Engine:
        onnx_file_path: /home/mgoin/.cache/sparsezoo/15a1359c-6389-4ffd-ab06-d44a945159c2/model.onnx
        batch_size: 1
        num_cores: 8
        num_streams: 1
        scheduler: Scheduler.default
        fraction_of_supported_ops: 0.9963
        cpu_avx_type: avx512
        cpu_vnni: False
```