### PR TITLE
[MLOps 1.5] Add `BatchResult` object to hold list-like values for logging

### DIFF
--- a/src/deepsparse/loggers/metric_functions/computer_vision/built_ins.py
+++ b/src/deepsparse/loggers/metric_functions/computer_vision/built_ins.py
@@ -19,6 +19,8 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import numpy
 
+from deepsparse.loggers.metric_functions.utils import BatchResult
+
 
 __all__ = [
     "image_shape",
@@ -148,7 +150,7 @@ def detected_classes(
 
 def number_detected_objects(
     detected_classes: List[List[Union[int, str, None]]]
-) -> Dict[str, int]:
+) -> BatchResult:
     """
     Count the number of successful detections per sample
 
@@ -159,28 +161,18 @@ def number_detected_objects(
         either contain a single `None` value (no detection)
         or a number of integer/string representation of the
         detected classes.
-    :return: Dictionary, where the keys are image indices within
-        a batch and the values are the number of detected objects per image
-        Example:
-            {"0": 3, # 3 objects detected in the zeroth image
-             "1": 0, # no objects detected in the first image
-             "2": 1  # 1 object detected in the second image
-             ...
-             }
+    :return: BatchResult object, that contains the number of
+        detections per sample in the batch
     """
 
-    number_objects_per_image = {}
-    for detection_idx, detection in enumerate(detected_classes):
+    batch_result = BatchResult()
+    for detection in detected_classes:
         _check_valid_detection(detection)
-        number_objects_per_image[str(detection_idx)] = (
-            0 if detection == [None] else len(detection)
-        )
-    return number_objects_per_image
+        batch_result.append(0 if detection == [None] else len(detection))
+    return batch_result
 
 
-def mean_score_per_detection(
-    scores: List[List[Union[None, float]]]
-) -> Dict[str, float]:
+def mean_score_per_detection(scores: List[List[Union[None, float]]]) -> BatchResult:
     """
     Return the mean score per detection
 
@@ -191,20 +183,18 @@ def mean_score_per_detection(
         either contain a single `None` value (no detection)
         or a number of float representation of the
         score (confidence) of the detected classes.
-    :return: Dictionary, where the keys are image indices within
-        a batch and the values are the mean score per detection
+    :return: BatchResult object, that contains the mean scores
+        per detection in the batch
     """
-    mean_scores_per_image = {}
-    for score_idx, score in enumerate(scores):
+    batch_result = BatchResult()
+    for score in scores:
         _check_valid_score(score)
-        mean_scores_per_image[str(score_idx)] = (
-            0.0 if score == [None] else numpy.mean(score)
-        )
+        batch_result.append(0.0 if score == [None] else numpy.mean(score))
 
-    return mean_scores_per_image
+    return batch_result
 
 
-def std_score_per_detection(scores: List[List[Optional[float]]]) -> Dict[str, float]:
+def std_score_per_detection(scores: List[List[Optional[float]]]) -> BatchResult:
     """
     Return the standard deviation of scores per detection
 
@@ -215,17 +205,15 @@ def std_score_per_detection(scores: List[List[Optional[float]]]) -> Dict[str, fl
         either contain a single `None` value (no detection)
         or a number of float representation of the
         score (confidence) of the detected classes.
-    :return: Dictionary, where the keys are image indices within
-        a batch and the values are the standard deviation of scores per detection
+    :return: BatchResult object, that contains the standard
+        deviation of scores per detection in the batch
     """
-    std_scores_per_image = {}
-    for score_idx, score in enumerate(scores):
+    batch_result = BatchResult()
+    for score in scores:
         _check_valid_score(score)
-        std_scores_per_image[str(score_idx)] = (
-            0.0 if score == [None] else numpy.std(score)
-        )
+        batch_result.append(0.0 if score == [None] else numpy.std(score))
 
-    return std_scores_per_image
+    return batch_result
 
 
 def _check_valid_detection(detection: List[Union[int, str, None]]):

--- a/src/deepsparse/loggers/metric_functions/natural_language_processing/built_ins.py
+++ b/src/deepsparse/loggers/metric_functions/natural_language_processing/built_ins.py
@@ -14,22 +14,26 @@
 """
 Set of functions for logging metrics from the natural language processing pipelines
 """
-from typing import Dict, List, Union
+from typing import List, Union
+
+from deepsparse.loggers.metric_functions.utils import BatchResult
 
 
 __all__ = ["string_length", "percent_unknown_tokens"]
 
 
-def string_length(sequence: Union[List[str], str]) -> Union[Dict[str, int], int]:
+def string_length(sequence: Union[List[str], str]) -> Union[BatchResult, int]:
     """
     Returns the length of the sequence
 
     :param sequence: The sequence whose length is to be returned
-    :return: The length of the sequence
+    :return: The length of the sequence if sequence is a string,
+        else a BatchResult containing the length of each sequence
+        in the batch
     """
     if isinstance(sequence, str):
         return len(sequence)
-    return {str(string_id): len(string) for string_id, string in enumerate(sequence)}
+    return BatchResult([len(seq) for seq in sequence])
 
 
 def percent_unknown_tokens():

--- a/src/deepsparse/loggers/metric_functions/natural_language_processing/token_classification/built_ins.py
+++ b/src/deepsparse/loggers/metric_functions/natural_language_processing/token_classification/built_ins.py
@@ -14,9 +14,11 @@
 """
 Set of functions for logging metrics from the token classification pipeline
 """
-from typing import Dict, List
+from typing import List
 
 import numpy
+
+from deepsparse.loggers.metric_functions.utils import BatchResult
 
 
 __all__ = ["mean_score", "percent_zero_labels"]
@@ -24,38 +26,34 @@ __all__ = ["mean_score", "percent_zero_labels"]
 
 def percent_zero_labels(
     token_classification_output: "TokenClassificationOutput",  # noqa: F821
-) -> Dict[str, float]:
+) -> BatchResult:
     """
     Returns the percentage of zero labels in the token classification output
 
     :param token_classification_output: the TokenClassificationOutput object
-    :return: A dictionary where the key is the token sequence index and the
-        value is the percentage of zero labels in the sequence of tokens
+    :return: BatchResult object, that contains the percentage of zero labels
+        in for each sequence of tokens in the batch
     """
