### PR TITLE
[EmbeddingExtraction][fix] clear 'None' shapes from uninfered extracted onnx outputs

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -342,6 +342,12 @@ def truncate_onnx_model(
         f"{extracted_num_nodes} remaining"
     )
 
+    for output in extracted_model.graph.output:
+        if len(output.type.tensor_type.shape.dim) == 0:
+            # ONNX checker treats None shapes and empty shapes
+            # differently, clear None shape to pass checker
+            output.type.tensor_type.shape.Clear()
+
     # save and check model
     onnx.save(extracted_model, output_filepath)
     onnx.checker.check_model(output_filepath)


### PR DESCRIPTION
fixes an issue where extracted layers who were unable to be issued shape inference (any non trivial node) with the onnx shape inference API would have improper tensor type shapes set causing an unnecessary crash with the onnx checker

**test_plan:**
* unit tests passing
* manually verified fix across multiple domains and models