### PR TITLE
pin opencv-python==4.6.0.66

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,11 +130,11 @@ _onnxruntime_deps = [
 ]
 _yolo_integration_deps = [
     "torchvision>=0.3.0,<=0.13",
-    "opencv-python",
+    "opencv-python==4.6.0.66",
 ]
 _openpifpaf_integration_deps = [
     "openpifpaf==0.13.6",
-    "opencv-python",
+    "opencv-python==4.6.0.66",
 ]
 # haystack dependencies are installed from a requirements file to avoid
 # conflicting versions with NM's deepsparse/transformers


### PR DESCRIPTION
There are issues with the latest opencv-python as you can see in https://github.com/opencv/opencv-python/issues/772.

This PR pins opencv-python to the last working version, as suggested in the above PR.

# Testing plan

Ran pip install before this PR to verify that opencv `4.7.0.68` is installed, and after this PR `4.6.0.66` is installed.