### PR TITLE
[MLOps 1.5] Refactor the constants that contain a set of `SystemGroups`

### DIFF
--- a/src/deepsparse/loggers/constants.py
+++ b/src/deepsparse/loggers/constants.py
@@ -15,19 +15,17 @@ Holds logging-related objects with constant values
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from enum import Enum
 
 
 __all__ = [
     "MetricCategories",
     "validate_identifier",
-    "REQUEST_DETAILS_IDENTIFIER_PREFIX",
-    "RESOURCE_UTILIZATION_IDENTIFIER_PREFIX",
+    "SystemGroups",
 ]
 
 UNSUPPORTED_IDENTIFIER_CHARS = {".", "[", "]"}
-REQUEST_DETAILS_IDENTIFIER_PREFIX = "request_details"
-RESOURCE_UTILIZATION_IDENTIFIER_PREFIX = "resource_utilization"
 
 
 class MetricCategories(Enum):
@@ -41,6 +39,15 @@ class MetricCategories(Enum):
     # Categories
     SYSTEM = "system"
     DATA = "data"
+
+
+@dataclass(frozen=True)
+class SystemGroups:
+    # Pipeline System Groups
+    PREDICTION_LATENCY: str = "prediction_latency"
+    # Server System Groups
+    REQUEST_DETAILS: str = "request_details"
+    RESOURCE_UTILIZATION: str = "resource_utilization"
 
 
 def validate_identifier(identifier: str):

--- a/src/deepsparse/loggers/prometheus_logger.py
+++ b/src/deepsparse/loggers/prometheus_logger.py
@@ -22,12 +22,7 @@ import warnings
 from collections import defaultdict
 from typing import Any, Dict, Optional, Type, Union
 
-from deepsparse.loggers import (
-    REQUEST_DETAILS_IDENTIFIER_PREFIX,
-    RESOURCE_UTILIZATION_IDENTIFIER_PREFIX,
-    BaseLogger,
-    MetricCategories,
-)
+from deepsparse.loggers import BaseLogger, MetricCategories, SystemGroups
 from deepsparse.loggers.helpers import unwrap_logged_value
 
 
@@ -64,9 +59,9 @@ _NAMESPACE = "deepsparse"
 _PrometheusMetric = Union[Histogram, Gauge, Summary, Counter]
 _IDENTIFIER_TO_METRIC_TYPE = {
     "prediction_latency": Histogram,
-    RESOURCE_UTILIZATION_IDENTIFIER_PREFIX: Gauge,
-    f"{REQUEST_DETAILS_IDENTIFIER_PREFIX}/successful_request": Counter,
-    f"{REQUEST_DETAILS_IDENTIFIER_PREFIX}/input_batch_size": Histogram,
+    SystemGroups.RESOURCE_UTILIZATION: Gauge,
+    f"{SystemGroups.REQUEST_DETAILS}/successful_request": Counter,
+    f"{SystemGroups.REQUEST_DETAILS}/input_batch_size": Histogram,
 }
 _SUPPORTED_DATA_TYPES = (int, float)
 _DESCRIPTION = (

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -31,9 +31,8 @@ from deepsparse.cpu import cpu_details
 from deepsparse.loggers.base_logger import BaseLogger
 from deepsparse.loggers.build_logger import logger_from_config
 from deepsparse.loggers.constants import (
-    REQUEST_DETAILS_IDENTIFIER_PREFIX,
-    RESOURCE_UTILIZATION_IDENTIFIER_PREFIX,
     MetricCategories,
+    SystemGroups,
     validate_identifier,
 )
 from deepsparse.tasks import SupportedTasks, dynamic_import_task
@@ -208,7 +207,7 @@ class Pipeline(ABC):
         self._batch_size = self._batch_size or 1
 
         self.log(
-            identifier=f"{RESOURCE_UTILIZATION_IDENTIFIER_PREFIX}/num_cores_total",
+            identifier=f"{SystemGroups.RESOURCE_UTILIZATION}/num_cores_total",
             value=num_cores,
             category=MetricCategories.SYSTEM,
         )
@@ -253,9 +252,7 @@ class Pipeline(ABC):
             category=MetricCategories.DATA,
         )
         self.log(
-            # note, will be replaced by a reference instead of "bare" string
-            # with the upcoming PR for system logging
-            identifier=f"prediction_latency/{InferencePhases.PRE_PROCESS}_seconds",
+            identifier=f"{SystemGroups.PREDICTION_LATENCY}/{InferencePhases.PRE_PROCESS}_seconds",  # noqa E501
             value=timer.time_delta(InferencePhases.PRE_PROCESS),
             category=MetricCategories.SYSTEM,
         )
