### PR TITLE
restrict max fastpi version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ _server_deps = [
     "requests>=2.26.0",
     "python-multipart>=0.0.5",
     "prometheus-client>=0.14.1",
+    "httpx >=0.23.0,<0.24.0",
 ]
 _onnxruntime_deps = [
     "onnxruntime>=1.7.0",

--- a/setup.py
+++ b/setup.py
@@ -103,12 +103,11 @@ _dev_deps = [
 ]
 _server_deps = [
     "uvicorn>=0.15.0",
-    "fastapi>=0.70.0",
+    "fastapi>=0.70.0,<0.87.0",
     "pydantic>=1.8.2",
     "requests>=2.26.0",
     "python-multipart>=0.0.5",
     "prometheus-client>=0.14.1",
-    "httpx >=0.23.0,<0.24.0",
 ]
 _onnxruntime_deps = [
     "onnxruntime>=1.7.0",


### PR DESCRIPTION
fastapi dropped httpx as a dependency and has a few other dependency changes causing issues in `0.87`. this PR restricts the max supported fastapi version to resolve these and unblock development. future work should reconcile dependencies to support later versions.

**test_plan:**
GHA tests now passing