### PR TITLE
Pin numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def _parse_requirements_file(file_path):
 
 
 _deps = [
-    "numpy>=1.16.3",
+    "numpy>=1.16.3,<=1.21.6",
     "onnx>=1.5.0,<=1.12.0",
     "pydantic>=1.8.2",
     "requests>=2.0.0",


### PR DESCRIPTION
Pinning numpy version to <=1.21.6 to avoid deprecation warning/index errors in pipelines