### PR TITLE
[Open Pif Paf] STAGE 0 - onnx export and basic pipeline implementation

### DIFF
--- a/src/deepsparse/open_pif_paf/pipelines.py
+++ b/src/deepsparse/open_pif_paf/pipelines.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+OpenPifPafPipeline
+"""
+from typing import Type
+
+from deepsparse.open_pif_paf.schemas import OpenPifPafInput, OpenPifPafOutput
+from deepsparse.pipeline import Pipeline
+
+
+__all__ = [
+    "OpenPifPafPipeline",
+]
+
+
+@Pipeline.register(
+    task="open_pif_paf",
+    default_model_path=("/home/damian/pifpaf/openpifpaf-resnet50.onnx"),
+)
+class OpenPifPafPipeline(Pipeline):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @property
+    def input_schema(self) -> Type[OpenPifPafInput]:
+        return OpenPifPafInput
+
+    @property
+    def output_schema(self) -> Type[OpenPifPafOutput]:
+        return OpenPifPafOutput
+
+    def setup_onnx_file_path(self) -> str:
+        return self.model_path
+
+    def process_inputs(self, inp):
+        return inp.images
+
+    def process_engine_outputs(self, out):
+        return self.output_schema(out=out)

--- a/src/deepsparse/open_pif_paf/schemas.py
+++ b/src/deepsparse/open_pif_paf/schemas.py
@@ -11,3 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from typing import List
+
+import numpy
+from pydantic import BaseModel
+
+from deepsparse.pipelines.computer_vision import ComputerVisionSchema
+
+
+__all__ = [
+    "OpenPifPafInput",
+    "OpenPifPafOutput",
+]
+
+
+class OpenPifPafInput(ComputerVisionSchema):
+    pass
+
+
+class OpenPifPafOutput(BaseModel):
+    out: List[numpy.ndarray]
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/src/deepsparse/tasks.py
+++ b/src/deepsparse/tasks.py
@@ -119,6 +119,9 @@ class SupportedTasks:
             "embedding_extraction", ["embedding_extraction"]
         ),
     )
+    open_pif_paf = namedtuple("open_pif_paf", ["open_pif_paf"])(
+        open_pif_paf=AliasedTask("open_pif_paf", ["open_pif_paf"]),
+    )
 
     all_task_categories = [
         nlp,
@@ -127,6 +130,7 @@ class SupportedTasks:
         yolact,
         haystack,
         embedding_extraction,
+        open_pif_paf,
     ]
 
     @classmethod
@@ -168,6 +172,11 @@ class SupportedTasks:
             # trigger embedding_extraction pipelines to register with
             #  Pipeline.register
             import deepsparse.pipelines.embedding_extraction  # noqa :F401
+
+        elif cls.is_open_pif_paf(task):
+            # trigger embedding_extraction pipelines to register with
+            #  Pipeline.register
+            import deepsparse.open_pif_paf.pipelines  # noqa :F401
 
         all_tasks = set(cls.task_names() + (list(extra_tasks or [])))
         if task not in all_tasks:
@@ -238,6 +247,17 @@ class SupportedTasks:
         return any(
             embedding_extraction_task.matches(task)
             for embedding_extraction_task in cls.embedding_extraction
+        )
+
+    @classmethod
+    def is_open_pif_paf(cls, task):
+        """
+        :param task: the name of the task to check whether it is an
+            embedding_extraction task
+        :return: True if it is an open_pif_paf task, False otherwise
+        """
+        return any(
+            open_pif_paf_task.matches(task) for open_pif_paf_task in cls.open_pif_paf
         )
 
     @classmethod


### PR DESCRIPTION
# OpenPifPaf Stage 0 

## Onnx Export
Without any network training, the OpenPifPaf devs allow the user to export any of the untrained versions of their model (Resnet-/Mobilenet-/ SwinTransformers- /... based) as ONNX file (`https://openpifpaf.github.io/cli_help.html?highlight=onnx#export-onnx`). They also apply utilities to optimize and simplify the resulting onnx file.

![image](https://user-images.githubusercontent.com/97082108/202711888-74643c82-a8ad-419a-9e1a-a4ee2dc3a27b.png)

## Quick Benchmarking
Roughly we have 2x speedup running the sample OpenPifPaf model with the engine vs onnxruntime

![image](https://user-images.githubusercontent.com/97082108/202711981-91f8e140-d967-4db0-877b-f55a7014fee7.png)

## Minimal pipeline implementation for Open Pif Paf 
```python
from deepsparse import Pipeline
import numpy as np


pipeline = Pipeline.create(task="open_pif_paf", batch_size = 1)
out = pipeline(images=[np.random.rand(1, 3, 97, 129).astype(np.float32)])
```

`out: List[numpy.array]` with two numpy arrays of size `(1,17,5,13,17)` and `(1,19,8,13,17)` (consistent with the expectations, see: PIF and PAF network components in the original OpenPifPaf paper)