-    result = {}
-    for prediction_idx, prediction in enumerate(
-        token_classification_output.predictions
-    ):
-        result[str(prediction_idx)] = _percent_zero_labels(prediction)
-    return result
+    batch_result = BatchResult()
+    for prediction in token_classification_output.predictions:
+        batch_result.append(_percent_zero_labels(prediction))
+    return batch_result
 
 
 def mean_score(
     token_classification_output: "TokenClassificationOutput",  # noqa: F821
-) -> Dict[str, float]:
+) -> BatchResult:
     """
     Returns the mean score of the token classification output
 
     :param token_classification_output: the TokenClassificationOutput object
-    :return: A dictionary where the key is the token sequence index and the
-        value is the mean score of the sequence of tokens
+    :return: BatchResult object, that contains the mean score for each
+        sequence of tokens in the batch
     """
-    result = {}
-    for prediction_idx, prediction in enumerate(
-        token_classification_output.predictions
-    ):
-        result[str(prediction_idx)] = _mean_score(prediction)
-    return result
+    batch_result = BatchResult()
+    for prediction in token_classification_output.predictions:
+        batch_result.append(_mean_score(prediction))
+    return batch_result
 
 
 def _mean_score(

--- a/src/deepsparse/loggers/metric_functions/utils.py
+++ b/src/deepsparse/loggers/metric_functions/utils.py
@@ -12,18 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-from deepsparse.loggers.metric_functions.natural_language_processing import (
-    string_length,
-)
+__all__ = ["BatchResult"]
 
 
-@pytest.mark.parametrize(
-    "string, expected_len",
-    [
-        ("His palms are sweaty", 20),
-        (["knees weak", "arms are heavy"], [10, 14]),
-    ],
-)
-def test_string_length(string, expected_len):
-    assert string_length(string) == expected_len
+class BatchResult(list):
+    pass

--- a/src/deepsparse/loggers/metric_functions/utils.py
+++ b/src/deepsparse/loggers/metric_functions/utils.py
@@ -16,4 +16,7 @@ __all__ = ["BatchResult"]
 
 
 class BatchResult(list):
-    pass
+    """
+    Wrapper class for a list of values that
+    are derived from a set of batch data
+    """

--- a/tests/deepsparse/loggers/metric_functions/computer_vision/test_built_ins.py
+++ b/tests/deepsparse/loggers/metric_functions/computer_vision/test_built_ins.py
@@ -173,10 +173,10 @@ def test_detected_classes(classes, expected_count_classes, should_raise_error):
 @pytest.mark.parametrize(
     "classes, expected_count_classes",
     [
-        ([[None], [0, 1, 3], [3, 3, 0]], {"0": 0, "1": 3, "2": 3}),
-        ([[None], [None]], {"0": 0, "1": 0}),
-        ([["foo", "bar"], ["foo", "bar", "alice"], ["bar"]], {"0": 2, "1": 3, "2": 1}),
-        ([["foo", "bar"], ["foo", "bar", "alice"], [None]], {"0": 2, "1": 3, "2": 0}),
+        ([[None], [0, 1, 3], [3, 3, 0]], [0, 3, 3]),
+        ([[None], [None]], [0, 0]),
+        ([["foo", "bar"], ["foo", "bar", "alice"], ["bar"]], [2, 3, 1]),
+        ([["foo", "bar"], ["foo", "bar", "alice"], [None]], [2, 3, 0]),
     ],
 )
 def test_number_detected_objects(classes, expected_count_classes):
@@ -186,10 +186,10 @@ def test_number_detected_objects(classes, expected_count_classes):
 @pytest.mark.parametrize(
     "scores, expected_mean_score",
     [
-        ([[None], [0.5, 0.5, 0.5], [0.3, 0.3, 0.3]], {"0": 0.0, "1": 0.5, "2": 0.3}),
-        ([[None], [None]], {"0": 0.0, "1": 0.0}),
-        ([[0.5, 0.5], [0.9, 0.9, 0.9], [1.0]], {"0": 0.5, "1": 0.9, "2": 1.0}),
-        ([[1.0, 0.0], [None]], {"0": 0.5, "1": 0.0}),
+        ([[None], [0.5, 0.5, 0.5], [0.3, 0.3, 0.3]], [0.0, 0.5, 0.3]),
+        ([[None], [None]], [0.0, 0.0]),
+        ([[0.5, 0.5], [0.9, 0.9, 0.9], [1.0]], [0.5, 0.9, 1.0]),
+        ([[1.0, 0.0], [None]], [0.5, 0.0]),
     ],
 )
 def test_mean_score_per_detection(scores, expected_mean_score):
@@ -201,16 +201,12 @@ def test_mean_score_per_detection(scores, expected_mean_score):
     [
         (
             [[None], [0.5, 0.5, 0.5], [0.6, 0.7, 0.8]],
-            {"0": 0.0, "1": 0.0, "2": 0.08164},
+            [0.0, 0.0, 0.08164],
         ),
-        ([[None], [None]], {"0": 0.0, "1": 0.0}),
-        ([[1.0, 0.0], [None]], {"0": 0.5, "1": 0.0}),
+        ([[None], [None]], [0.0, 0.0]),
+        ([[1.0, 0.0], [None]], [0.5, 0.0]),
     ],
 )
 def test_std_score_per_detection(scores, expected_std_score):
     result = std_score_per_detection(scores)
