### PR TITLE
Remove redundant argument from __call__

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -187,7 +187,7 @@ class Pipeline(ABC):
 
         self._batch_size = self._batch_size or 1
 
-    def __call__(self, *args, monitoring: bool = False, **kwargs) -> BaseModel:
+    def __call__(self, *args, **kwargs) -> BaseModel:
         if "engine_inputs" in kwargs:
             raise ValueError(
                 "invalid kwarg engine_inputs. engine inputs determined "


### PR DESCRIPTION
Something that should have been removed when we redesigned the pipeline logging logic.