### PR TITLE
IC pipeline to accept PNG images

### DIFF
--- a/src/deepsparse/image_classification/pipelines.py
+++ b/src/deepsparse/image_classification/pipelines.py
@@ -183,7 +183,7 @@ class ImageClassificationPipeline(Pipeline):
             image = Image.fromarray(image)
         elif isinstance(image, str):
             # load image from string filepath
-            image = Image.open(image)
+            image = Image.open(image).convert('RGB')
         elif isinstance(image, numpy.ndarray):
             image = image.astype(numpy.uint8)
             if image.shape[0] < image.shape[-1]:

--- a/src/deepsparse/image_classification/pipelines.py
+++ b/src/deepsparse/image_classification/pipelines.py
@@ -183,7 +183,7 @@ class ImageClassificationPipeline(Pipeline):
             image = Image.fromarray(image)
         elif isinstance(image, str):
             # load image from string filepath
-            image = Image.open(image).convert('RGB')
+            image = Image.open(image).convert("RGB")
         elif isinstance(image, numpy.ndarray):
             image = image.astype(numpy.uint8)
             if image.shape[0] < image.shape[-1]:


### PR DESCRIPTION
PIL reads PNG images as RGBA by default, causing an error later on in the pipeline as all images are assumed to have three channels. This PR makes sure that whatever is being returned by PIL, has 3 dimensions

Testing:
- manually tested the result of the pipeline for an input JPG image (the result does not change after introducing this PR)
- made sure that the PNG image gets properly inferred (the image below results in top 3 labels `labels=["banana", "orange", "lemon"]`)![image](https://user-images.githubusercontent.com/97082108/213651151-9f5a846f-89e2-4e8a-b216-e1cadec037b2.png)