### PR TITLE
Moving license_files to setup.py from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[metadata]
-license_files = NOTICE LICENSE* licenses/* src/deepsparse/licenses/*
-
 [isort]
 profile = black
 default_section = FIRSTPARTY

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,16 @@ if is_enterprise:
 # File regexes for binaries to include in package_data
 binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
 
+# regexes for things to include as license files in the .dist-info
+# see https://github.com/pypa/setuptools/blob/v65.6.0/docs/references/keywords.rst
+# for more info
+license_files = [
+    "NOTICE",
+    "LICENSE*",
+    "licenses/*",
+    "src/deepsparse/licenses/*",
+]
+
 
 def _parse_requirements_file(file_path):
     with open(file_path, "r") as requirements_file:
@@ -279,12 +289,7 @@ setup(
         "object detection, sparsity"
     ),
     license="Neural Magic DeepSparse Community License, Apache",
-    license_files=[
-        "NOTICE",
-        "LICENSE*",
-        "licenses/*",
-        "src/deepsparse/licenses/*",
-    ],
+    license_files=license_files,
     url="https://github.com/neuralmagic/deepsparse",
     package_dir=_setup_package_dir(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -279,6 +279,12 @@ setup(
         "object detection, sparsity"
     ),
     license="Neural Magic DeepSparse Community License, Apache",
+    license_files=[
+        "NOTICE",
+        "LICENSE*",
+        "licenses/*",
+        "src/deepsparse/licenses/*",
+    ],
     url="https://github.com/neuralmagic/deepsparse",
     package_dir=_setup_package_dir(),
     include_package_data=True,


### PR DESCRIPTION
Including as much detail here for future purposes.

I'm not sure why this suddenly stopped working or even worked in the first place.

# Information

1. Sample setup.cfg file here: https://github.com/pypa/sampleproject/blob/main/setup.cfg, however it only lists one entry in license_files
2. https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file details the license_files fields with this example (note the newline delimited values.)
```cfg
[metadata]
license_files =
   license.txt
   3rdparty/*.txt
```
3. https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata has a table of metadata. the license_files row has the entry `list-comma`, which I take to also mean commas are accepted.
4. The values in setuptools are actually populated on this line https://github.com/pypa/setuptools/blob/d680efc8b4cd9aa388d07d3e298b870d26e9e04b/setuptools/dist.py#L150, but the source code under `_read_list_from_msg` doesn't have the parsing logic (and I can't even find the function it calls)
5. https://github.com/pypa/setuptools/blob/75e64961b4486345429bbb1a994da5c029ff87e2/setuptools/tests/test_egg_info.py#L585 contains a lot of tests for this field, and most of which seem to be newline/space delimited.
6. apache includes multiple files on multiple lines here https://github.com/apache/airflow/blob/main/setup.cfg#L27 (thanks @rahul-tuli )

# Test plan

I confirmed that the old version didn't copy licenses anymore - odd because I had tested this multiple times and it worked.

I confirmed that the new version did copy licenses with a `pip install .`, and also confirmed that setuptools includes the licenses when running `python setup.py sdist bdist_wheel`:

```
adding 'deepsparse_nightly-1.3.0.dist-info/LICENSE'
adding 'deepsparse_nightly-1.3.0.dist-info/LICENSE-NEURALMAGIC'
adding 'deepsparse_nightly-1.3.0.dist-info/METADATA'
adding 'deepsparse_nightly-1.3.0.dist-info/NOTICE'
adding 'deepsparse_nightly-1.3.0.dist-info/WHEEL'
adding 'deepsparse_nightly-1.3.0.dist-info/boost.license'
adding 'deepsparse_nightly-1.3.0.dist-info/entry_points.txt'
adding 'deepsparse_nightly-1.3.0.dist-info/fmath.license'
adding 'deepsparse_nightly-1.3.0.dist-info/json.license'
adding 'deepsparse_nightly-1.3.0.dist-info/jwt-cpp.license'
adding 'deepsparse_nightly-1.3.0.dist-info/libnpy.license'
adding 'deepsparse_nightly-1.3.0.dist-info/libstdc++.license'
adding 'deepsparse_nightly-1.3.0.dist-info/onnx-runtime.license'
adding 'deepsparse_nightly-1.3.0.dist-info/onnx.license'
adding 'deepsparse_nightly-1.3.0.dist-info/protobuf.license'
adding 'deepsparse_nightly-1.3.0.dist-info/pybind11.license'
adding 'deepsparse_nightly-1.3.0.dist-info/spookyhash.license'
adding 'deepsparse_nightly-1.3.0.dist-info/tinyformat.license'
adding 'deepsparse_nightly-1.3.0.dist-info/top_level.txt'
adding 'deepsparse_nightly-1.3.0.dist-info/xbyak.license'
adding 'deepsparse_nightly-1.3.0.dist-info/yaml-cpp.license'
adding 'deepsparse_nightly-1.3.0.dist-info/zlib.license'
adding 'deepsparse_nightly-1.3.0.dist-info/RECOR
```