### PR TITLE
[Data Logging] Custom Logger

### DIFF
--- a/src/deepsparse/server/build_logger.py
+++ b/src/deepsparse/server/build_logger.py
@@ -27,6 +27,7 @@ from deepsparse import (
 )
 from deepsparse.loggers.helpers import get_function_and_function_name
 from deepsparse.server.config import ServerConfig
+from deepsparse.server.helpers import custom_logger_from_identifier
 
 
 __all__ = ["build_logger"]
@@ -72,15 +73,20 @@ def build_leaf_loggers(
     """
     loggers = {}
     for logger_name, logger_arguments in loggers_config.items():
-
-        logger_to_instantiate = _LOGGER_MAPPING.get(logger_name)
-        if logger_to_instantiate is None:
-            raise ValueError(
-                f"Unknown logger name: {logger_name}. "
-                f"supported logger names: {list(_LOGGER_MAPPING.keys())}"
-            )
-        logger_arguments = {} if logger_arguments is None else logger_arguments
-        leaf_logger = logger_to_instantiate(**logger_arguments)
+        path_custom_logger = logger_arguments.get("path")
+        if path_custom_logger:
+            # if `path` argument is provided, use the custom logger
+            leaf_logger = _build_custom_logger(logger_arguments)
+        else:
+            # otherwise, use the built-in logger
+            logger_to_instantiate = _LOGGER_MAPPING.get(logger_name)
+            if logger_to_instantiate is None:
+                raise ValueError(
+                    f"Unknown logger name: {logger_name}. "
+                    f"supported logger names: {list(_LOGGER_MAPPING.keys())}"
+                )
+            logger_arguments = {} if logger_arguments is None else logger_arguments
+            leaf_logger = logger_to_instantiate(**logger_arguments)
         loggers.update({logger_name: leaf_logger})
     return loggers
 
@@ -137,6 +143,17 @@ def _build_function_logger(
         function_name=function_name,
         frequency=metric_function_cfg.frequency,
     )
+
+
+def _build_custom_logger(logger_arguments: Dict[str, Any]) -> BaseLogger:
+    custom_logger_identifier = logger_arguments.pop("path")
+    logger = custom_logger_from_identifier(custom_logger_identifier)(**logger_arguments)
+    if not isinstance(logger, BaseLogger):
+        raise ValueError(
+            f"Custom logger must be a subclass of BaseLogger. "
+            f"Got {type(logger)} instead."
+        )
+    return logger
 
 
 def _get_target_identifier(endpoint_name: str, target_name: str) -> str:

--- a/src/deepsparse/server/build_logger.py
+++ b/src/deepsparse/server/build_logger.py
@@ -147,7 +147,7 @@ def _build_function_logger(
 
 def _build_custom_logger(logger_arguments: Dict[str, Any]) -> BaseLogger:
     # gets the identifier from logger arguments and simultaneously
-    # remove the identifier from the arguments
+    # removes the identifier from the arguments
     custom_logger_identifier = logger_arguments.pop("path")
     logger = custom_logger_from_identifier(custom_logger_identifier)(**logger_arguments)
     if not isinstance(logger, BaseLogger):

--- a/src/deepsparse/server/build_logger.py
+++ b/src/deepsparse/server/build_logger.py
@@ -146,6 +146,8 @@ def _build_function_logger(
 
 
 def _build_custom_logger(logger_arguments: Dict[str, Any]) -> BaseLogger:
+    # gets the identifier from logger arguments and simultaneously
+    # remove the identifier from the arguments
     custom_logger_identifier = logger_arguments.pop("path")
     logger = custom_logger_from_identifier(custom_logger_identifier)(**logger_arguments)
     if not isinstance(logger, BaseLogger):

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -15,14 +15,32 @@
 Helper functions for deepsparse.server
 """
 
+import importlib
 import logging
+from typing import Type
 
 from deepsparse import BaseLogger, PythonLogger
 
 
-__all__ = ["log_system_info", "default_logger"]
+__all__ = ["log_system_info", "default_logger", "custom_logger_from_identifier"]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def custom_logger_from_identifier(custom_logger_identifier: str) -> Type[BaseLogger]:
+    """
+    Parse the custom logger identifier and import a custom logger class object
+    from the user-specified script
+
+    :param custom_logger_identifier: string in the form of
+           '<path_to_the_python_script>:<custom_logger_class_name>
+    :return: Custom logger class object
+    """
+    path, logger_name = custom_logger_identifier.split(":")
+    spec = importlib.util.spec_from_file_location("user_defined_custom_logger", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, logger_name)
 
 
 def default_logger() -> BaseLogger:

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -29,18 +29,18 @@ _LOGGER = logging.getLogger(__name__)
 
 def custom_logger_from_identifier(custom_logger_identifier: str) -> Type[BaseLogger]:
     """
-    Parse the custom logger identifier and import a custom logger class object
-    from the user-specified script
+    Parse the custom logger identifier in order to import a custom logger class object
+    from the user-specified python script
 
     :param custom_logger_identifier: string in the form of
            '<path_to_the_python_script>:<custom_logger_class_name>
     :return: Custom logger class object
     """
-    path, logger_name = custom_logger_identifier.split(":")
+    path, logger_object_name = custom_logger_identifier.split(":")
     spec = importlib.util.spec_from_file_location("user_defined_custom_logger", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return getattr(module, logger_name)
+    return getattr(module, logger_object_name)
 
 
 def default_logger() -> BaseLogger:

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -34,7 +34,7 @@ def custom_logger_from_identifier(custom_logger_identifier: str) -> Type[BaseLog
 
     :param custom_logger_identifier: string in the form of
            '<path_to_the_python_script>:<custom_logger_class_name>
-    :return: Custom logger class object
+    :return: custom logger class object
     """
     path, logger_object_name = custom_logger_identifier.split(":")
     spec = importlib.util.spec_from_file_location("user_defined_custom_logger", path)

--- a/tests/deepsparse/loggers/helpers.py
+++ b/tests/deepsparse/loggers/helpers.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helper classes and functions for testing deepsparse.loggers
+"""
+
+import os
+from datetime import datetime
+from time import sleep
+from typing import Any
+
+from deepsparse.loggers import BaseLogger, MetricCategories
+
+
+__all__ = [
+    "ErrorLogger",
+    "FileLogger",
+    "NullLogger",
+    "SleepLogger",
+]
+
+
+class ErrorLogger(BaseLogger):
+    # raises an error on log for testing purposes
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        raise RuntimeError("Raising for testing purposes")
+
+
+class FileLogger(BaseLogger):
+    # NOT THREAD SAFE - should be used for testing accordingly
+    # logs results by appending to the given file_path
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+
+        # create file
+        if not os.path.exists(self.file_path):
+            with open(self.file_path, "w"):
+                pass
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        msg = (
+            f" Identifier: {identifier} | Category: {category.value} "
+            f"| Logged Data: {value}"
+        )
+        msg = datetime.now().strftime("%d/%m/%Y %H:%M:%S:%f") + msg
+
+        with open(self.file_path, "a") as file:
+            file.write(msg + "\n")
+
+
+class NullLogger(BaseLogger):
+    # leaf logger that does nothing
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        pass
+
+
+class SleepLogger(BaseLogger):
+    # sleeps thread for sleep_time before forwarding to wrapped logger
+
+    def __init__(self, logger: BaseLogger, sleep_time: int = 1):
+        self.logger = logger
+        self.sleep_time = sleep_time
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        sleep(self.sleep_time)
+        self.logger.log(identifier=identifier, value=value, category=category)
+
+
+class CustomLogger(BaseLogger):
+    # mock custom logger for testing purposes
+
+    def __init__(self, arg1, arg2):
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+    def log(self, identifier: str, value: Any, category: MetricCategories):
+        pass

--- a/tests/server/test_build_logger.py
+++ b/tests/server/test_build_logger.py
@@ -123,6 +123,24 @@ endpoints:
           - func: tests/test_data/metric_functions.py:user_defined_identity
             frequency: 2"""
 
+yaml_config_8 = """
+num_cores: 2
+num_workers: 2
+loggers:
+    custom_logger:
+        path: tests/deepsparse/loggers/helpers.py:CustomLogger
+        arg1: 1
+        arg2: some_string
+endpoints:
+    - task: question_answering
+      route: /unpruned/predict
+      model: zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/base-none
+      batch_size: 1
+      data_logging:
+        engine_outputs:
+           - func: np.mean
+             frequency: 3"""
+
 
 @pytest.mark.parametrize(
     "yaml_config, raises_error, returns_logger, num_function_loggers",
@@ -134,6 +152,7 @@ endpoints:
         (yaml_config_5, True, None, None),
         (yaml_config_6, False, True, 1),
         (yaml_config_7.format(port=find_free_port()), False, True, 1),
+        (yaml_config_8, False, True, 1),
     ],
 )
 def test_build_logger(yaml_config, raises_error, returns_logger, num_function_loggers):


### PR DESCRIPTION
Allows the user to specify their custom leaf loggers to use in the server.
First, the user needs to specify the path to the custom logger in the yaml config:
```yaml
num_cores: 2
num_workers: 2
loggers:
    custom_logger:
        path: tests/deepsparse/loggers/helpers.py:CustomLogger
        arg1: 1
        arg2: some_string
endpoints:
    - task: question_answering
      route: /unpruned/predict
      model: zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/base-none
```
Then, the logic of `build_logger` function will attempt to instantiate the `custom_logger`.
- will look for module `tests/deepsparse/loggers/helpers.py`
- try to import `CustomLogger` from the module
- instantiate the `CustomLogger` with the specified arguments
- finally, it will also check whether `CustomLogger` inherits from our internal `BaseLogger`
