### PR TITLE
Bugfixes: benchmark-sweep

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -389,6 +389,8 @@ def benchmark_model(
     if input_shapes:
         with override_onnx_input_shapes(model_path, input_shapes) as model_path:
             input_list = generate_random_inputs(model_path, batch_size)
+    elif hasattr(model, "generate_random_inputs"):
+        input_list = model.generate_random_inputs()
     elif hasattr(engine, "generate_random_inputs"):
         input_list = engine.generate_random_inputs(batch_size=batch_size)
     else:

--- a/src/deepsparse/benchmark/benchmark_sweep.py
+++ b/src/deepsparse/benchmark/benchmark_sweep.py
@@ -248,11 +248,9 @@ def _get_models(
 
         if Path(model).is_file() or model.startswith("zoo:"):
             models.append(model)
-        elif Path(model).is_dir():
-            models.extend([str(model) for model in Path.rglob("*") if model.is_file()])
         else:
             raise ValueError(
-                "The specified models must either be valid paths that exist,"
+                "The specified models must either be valid files that exist,"
                 f"or a valid SparseZoo stub but found {model}"
             )
     if not models:
@@ -284,8 +282,7 @@ def _get_models(
     "--model_paths",
     type=str,
     default=None,
-    help="Comma separated list of model paths, or Sparsezoo stubs, or "
-    "directories containing onnx models",
+    help="Comma separated list of model paths, or Sparsezoo stubs",
 )
 @click.option(
     "--save-dir",

--- a/src/deepsparse/benchmark/benchmark_sweep.py
+++ b/src/deepsparse/benchmark/benchmark_sweep.py
@@ -243,11 +243,13 @@ def _get_models(
     all_model_paths = model_paths.split(",")
     for model in all_model_paths:
         model = model.strip()
+        if not model:
+            continue
 
         if Path(model).is_file() or model.startswith("zoo:"):
             models.append(model)
         elif Path(model).is_dir():
-            models.extend([str(model) for model in Path.rglob("*.onnx")])
+            models.extend([str(model) for model in Path.rglob("*") if model.is_file()])
         else:
             raise ValueError(
                 "The specified models must either be valid paths that exist,"
@@ -261,7 +263,14 @@ def _get_models(
     return models
 
 
-@click.command()
+@click.command(
+    context_settings=dict(
+        token_normalize_func=lambda x: x.replace("-", "_"),
+        show_default=True,
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    )
+)
 @click.option(
     "--num-cores",
     help="Comma separated values for different num_cores to benchmark against, "
@@ -343,7 +352,7 @@ def main(
         if model.startswith("zoo:"):
             model_name = ""
         else:
-            model_name = Path(model).name
+            model_name = Path(model).stem
 
         export_csv_name = f'benchmark_{model_name}_{time.strftime("%Y%m%d_%H%M%S")}.csv'
         export_csv_path = save_dir_path / export_csv_name
@@ -366,7 +375,11 @@ def _remove_duplicates(items: List[Any]):
 
 
 def _validate_batch_sizes(batch_sizes: str):
-    batch_sizes = [int(batch_size.strip()) for batch_size in batch_sizes.split(",")]
+    batch_sizes = [
+        int(batch_size.strip())
+        for batch_size in batch_sizes.split(",")
+        if batch_size.strip()
+    ]
     return _remove_duplicates(items=batch_sizes)
 
 
@@ -374,6 +387,8 @@ def _validate_num_cores(num_cores: str):
     valid_num_cores = []
     for cores in num_cores.split(","):
         cores = cores.strip()
+        if not cores:
+            continue
         if cores == "max":
             new_core_value = cpu_details()[0]
         else:


### PR DESCRIPTION
This PR includes a few bugfixes to benchmark-sweep script for ease of use + generating random inputs for custom engine use case. 

Major changes include:

- Check and generate random inputs from the instantiated model over engine class
- Add: Support for loading files with any extension, for cases where a custom file type is to be benchmarked
- Add: click context settings to avoid confusion b/w underscores vs hyphens + some other good defaults
- Update: export csv name to not include the extension of model, by using `Path(...).stem` over `Path(...).name`
- Fix: batch_size and num_core ingestion in case a trailing comma is provided with their values

Tests:

```bash
deepsparse.benchmark_sweep \
     --model-paths /home/rahul/resnet_v2_101_1_default_1.custom_ext \
    -e /home/XXXX/projects/deepsparse/src/deepsparse/benchmark/custom_engine.py:CustomEngine \
    --num_cores "1," --batch-sizes 1
```

Output:
```bash
Starting benchmarking sweep, writing result to benchmarking-results/benchmark_resnet_v2_101_1_default_1_20230130_163354.csv
2023-01-30 16:33:54 deepsparse.benchmark.benchmark_model INFO     Thread pinning to cores enabled
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
2023-01-30 16:33:54 deepsparse.benchmark.benchmark_model INFO     CustomEngine:
	custom_engine_file_path: /home/XXXX/resnet_v2_101_1_default_1.custom_ext
	batch_size: 1
	num_cores: 1
2023-01-30 16:33:54 deepsparse.benchmark.benchmark_model INFO     Starting 'singlestream' performance measurements for 30 seconds
2023-01-30 16:34:30 __main__     INFO     /home/XXXX/resnet_v2_101_1_default_1.custom_ext benchmarking results written to benchmarking-results/benchmark_resnet_v2_101_1_default_1_20230130_163354.csv
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203904910244353