### PR TITLE
temporary fix for local-develop-test GHA failure

### DIFF
--- a/.github/workflows/local-install-check.yaml
+++ b/.github/workflows/local-install-check.yaml
@@ -29,6 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "⚙️ Install local develop deepsparse"
-        run: pip3 install -e .
+        run: pip3 install --use-pep517 -e .
       - name: "deepsparse.benchmark"
         run: deepsparse.benchmark zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned_quant-moderate -w 1 -t 1

--- a/.github/workflows/local-install-check.yaml
+++ b/.github/workflows/local-install-check.yaml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "⚙️ Install local develop deepsparse"
-        run: pip3 install --use-pep517 -e .
+        run: |
+          python3.8 -m venv venv
+          source venv/bin/activate
+          pip install -e .
       - name: "deepsparse.benchmark"
         run: deepsparse.benchmark zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned_quant-moderate -w 1 -t 1

--- a/.github/workflows/local-install-check.yaml
+++ b/.github/workflows/local-install-check.yaml
@@ -30,8 +30,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: "⚙️ Install local develop deepsparse"
         run: |
-          python3.8 -m venv venv
-          source venv/bin/activate
+          python3.8 -m venv venv-dev
+          source venv-dev/bin/activate
           pip install -e .
       - name: "deepsparse.benchmark"
-        run: deepsparse.benchmark zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned_quant-moderate -w 1 -t 1
+        run: |
+          source venv-dev/bin/activate
+          deepsparse.benchmark zoo:cv/classification/mobilenet_v1-1.0/pytorch/sparseml/imagenet/pruned_quant-moderate -w 1 -t 1


### PR DESCRIPTION
the version of `python-distro-info`installed in by GHA tests has a version that causes a crash when installing with our local develop mode install test.

until the version is updated, running the test in a virtual environment (this is our recommended flow anyways) which will not have visibility to the global install with the bad version.

see this issue for more information: https://github.com/pypa/setuptools/issues/3772

**test_plan:**

GHA `local-install-test` now passing