@@ -273,7 +270,7 @@ class Pipeline(ABC):
         timer.stop(InferencePhases.ENGINE_FORWARD)
 
         self.log(
-            identifier=f"{REQUEST_DETAILS_IDENTIFIER_PREFIX}/input_batch_size_total",
+            identifier=f"{SystemGroups.REQUEST_DETAILS}/input_batch_size_total",
             # to get the batch size of the inputs, we need to look
             # to multiply the engine batch size (self._batch_size)
             # by the number of batches processed by the engine during
@@ -288,7 +285,7 @@ class Pipeline(ABC):
             category=MetricCategories.DATA,
         )
         self.log(
-            identifier=f"prediction_latency/{InferencePhases.ENGINE_FORWARD}_seconds",
+            identifier=f"{SystemGroups.PREDICTION_LATENCY}/{InferencePhases.ENGINE_FORWARD}_seconds",  # noqa E501
             value=timer.time_delta(InferencePhases.ENGINE_FORWARD),
             category=MetricCategories.SYSTEM,
         )
@@ -312,12 +309,12 @@ class Pipeline(ABC):
             category=MetricCategories.DATA,
         )
         self.log(
-            identifier=f"prediction_latency/{InferencePhases.POST_PROCESS}_seconds",
+            identifier=f"{SystemGroups.PREDICTION_LATENCY}/{InferencePhases.POST_PROCESS}_seconds",  # noqa E501
             value=timer.time_delta(InferencePhases.POST_PROCESS),
             category=MetricCategories.SYSTEM,
         )
         self.log(
-            identifier=f"prediction_latency/{InferencePhases.TOTAL_INFERENCE}_seconds",
+            identifier=f"{SystemGroups.PREDICTION_LATENCY}/{InferencePhases.TOTAL_INFERENCE}_seconds",  # noqa E501
             value=timer.time_delta(InferencePhases.TOTAL_INFERENCE),
             category=MetricCategories.SYSTEM,
         )

--- a/src/deepsparse/server/system_logging.py
+++ b/src/deepsparse/server/system_logging.py
@@ -18,12 +18,7 @@ from os import getpid
 from typing import Any, Dict, List, Optional, Union
 
 import psutil
-from deepsparse.loggers import (
-    REQUEST_DETAILS_IDENTIFIER_PREFIX,
-    RESOURCE_UTILIZATION_IDENTIFIER_PREFIX,
-    BaseLogger,
-    MetricCategories,
-)
+from deepsparse.loggers import BaseLogger, MetricCategories, SystemGroups
 from deepsparse.server.config import SystemLoggingConfig, SystemLoggingGroup
 from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -64,13 +59,13 @@ class SystemLoggingMiddleware(BaseHTTPMiddleware):
             log_system_information(
                 self.server_logger,
                 self.system_logging_config,
-                REQUEST_DETAILS_IDENTIFIER_PREFIX,
+                SystemGroups.REQUEST_DETAILS,
                 response_message=f"{err.__class__.__name__}: {err}",
             )
             log_system_information(
                 self.server_logger,
                 self.system_logging_config,
-                REQUEST_DETAILS_IDENTIFIER_PREFIX,
+                SystemGroups.REQUEST_DETAILS,
                 successful_request_count=0,
             )
             _LOGGER.error(err)
@@ -79,13 +74,13 @@ class SystemLoggingMiddleware(BaseHTTPMiddleware):
         log_system_information(
             self.server_logger,
             self.system_logging_config,
-            REQUEST_DETAILS_IDENTIFIER_PREFIX,
+            SystemGroups.REQUEST_DETAILS,
             response_message=f"Response status code: {response.status_code}",
         )
         log_system_information(
             self.server_logger,
             self.system_logging_config,
-            REQUEST_DETAILS_IDENTIFIER_PREFIX,
+            SystemGroups.REQUEST_DETAILS,
             successful_request_count=int((response.status_code == 200)),
         )
         return response
@@ -93,7 +88,7 @@ class SystemLoggingMiddleware(BaseHTTPMiddleware):
 
 def log_resource_utilization(
     server_logger: BaseLogger,
-    prefix: str = RESOURCE_UTILIZATION_IDENTIFIER_PREFIX,
+    prefix: str = SystemGroups.RESOURCE_UTILIZATION,
     **items_to_log: Dict[str, Any],
 ):
     """
@@ -135,7 +130,7 @@ def log_resource_utilization(
 
 def log_request_details(
     server_logger: BaseLogger,
-    prefix: str = REQUEST_DETAILS_IDENTIFIER_PREFIX,
+    prefix: str = SystemGroups.REQUEST_DETAILS,
     **items_to_log: Dict[str, Any],
 ):
     """
@@ -171,8 +166,8 @@ def log_request_details(
 # maps the metric group name to the function that logs the information
 # pertaining to this metric group name
 _PREFIX_MAPPING = {
-    REQUEST_DETAILS_IDENTIFIER_PREFIX: log_request_details,
-    RESOURCE_UTILIZATION_IDENTIFIER_PREFIX: log_resource_utilization,
+    SystemGroups.REQUEST_DETAILS: log_request_details,
+    SystemGroups.RESOURCE_UTILIZATION: log_resource_utilization,
 }
 
 


### PR DESCRIPTION
At the current state, manipulating and moving around the system group names is a bit tedious. This is because they exist as separate values. This PR wraps them inside a `dataclass` object.