### PR TITLE
[bug-fix] model extractor suport for onnx < 1.10

### DIFF
--- a/src/deepsparse/utils/extractor.py
+++ b/src/deepsparse/utils/extractor.py
@@ -116,6 +116,9 @@ class Extractor:
         self,
         nodes,  # type: List[NodeProto]
     ):  # type: (...) -> List[FunctionProto]
+        if not hasattr(self.model, "functions"):
+            # model.functions added in onnx v1.10, skip if not included in model
+            return []
         # a node in a model graph may refer a function.
         # a function contains nodes, some of which may in turn refer a function.
         # we need to find functions referred by graph nodes and

--- a/src/deepsparse/utils/extractor.py
+++ b/src/deepsparse/utils/extractor.py
@@ -119,6 +119,7 @@ class Extractor:
         if not hasattr(self.model, "functions"):
             # model.functions added in onnx v1.10, skip if not included in model
             return []
+
         # a node in a model graph may refer a function.
         # a function contains nodes, some of which may in turn refer a function.
         # we need to find functions referred by graph nodes and


### PR DESCRIPTION
fixes a bug found by @mgoin where a line of code references a property added by onnx 1.10. Deepsparse support lower versions, this PR adds a check