### PR TITLE
[data-logging] AsyncLogger implementation

### DIFF
--- a/src/deepsparse/loggers/__init__.py
+++ b/src/deepsparse/loggers/__init__.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base_logger import *
-
 # flake8: noqa
+# isort: skip_file
+
+# base modules
+from .base_logger import *
 from .constants import *
+
+# logger implementations
+from .async_logger import *
 from .function_logger import *
 from .multi_logger import *
 from .prometheus_logger import *

--- a/src/deepsparse/loggers/async_logger.py
+++ b/src/deepsparse/loggers/async_logger.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Logger wrapper to run log calls asynchronously to not block the main process
+"""
+
+import logging
+from concurrent.futures import Executor, ThreadPoolExecutor
+from typing import Any
+
+from deepsparse.loggers import BaseLogger, MetricCategories
+
+
+__all__ = ["AsyncLogger"]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AsyncLogger(BaseLogger):
+    """
+    Logger wrapper that forwards log calls to run asynchronously, freeing
+    the main process. No call back/returned future currently provided
+
+    :param logger: logger object to wrap
+    :param max_workers: maximum logging tasks to run in the job pool at once.
+        defaults to 1
+    """
+
+    def __init__(self, logger: BaseLogger, max_workers: int = 1):
+        self.logger = logger
+        self._job_pool: Executor = ThreadPoolExecutor(max_workers=max_workers)
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        """
+        Forward log calls to wrapped logger to run asynchronously
+
+        :param identifier: The name of the item that is being logged.
+        :param value: The data structure that the logger is logging
+        :param category: The metric category that the log belongs to
+        """
+        job_future = self._job_pool.submit(
+            self.logger.log,
+            identifier=identifier,
+            value=value,
+            category=category,
+        )
+        job_future.add_done_callback(_log_async_job_exception)
+
+
+def _log_async_job_exception(future):
+    exception = future.exception()
+    if exception is not None:
+        _LOGGER.error(f"Exception occurred during async logging job: {repr(exception)}")

--- a/src/deepsparse/server/build_logger.py
+++ b/src/deepsparse/server/build_logger.py
@@ -18,7 +18,8 @@ Specifies the mapping from the ServerConfig to the DeepSparse Logger
 
 from typing import Any, Dict, List, Optional
 
-from deepsparse import (
+from deepsparse.loggers import (
+    AsyncLogger,
     BaseLogger,
     FunctionLogger,
     MultiLogger,
@@ -58,7 +59,10 @@ def build_logger(server_config: ServerConfig) -> BaseLogger:
 
     leaf_loggers = build_leaf_loggers(loggers_config)
     loggers = build_function_loggers(server_config.endpoints, leaf_loggers)
-    return MultiLogger(loggers)
+    return AsyncLogger(
+        logger=MultiLogger(loggers),  # wrap all loggers to async log call
+        max_workers=1,
+    )
 
 
 def build_leaf_loggers(

--- a/tests/deepsparse/loggers/helpers.py
+++ b/tests/deepsparse/loggers/helpers.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helper classes and functions for testing deepsparse.loggers
+"""
+
+import os
+from datetime import datetime
+from time import sleep
+from typing import Any
+
+from deepsparse.loggers import BaseLogger, MetricCategories
+
+
+__all__ = [
+    "ErrorLogger",
+    "FileLogger",
+    "NullLogger",
+    "SleepLogger",
+]
+
+
+class ErrorLogger(BaseLogger):
+    # raises an error on log for testing purposes
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        raise RuntimeError("Raising for testing purposes")
+
+
+class FileLogger(BaseLogger):
+    # NOT THREAD SAFE - should be used for testing accordingly
+    # logs results by appending to the given file_path
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+
+        # create file
+        if not os.path.exists(self.file_path):
+            with open(self.file_path, "w"):
+                pass
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        msg = (
+            f" Identifier: {identifier} | Category: {category.value} "
+            f"| Logged Data: {value}"
+        )
+        msg = datetime.now().strftime("%d/%m/%Y %H:%M:%S:%f") + msg
+
+        with open(self.file_path, "a") as file:
+            file.write(msg + "\n")
+
+
+class NullLogger(BaseLogger):
+    # leaf logger that does nothing
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        pass
+
+
+class SleepLogger(BaseLogger):
+    # sleeps thread for sleep_time before forwarding to wrapped logger
+
+    def __init__(self, logger: BaseLogger, sleep_time: int = 1):
+        self.logger = logger
+        self.sleep_time = sleep_time
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        sleep(self.sleep_time)
+        self.logger.log(identifier=identifier, value=value, category=category)

