### PR TITLE
[zero_shot_classification] assign task to wrapped zero shot pipeline class

### DIFF
--- a/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
@@ -181,17 +181,20 @@ class ZeroShotTextClassificationPipeline(TransformersPipeline):
         model_scheme: str = ModelSchemes.mnli.value,
         **kwargs,
     ):
+        pipeline = None
         if model_scheme == ModelSchemes.mnli:
             from deepsparse.transformers.pipelines.mnli_text_classification import (
                 MnliTextClassificationPipeline,
             )
 
-            return MnliTextClassificationPipeline(model_path, **kwargs)
+            pipeline = MnliTextClassificationPipeline(model_path, **kwargs)
         else:
             raise ValueError(
                 f"Unknown model_scheme {model_scheme}. Currently supported model "
                 f"schemes are {ModelSchemes.to_list()}"
             )
+        pipeline.task = cls.task
+        return pipeline
 
 
 class ZeroShotTextClassificationInputBase(BaseModel):


### PR DESCRIPTION
the task attribute is generally assigned to pipeline classes at registration time, however since the zero shot pipeline routes the creation of new classes to a child class, the child class is not assigned their registered task name. this leads to an immediate error when the pipeline's task attribute is accessed during logging.

this pr assigns the task to the wrapped class

**test_plan:**
unit tests for mnli text classificaiton pipeline now passing on top of logging feature branch