### PR TITLE
[EmbeddingExtraction] fix graph output assignment in str extraction layer targets

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -377,10 +377,21 @@ def truncate_onnx_embedding_model(
         output_filepath = tmp_file.name
 
     # determine where to cut the model
+    model = onnx.load(model_path)
     if isinstance(emb_extraction_layer, str):
-        final_node_name = emb_extraction_layer
+        final_node = None
+        for graph_node in model.graph.node:
+            if graph_node.name == emb_extraction_layer:
+                final_node = graph_node
+
+        if final_node is None:
+            raise RuntimeError(
+                f"Unable to find node {emb_extraction_layer} for extraction in graph"
+            )
+
+        final_node_name = final_node.name
+        graph_output_name = final_node.output[0]
     else:
-        model = onnx.load(model_path)
         final_node_name = model.graph.node[emb_extraction_layer].name
         graph_output_name = model.graph.node[emb_extraction_layer].output[0]
 


### PR DESCRIPTION
`graph_output_name` previously was not set when `emb_extraction_layer` was a str

**test_plan:**
manually verified