### PR TITLE
[System Logging] Raise warning when attempting to slice/index arrays or torch

### DIFF
--- a/src/deepsparse/loggers/helpers.py
+++ b/src/deepsparse/loggers/helpers.py
@@ -218,7 +218,8 @@ def access_nested_value(
             # indexing
             operator = int(string_operator)
 
-        value = _warn_if_array_or_tensor(value.__getitem__(operator))
+        _warn_if_array_or_tensor(value)
+        value = value.__getitem__(operator)
 
     return value
 
@@ -285,4 +286,3 @@ def _warn_if_array_or_tensor(value: Any) -> Any:
 
     if isinstance(value, numpy.ndarray) or hasattr(value, "numpy"):
         warnings.warn(msg)
-    return value

--- a/src/deepsparse/loggers/helpers.py
+++ b/src/deepsparse/loggers/helpers.py
@@ -17,6 +17,7 @@ Helpers functions for logging
 import importlib
 import os.path
 import re
+import warnings
 from types import ModuleType
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -217,7 +218,7 @@ def access_nested_value(
             # indexing
             operator = int(string_operator)
 
-        value = value.__getitem__(operator)
+        value = _warn_if_array_or_tensor(value.__getitem__(operator))
 
     return value
 
@@ -271,3 +272,17 @@ def _get_function_and_function_name_from_framework(
     for attribute in func_attributes:
         module = getattr(module, attribute)
     return module, ".".join(func_attributes)
+
+
+def _warn_if_array_or_tensor(value: Any) -> Any:
+    msg = """
+    If value is an array or tensor, one should refrain from 
+    slicing/indexing/accessing its elements using 'access_nested_value'.
+    This function should only be used for Sequence types 
+    (lists, tuple, ranges, etc.) or Dictionaries due to their simple structure.
+    For more complex operations on `value`, one should use `metric_functions`
+    specified directly in the data logging config"""  # noqa W291
+
+    if isinstance(value, numpy.ndarray) or hasattr(value, "numpy"):
+        warnings.warn(msg)
+    return value

--- a/tests/deepsparse/loggers/test_helpers.py
+++ b/tests/deepsparse/loggers/test_helpers.py
@@ -121,10 +121,12 @@ def test_possibly_extract_value(value, remainder, expected_value):
 )
 def test_access_nested_value(value, square_brackets, expected_value):
     if isinstance(expected_value, numpy.ndarray):
-        assert numpy.array_equal(
-            expected_value, access_nested_value(value, square_brackets)
-        )
-        return
+        # assert raises warning
+        with pytest.warns(UserWarning):
+            assert numpy.array_equal(
+                expected_value, access_nested_value(value, square_brackets)
+            )
+            return
 
     assert expected_value == access_nested_value(
         value=value, square_brackets=square_brackets


### PR DESCRIPTION
One of the requirements for 1.4 is:

`Support [:,:0] slicing in the configuration file for identifiers`. 

This is essentially support for slicing/indexing data identifier properties that are numpy arrays or torch tensors (N-dimensional data structures) in the context of DeepSparse server data logging.

After consultation with @rsnm2 we have decided to drop this feature. This is my logic behind the decision:

----> from my convo with Rob:
Let me show by example why numpy slicing in our context is pretty difficult:

Imagine this operation:
```python
array = numpy.randn(10,10,3) # creates random array with dims: (10,10,3)
array_sliced = array[:1,:1,0] 
# array sliced would have as result shape (1,1)
```
Now If we did this in the context of our repo, we would apply slicing as a sequence :1 -> :1 -> 0
This would mean:
```python
array = numpy.randn(10,10,3)
array = array[:1] # now array has shape (1,10,3)
array = array[:1] # now array has shape (1,10,3)
array = array[0] # now array has shape (10,3)
```

I do not think we should be developing a library for reinventing the numpy slicing, this is why I "rebel" against this feature.  The user should use (custom) metric functions for this degree of parsing complexity. I propose we could raise a warning if the user attempts to do slicing on the NumPy array or torch tensor.
