### PR TITLE
Update: Open Pif Paf callables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,7 @@ def _setup_entry_points() -> Dict:
             "deepsparse.benchmark_sweep=deepsparse.benchmark.benchmark_sweep:main",
             "deepsparse.server=deepsparse.server.cli:main",
             "deepsparse.object_detection.annotate=deepsparse.yolo.annotate:main",
-            "deepsparse.pose_estimation.annotate=deepsparse.openpifpaf.annotate:main",
+            "deepsparse.pose_estimation.annotate=deepsparse.open_pif_paf.annotate:main",
             "deepsparse.image_classification.annotate=deepsparse.image_classification.annotate:main",  # noqa E501
             "deepsparse.instance_segmentation.annotate=deepsparse.yolact.annotate:main",
             f"deepsparse.image_classification.eval={ic_eval}",

--- a/src/deepsparse/open_pif_paf/README.md
+++ b/src/deepsparse/open_pif_paf/README.md
@@ -10,7 +10,8 @@ DeepSparse pipeline for OpenPifPaf
 ```python
 from deepsparse import Pipeline
 
-pipeline = Pipeline.create(task="open_pif_paf", batch_size = 1)
+model_path: str = ... # path to open_pif_paf model
+pipeline = Pipeline.create(task="open_pif_paf", batch_size=1, model_path=model_path)
 predictions = pipeline(images=['dancers.jpg'])
 # predictions have attributes `data', 'keypoints', 'scores', 'skeletons'
 predictions[0].scores

--- a/src/deepsparse/open_pif_paf/annotate.py
+++ b/src/deepsparse/open_pif_paf/annotate.py
@@ -57,10 +57,14 @@ Options:
 #######
 Examples:
 
-1) deepsparse.open_pif_paf.annotate --source PATH/TO/IMAGE.jpg
-2) deepsparse.open_pif_paf.annotate --source PATH/TO/VIDEO.mp4
-3) deepsparse.open_pif_paf.annotate --source 0
-4) deepsparse.open_pif_paf.annotate --source PATH/TO/IMAGE_DIR
+1) deepsparse.pose_estimation.annotate --model_filepath PATH/TO/MODEL.ONNX \
+       --source PATH/TO/IMAGE.jpg
+2) deepsparse.pose_estimation.annotate --model_filepath PATH/TO/MODEL.ONNX \
+       --source PATH/TO/VIDEO.mp4
+3) deepsparse.pose_estimation.annotate --model_filepath PATH/TO/MODEL.ONNX \
+       --source 0
+4) deepsparse.pose_estimation.annotate --model_filepath PATH/TO/MODEL.ONNX \
+       --source PATH/TO/IMAGE_DIR
 """
 import logging
 from typing import Optional, Tuple


### PR DESCRIPTION
The Open Pif Paf callables in `setup.py` were pointing to incorrect location this PR fixes that, and also adds `--model_filepath` in example commands, (it is required)