### PR TITLE
Dynamic Engine Load

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -320,11 +320,11 @@ def load_custom_engine(custom_engine_identifier: str):
            '<path_to_the_python_script>:<custom_engine_class_name>
     :return: custom engine class object
     """
-    path, logger_object_name = custom_engine_identifier.split(":")
+    path, engine_object_name = custom_engine_identifier.split(":")
     spec = importlib.util.spec_from_file_location("user_defined_custom_engine", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return getattr(module, logger_object_name)
+    return getattr(module, engine_object_name)
 
 
 def benchmark_model(

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -387,6 +387,8 @@ def benchmark_model(
     if input_shapes:
         with override_onnx_input_shapes(model_path, input_shapes) as model_path:
             input_list = generate_random_inputs(model_path, batch_size)
+    elif hasattr(engine, "generate_random_inputs"):
+        input_list = engine.generate_random_inputs(batch_size=batch_size)
     else:
         input_list = generate_random_inputs(model_path, batch_size)
 

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -308,6 +308,18 @@ def parse_num_streams(num_streams: int, num_cores: int, scenario: str):
             return default_num_streams
 
 
+def load_custom_engine(custom_engine_identifier):
+    """
+    import a custom engine based off the specified `custom_engine_identifier`
+    from user specified script
+
+    :param custom_engine_identifier: string in the form of
+           '<path_to_the_python_script>:<custom_engine_class_name>
+    :return: custom engine class object
+    """
+    pass
+
+
 def benchmark_model(
     model_path: str,
     batch_size: int = 1,
@@ -352,6 +364,9 @@ def benchmark_model(
             num_cores=num_cores,
             input_shapes=input_shapes,
         )
+    elif ":" in engine:
+        Engine = load_custom_engine(custom_engine_identifier=engine)
+        print(Engine)
     else:
         raise ValueError(f"Invalid engine choice '{engine}'")
     _LOGGER.info(model)

--- a/src/deepsparse/benchmark/benchmark_sweep.py
+++ b/src/deepsparse/benchmark/benchmark_sweep.py
@@ -306,6 +306,17 @@ def _get_models(
     help="The warmup_time to execute model for",
     show_default=True,
 )
+@click.option(
+    "--engine",
+    "-e",
+    multiple=True,
+    default=["onnxruntime", "deepsparse"],
+    help="Inference engine backend to run eval on. Choices are 'deepsparse', "
+     "'onnxruntime'. Default is 'deepsparse' and 'onnxruntime'. Can also specify a user "
+     "defined engine class by giving the script and class name in the following format "
+     "<path to python script>:<Engine Class name>. This engine class will be "
+     "dynamically imported during runtime. Note multiple engines can also be specified"
+)
 def main(
     num_cores: str,
     batch_sizes: str,
@@ -314,6 +325,7 @@ def main(
     save_dir: str,
     run_time: int,
     warmup_time: int,
+    engine: List[str]
 ):
     """
     Script to run benchmark sweep over a directory containing models or a
@@ -354,7 +366,7 @@ def main(
             models=[str(model)],
             batch_sizes=batch_sizes,
             num_cores=num_cores,
-            engines=["onnxruntime", "deepsparse"],
+            engines=engine,
             scenario_streams_dict={
                 "sync": [None],
             },


### PR DESCRIPTION
This PR will add support to load a Engine Dynamically from a user specified python script

In the `benchmark_sweep` and `deepsparse.benchmark` utility now users can specify a custom engine class, that will be dynamically loaded during runtime. A possible use case could be to benchmark different Inference backends.

Note: If the graph is not in `onnx` format then the engine classes must specify a function `generate_random_inputs` that takes in a batch size and returns inputs for the model in an ingestable format. A better solution could be to force this contract by creating a base class. But have left this as is for now