--- a/tests/deepsparse/loggers/test_async_logger.py
+++ b/tests/deepsparse/loggers/test_async_logger.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+import time
+from pathlib import Path
+
+import numpy
+
+import pytest
+from deepsparse.loggers import AsyncLogger, FunctionLogger, MetricCategories
+from tests.deepsparse.loggers.helpers import (
+    ErrorLogger,
+    FileLogger,
+    NullLogger,
+    SleepLogger,
+)
+
+
+def _build_sleep_logger():
+    return SleepLogger(logger=NullLogger(), sleep_time=0.3)
+
+
+def _build_numpy_function_logger():
+    return FunctionLogger(
+        logger=NullLogger(),
+        target_identifier="test_log",
+        function_name="mean",
+        function=numpy.mean,
+        frequency=1,
+    )
+
+
+@pytest.mark.parametrize(
+    "base_logger_lambda,logged_value_lambda",
+    [
+        # tests that a logger that sleeps for 1s does not block
+        (_build_sleep_logger, lambda: None),
+        # tests 1) numpy functions and arrays may be submitted to async backend
+        # 2) even if logged value is large, submission does not significantly
+        # block (relevant if executor changes and requires serialization/IPC)
+        (_build_numpy_function_logger, lambda: numpy.random.randn(int(3e7))),
+    ],
+)
+def test_async_log_is_non_blocking(base_logger_lambda, logged_value_lambda):
+    logger = AsyncLogger(logger=base_logger_lambda())
+    logged_value = logged_value_lambda()
+
+    # allow for max elapsed time of 0.1 ms
+    _log_and_test_time_elasped(logger, logged_value, 0.1)
+
+
+def test_async_log_executes(tmp_path: Path):
+    log_file_path = tmp_path / "test_logs.txt"
+    logger = AsyncLogger(logger=FileLogger(file_path=log_file_path))
+
+    with open(log_file_path, "r") as file:
+        # base check that no logs have been written
+        assert len(file.readlines()) == 0
+
+    # log sample value to file
+    logged_value = "test_log_value"
+    _log_and_test_time_elasped(logger, logged_value, 0.1)
+
+    # sleep to allow log job to complete then check file has been updated
+    time.sleep(0.5)
+    with open(log_file_path, "r") as file:
+        # base check that no logs have been written
+        logged_items = file.readlines()
+
+    assert len(logged_items) == 1
+    assert logged_value in logged_items[0]
+
+
+def test_async_logger_error_propagation(caplog):
+    logger = AsyncLogger(logger=ErrorLogger())
+
+    # listen for expected ERROR log
+    caplog.set_level(logging.ERROR)
+    assert len(caplog.messages) == 0  # check no logs have been issued yet
+
+    logger.log("test_log", 1.0, MetricCategories.SYSTEM)
+    time.sleep(0.5)
+
+    assert len(caplog.messages) == 1
+    assert "RuntimeError('Raising for testing purposes')" in caplog.messages[0]
+
+
+def _log_and_test_time_elasped(logger, logged_value, max_time_elapsed_ms):
+    log_call_start = time.time()
+    logger.log("test_log", logged_value, MetricCategories.SYSTEM)
+    log_call_time_ms = time.time() - log_call_start
+
+    assert log_call_time_ms <= 0.1

--- a/tests/server/test_build_logger.py
+++ b/tests/server/test_build_logger.py
@@ -15,6 +15,7 @@
 import yaml
 
 import pytest
+from deepsparse.loggers import AsyncLogger, MultiLogger
 from deepsparse.server.build_logger import build_logger
 from deepsparse.server.config import ServerConfig
 from tests.helpers import find_free_port
@@ -147,4 +148,7 @@ def test_build_logger(yaml_config, raises_error, returns_logger, num_function_lo
     assert bool(logger) == returns_logger
     if not returns_logger:
         return
-    assert len(logger.loggers) == num_function_loggers
+
+    assert isinstance(logger, AsyncLogger)
+    assert isinstance(logger.logger, MultiLogger)
+    assert len(logger.logger.loggers) == num_function_loggers

--- a/tests/server/test_prometheus.py
+++ b/tests/server/test_prometheus.py
@@ -29,7 +29,7 @@ def test_instantiate_prometheus(tmp_path):
                     prometheus={
                         "port": find_free_port(),
                         "text_log_save_dir": str(tmp_path),
-                        "text_log_save_freq": 30,
+                        "text_log_save_frequency": 30,
                     }
                 ),
             )


### PR DESCRIPTION
basic implementation for a `AsyncLogger` that submits logging jobs that do not block the main process.

current implementation uses a threadpool, however should further evaluate tradeoffs with process pool, and potential future need for a more sophisticated job worker

open questions:
* how to best propagate errors after jobs have been submitted and user requests have been returned. currently issuing a python `error` log that displays the error message however this is more of a "silent" failure which is not ideal - a separate job worker may be able to better handle this
* exploration of limitations of executors and potential overhead added

**test_plan:**
included tests to verify that calls are non blocking, numpy arrays and functions may be submitted, verification of job run and error propagation

more thorough testing should be added in E2E tests