### PR TITLE
Update: Yolo Annotation to allow shape overrides

### DIFF
--- a/src/deepsparse/yolo/annotate.py
+++ b/src/deepsparse/yolo/annotate.py
@@ -23,13 +23,16 @@ Options:
                                   used for annotation  [default: zoo:cv/detect
                                   ion/yolov5-s/pytorch/ultralytics/coco/pruned
                                   -aggressive_96]
-  --source TEXT                   File path to an image or directory of image
+  --source TEXT                   File path to image or directory of .jpg
                                   files, a .mp4 video, or an integer (i.e. 0)
                                   for webcam  [required]
   --engine [deepsparse|onnxruntime|torch]
                                   Inference engine backend to run on. Choices
                                   are 'deepsparse', 'onnxruntime', and
                                   'torch'. Default is 'deepsparse'
+  --model_input_shape, --model-input-shape INTEGER...
+                                  Image shape to override model with for
+                                  inference, must be two integers
   --num_cores, --num-cores INTEGER
                                   The number of physical cores to run the
                                   annotations with, defaults to using all
@@ -51,8 +54,7 @@ Options:
   --no_save, --no-save            Set flag when source is from webcam to not
                                   save results.Not supported for non-webcam
                                   sources  [default: False]
-  --help                          Show this message and exit
-
+  --help                          Show this message and exit.
 #######
 Examples:
 
@@ -62,7 +64,7 @@ Examples:
 4) deepsparse.object_detection.annotate --source PATH/TO/IMAGE_DIR
 """
 import logging
-from typing import Optional
+from typing import Optional, Tuple
 
 import click
 
@@ -110,6 +112,15 @@ _LOGGER = logging.getLogger(__name__)
     default=DEEPSPARSE_ENGINE,
     help="Inference engine backend to run on. Choices are 'deepsparse', "
     "'onnxruntime', and 'torch'. Default is 'deepsparse'",
+)
+@click.option(
+    "--model_input_shape",
+    "--model-input-shape",
+    type=int,
+    nargs=2,
+    default=None,
+    help="Image shape to override model with for inference, must be two integers",
+    show_default=True,
 )
 @click.option(
     "--num_cores",
@@ -166,6 +177,7 @@ def main(
     name: Optional[str],
     target_fps: Optional[float],
     no_save: bool,
+    model_input_shape: Optional[Tuple[int, ...]],
 ) -> None:
     """
     Annotation Script for YOLO with DeepSparse
@@ -191,6 +203,7 @@ def main(
         class_names="coco",
         engine_type=engine,
         num_cores=num_cores,
+        image_size=model_input_shape,
     )
 
     for iteration, (input_image, source_image) in enumerate(loader):

--- a/src/deepsparse/yolo/annotate.py
+++ b/src/deepsparse/yolo/annotate.py
@@ -30,7 +30,7 @@ Options:
                                   Inference engine backend to run on. Choices
                                   are 'deepsparse', 'onnxruntime', and
                                   'torch'. Default is 'deepsparse'
-  --model_input_shape, --model-input-shape INTEGER...
+  --model_input_image_shape, --model-input-shape INTEGER...
                                   Image shape to override model with for
                                   inference, must be two integers
   --num_cores, --num-cores INTEGER
@@ -114,8 +114,8 @@ _LOGGER = logging.getLogger(__name__)
     "'onnxruntime', and 'torch'. Default is 'deepsparse'",
 )
 @click.option(
-    "--model_input_shape",
-    "--model-input-shape",
+    "--model_input_image_shape",
+    "--model-input-image-shape",
     type=int,
     nargs=2,
     default=None,
@@ -177,7 +177,7 @@ def main(
     name: Optional[str],
     target_fps: Optional[float],
     no_save: bool,
-    model_input_shape: Optional[Tuple[int, ...]],
+    model_input_image_shape: Optional[Tuple[int, ...]],
 ) -> None:
     """
     Annotation Script for YOLO with DeepSparse
@@ -203,7 +203,7 @@ def main(
         class_names="coco",
         engine_type=engine,
         num_cores=num_cores,
-        image_size=model_input_shape,
+        image_size=model_input_image_shape,
     )
 
     for iteration, (input_image, source_image) in enumerate(loader):


### PR DESCRIPTION
This PR adds in support to override onnx graph shape for yolo annotation flow:

The update needed two minor changes:
 - Accepting a 2 integer tuple representing image shape to override model input shapes with; added `--model_input_shape` cli argument for that

- Propagating the new model input shape to the yolo pipeline constructor via the `image_size` argument; the actual code to override the shapes is already in place in the YOLO pipeline.

Command:
```bash
deepsaprse.object_detection.annotate \
    --source ./tests/deepsparse/pipelines/sample_images/basilica.jpg \
    --save-dir /home/rahul/projects/deepsparse/results \
    --model_input_shape 1280 1280
```

A breakpoint was set after pipeline creation and the model shape was checked to conform with the passed in `--model_input_shape`