### PR TITLE
[Fix] Prometheus Logger logging all zeros for latency metrics

### DIFF
--- a/src/deepsparse/loggers/prometheus_logger.py
+++ b/src/deepsparse/loggers/prometheus_logger.py
@@ -130,8 +130,6 @@ class PrometheusLogger(BaseLogger):
     def _validate(self, value: Any) -> Any:
         # make sure we are passing a value that is
         # a valid metric by prometheus client's standards
-        if hasattr(value, "is_integer"):
-            value = int(value)
         if not isinstance(value, SUPPORTED_DATA_TYPES):
             raise ValueError(
                 "Prometheus logger expects the incoming values "

--- a/src/deepsparse/server/build_logger.py
+++ b/src/deepsparse/server/build_logger.py
@@ -58,7 +58,9 @@ def build_logger(server_config: ServerConfig) -> BaseLogger:
     loggers_config = server_config.loggers
     if not loggers_config:
         return AsyncLogger(
-            logger=MultiLogger(default_logger()),  # wrap all loggers to async log call
+            logger=MultiLogger(
+                [default_logger()]
+            ),  # wrap all loggers to async log call
             max_workers=1,
         )
 

--- a/tests/server/test_build_logger.py
+++ b/tests/server/test_build_logger.py
@@ -167,7 +167,7 @@ def test_build_logger(yaml_config, raises_error, default_logger, num_function_lo
     assert isinstance(logger, AsyncLogger)
     assert isinstance(logger.logger, MultiLogger)
     if default_logger:
-        assert isinstance(logger.logger.loggers, PythonLogger)
+        assert isinstance(logger.logger.loggers[0], PythonLogger)
         return
     assert len(logger.logger.loggers) == num_function_loggers + 1
 

--- a/tests/server/test_loggers.py
+++ b/tests/server/test_loggers.py
@@ -52,7 +52,7 @@ def test_default_logger():
 
     for _ in range(2):
         client.post("/predict", json={"sequences": "today is great"})
-    assert isinstance(server_logger.logger.loggers, PythonLogger)
+    assert isinstance(server_logger.logger.loggers[0], PythonLogger)
 
 
 def test_logging_only_system_info():


### PR DESCRIPTION
Reported by @rsnm2 : https://app.asana.com/0/1203146234476221/1203483881614817/f

Prometheus collects metrics in the form o of integers/floats and does not digest any complex data types such as lists, tuples, or arrays. 

Before I implemented a quick fix to account for values such as `np.array([3])`, s.t Prometheus can log it as `3`. 
However, since not only NumPy arrays have an attribute `is_integer` but python ints/floats, as well, the logic was rounding up all the values to the full integers.

I decided not to account for edge cases and not add any additional if statements to the `_validate` method. Accounting for different exceptions feels a bit hacky and dangerous. We should reserve `PrometheusLogger` for metrics (floats/ints) only, as this is an implicit assumption when one uses Prometheus. If the user wishes to log more complex data structures, they are free to use `CustomLogger` or one of the future Loggers we will introduce soon.

Ps. Also fixed here is a small unrelated bug (`MultiLogger` expects to receive a list of loggers, not a logger)

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/97082108/205581655-726832bb-8455-4ccc-98f3-5cd00a9a7d79.png">