-    for (result_keys, results_values), (keys, values) in zip(
-        result.items(), expected_std_score.items()
-    ):
-        numpy.testing.assert_allclose(results_values, values, atol=1e-5)
-        assert result_keys == keys
+    numpy.testing.assert_allclose(result, expected_std_score, atol=1e-5)

--- a/tests/deepsparse/loggers/metric_functions/natural_language_processing/token_classification/built_ins.py
+++ b/tests/deepsparse/loggers/metric_functions/natural_language_processing/token_classification/built_ins.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy
+
 import pytest
 from deepsparse.loggers.metric_functions.natural_language_processing import (
     mean_score,
@@ -37,7 +39,7 @@ label_1_result = TokenClassificationResult(entity="LABEL_1", score=0.6, index=0,
                     [label_0_result, label_0_result],
                 ]
             ),
-            {"0": 0.5, "1": 1.0},
+            [0.5, 1.0],
         )
     ],
 )
@@ -55,13 +57,10 @@ def test_percent_zero_labels(schema, expected_percent):
                     [label_0_result, label_0_result],
                 ]
             ),
-            {"0": 0.45, "1": 0.3},
+            [0.45, 0.3],
         )
     ],
 )
 def test_mean_score(schema, expected_score):
     result = mean_score(schema)
-    keys1, values1 = set(expected_score.keys()), set(expected_score.values())
-    keys2, values2 = set(result.keys()), set(result.values())
-    assert keys1 == keys2
-    assert pytest.approx(list(values1)) == list(values2)
+    numpy.testing.assert_allclose(result, expected_score)


### PR DESCRIPTION
For the sake of clarity, we want to move away from collecting the information derived from batches of data in a dictionary. Instead, let's collect them inside the `BatchResult` object (which we can further refer to inside the leaf loggers).

So instead of e.g. keeping label of each image in the batch in a dictionary like:
`{"0": "duck, "1": "rabbit", "2": "platypus", ... }`,
we use:
`BatchResult(["duck", "rabbit", "platypus", ...])`

Handing the `BatchResult` object within the leaf loggers will be handled in a separate PR.