### PR TITLE
[data-logging] support server default logging of all pipeline 'SYSTEM' logs

### DIFF
--- a/src/deepsparse/loggers/function_logger.py
+++ b/src/deepsparse/loggers/function_logger.py
@@ -70,7 +70,10 @@ class FunctionLogger(BaseLogger):
         :param category: The metric category that the log belongs to
         """
         extracted_value = match_and_extract(
-            template=self.target_identifier, identifier=identifier, value=value
+            template=self.target_identifier,
+            identifier=identifier,
+            value=value,
+            category=category,
         )
         # `None` can be a valid, extracted value.
         #  Hence, we check for `NO_MATCH` flag

--- a/src/deepsparse/server/build_logger.py
+++ b/src/deepsparse/server/build_logger.py
@@ -25,8 +25,9 @@ from deepsparse import (
     PrometheusLogger,
     PythonLogger,
 )
+from deepsparse.loggers import MetricCategories
 from deepsparse.loggers.helpers import get_function_and_function_name
-from deepsparse.server.config import ServerConfig
+from deepsparse.server.config import MetricFunctionConfig, ServerConfig
 
 
 __all__ = ["build_logger"]
@@ -56,9 +57,16 @@ def build_logger(server_config: ServerConfig) -> BaseLogger:
     if not loggers_config:
         return None
 
+    # base level loggers that log raw values for monitoring. ie python, prometheus
     leaf_loggers = build_leaf_loggers(loggers_config)
-    loggers = build_function_loggers(server_config.endpoints, leaf_loggers)
-    return MultiLogger(loggers)
+
+    # loggers that match to logged identifiers and apply transforms before leaf logging
+    function_loggers = build_function_loggers(server_config.endpoints, leaf_loggers)
+
+    # add logger to ensure leaf level logging of all system (timing) logs
+    function_loggers.append(_create_system_logger(leaf_loggers))
+
+    return MultiLogger(function_loggers)
 
 
 def build_leaf_loggers(
@@ -109,6 +117,18 @@ def build_function_loggers(
                     _build_function_logger(metric_function, target_identifier, loggers)
                 )
     return function_loggers
+
+
+def _create_system_logger(loggers: Dict[str, BaseLogger]) -> FunctionLogger:
+    # returns a function logger that matches to all system logs, logging
+    # every system call to each leaf logger
+    return _build_function_logger(
+        metric_function_cfg=MetricFunctionConfig(
+            func="identity", frequency=1, target_loggers=None
+        ),
+        target_identifier=f"category:{MetricCategories.SYSTEM.value}",
+        loggers=loggers,
+    )
 
 
 def _build_function_logger(

--- a/src/deepsparse/server/config.py
+++ b/src/deepsparse/server/config.py
@@ -24,6 +24,7 @@ from deepsparse.tasks import SupportedTasks
 __all__ = [
     "ServerConfig",
     "EndpointConfig",
+    "MetricFunctionConfig",
     "SequenceLengthsConfig",
     "ImageSizesConfig",
 ]

--- a/tests/deepsparse/loggers/test_helpers.py
+++ b/tests/deepsparse/loggers/test_helpers.py
@@ -16,6 +16,7 @@ import numpy
 
 import pytest
 import torch
+from deepsparse.loggers import MetricCategories
 from deepsparse.loggers.helpers import (
     check_identifier_match,
     get_function_and_function_name,
@@ -53,18 +54,22 @@ def test_get_function_and_function_name(
 
 
 @pytest.mark.parametrize(
-    "template, identifier, expected_output",
+    "template, identifier, category, expected_output",
     [
-        ("string_1.string_2", "string_1.string_2", (True, None)),
-        ("string_1.string_3", "string_1.string_2", (False, None)),
+        ("string_1.string_2", "string_1.string_2", None, (True, None)),
+        ("string_1.string_3", "string_1.string_2", None, (False, None)),
         (
             "string_1.string_2.string_3.string_4",
             "string_1.string_2",
+            None,
             (True, "string_3.string_4"),
         ),
-        ("re:string_*..*.string.*", "string_1.string_2", (True, None)),
-        ("re:string_*..*.string.*", "string_3.string_4", (True, None)),
+        ("re:string_*..*.string.*", "string_1.string_2", None, (True, None)),
+        ("re:string_*..*.string.*", "string_3.string_4", None, (True, None)),
+        ("category:system", "string_3.string_4", MetricCategories.SYSTEM, (True, None)),
+        ("category:system", "string_3.string_4", MetricCategories.DATA, (False, None)),
+        ("category:system", "string_3.string_4", None, (False, None)),
     ],
 )
-def test_match(template, identifier, expected_output):
-    assert check_identifier_match(template, identifier) == expected_output
+def test_match(template, identifier, category, expected_output):
+    assert check_identifier_match(template, identifier, category) == expected_output

--- a/tests/server/test_build_logger.py
+++ b/tests/server/test_build_logger.py
@@ -15,6 +15,7 @@
 import yaml
 
 import pytest
+from deepsparse.loggers import MetricCategories
 from deepsparse.server.build_logger import build_logger
 from deepsparse.server.config import ServerConfig
 from tests.helpers import find_free_port
@@ -147,4 +148,11 @@ def test_build_logger(yaml_config, raises_error, returns_logger, num_function_lo
     assert bool(logger) == returns_logger
     if not returns_logger:
         return
-    assert len(logger.loggers) == num_function_loggers
+    assert len(logger.loggers) == num_function_loggers + 1
+    # check for system logger
+    system_logger = logger.loggers[-1]
+    assert system_logger.target_identifier == (
+        f"category:{MetricCategories.SYSTEM.value}"
+    )
+    assert system_logger.function_name == "identity"
+    assert system_logger.frequency == 1


### PR DESCRIPTION
Currently, for a log to be propagated, the user must add a function logger definition for it in the endpoint config

By default, we would like to enable the logging of all pipeline system logs (right now this includes just the base timings recorded by the pipeline). This PR enables the propagating of these logs with the following changes:

1) support for a new identifier pattern `category:<CATEGORY>` which matches to any log of a given `MetricCategories` value
2) adding a function logger in build loggers that matches to `category:system` and passes these logs through on each call with an `identity` function

future work will enable the user to disable specific or all system logs via the config, logic for this may be added through updates to `_create_system_logger`

**test_plan**:
unit tests for identifier matching and `build_logger` updated