### PR TITLE
Pin black version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ _deps = [
 _nm_deps = [f"{'sparsezoo' if is_release else 'sparsezoo-nightly'}~={version_base}"]
 _dev_deps = [
     "beautifulsoup4>=4.9.3",
-    "black>=20.8b1",
+    "black==22.12.0",
     "flake8>=3.8.3",
     "isort>=5.7.0",
     "m2r2~=0.2.7",


### PR DESCRIPTION
New `black` version is messing up our tests. Let's pin the version to the latest, compliant one for now.