### PR TITLE
[OpenPifPaf] Allow for returning CifCaf fields

### DIFF
--- a/src/deepsparse/open_pif_paf/pipelines.py
+++ b/src/deepsparse/open_pif_paf/pipelines.py
@@ -22,7 +22,11 @@ import numpy
 
 import cv2
 import torch
-from deepsparse.open_pif_paf.schemas import OpenPifPafInput, OpenPifPafOutput
+from deepsparse.open_pif_paf.schemas import (
+    OpenPifPafFields,
+    OpenPifPafInput,
+    OpenPifPafOutput,
+)
 from deepsparse.pipeline import Pipeline
 from deepsparse.yolact.utils import preprocess_array
 from openpifpaf import decoder, network
@@ -57,12 +61,19 @@ class OpenPifPafPipeline(Pipeline):
     """
 
     def __init__(
-        self, *, image_size: Union[int, Tuple[int, int]] = (384, 384), **kwargs
+        self,
+        *,
+        image_size: Union[int, Tuple[int, int]] = (384, 384),
+        return_cifcaf_fields: bool = False,
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self._image_size = (
             image_size if isinstance(image_size, Tuple) else (image_size, image_size)
         )
+        # whether to return the cif and caf fields or the
+        # complete decoded output
+        self.return_cifcaf_fields = return_cifcaf_fields
         # necessary openpifpaf dependencies for now
         model_cpu, _ = network.Factory().factory(head_metas=None)
         self.processor = decoder.factory(model_cpu.head_metas)
@@ -79,7 +90,7 @@ class OpenPifPafPipeline(Pipeline):
         """
         :return: pydantic model class that outputs to this pipeline must comply to
         """
-        return OpenPifPafOutput
+        return OpenPifPafOutput if not self.return_cifcaf_fields else OpenPifPafFields
 
     def setup_onnx_file_path(self) -> str:
         """
@@ -114,6 +125,11 @@ class OpenPifPafPipeline(Pipeline):
         :return: Outputs of engine post-processed into an object in the `output_schema`
             format of this pipeline
         """
+        if self.return_cifcaf_fields:
+            batch_fields = []
+            for cif, caf in zip(*fields):
+                batch_fields.append([cif, caf])
+            return OpenPifPafFields(fields=batch_fields)
 
         data_batch, skeletons_batch, scores_batch, keypoints_batch = [], [], [], []
 

--- a/src/deepsparse/open_pif_paf/pipelines.py
+++ b/src/deepsparse/open_pif_paf/pipelines.py
@@ -111,9 +111,18 @@ class OpenPifPafPipeline(Pipeline):
 
         image_batch = list(self.executor.map(self._preprocess_image, images))
 
+        original_image_shapes = None
+        if image_batch and isinstance(image_batch[0], tuple):
+            # splits image batch is of format:
+            #  [(preprocesses_img, original_image_shape), ...] into separate lists
+            image_batch, original_image_shapes = list(map(list, zip(*image_batch)))
+
         image_batch = numpy.concatenate(image_batch, axis=0)
 
-        return [image_batch]
+        postprocessing_kwargs = dict(
+            original_image_shapes=original_image_shapes,
+        )
+        return [image_batch], postprocessing_kwargs
 
     def process_engine_outputs(
         self, fields: List[numpy.ndarray], **kwargs

--- a/src/deepsparse/open_pif_paf/schemas.py
+++ b/src/deepsparse/open_pif_paf/schemas.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
+from typing import Iterable, List, TextIO, Tuple
 
 import numpy
+from PIL import Image
 from pydantic import BaseModel, Field
 
 from deepsparse.pipelines.computer_vision import ComputerVisionSchema
@@ -48,8 +49,32 @@ class OpenPifPafFields(BaseModel):
     fields: List[List[numpy.ndarray]] = Field(
         description="Cif/Caf fields returned by the network. "
         "The outer list is the batch dimension, while the second "
-        "list contains two numpy arrays: Cif and Caf field values"
+        "list contains two numpy arrays: Cif and Caf field values. "
     )
+
+    @classmethod
+    def from_files(
+        cls, files: Iterable[TextIO], *args, from_server: bool = False, **kwargs
+    ) -> "OpenPifPafFields":
+        """
+        :param files: Iterable of file pointers to create OpenPifPafFields from
+        :param kwargs: extra keyword args to pass to OpenPifPafFields constructor
+        :return: OpenPifPafFields constructed from files
+        """
+        if "images" in kwargs:
+            raise ValueError(
+                f"argument 'images' cannot be specified in {cls.__name__} when "
+                "constructing from file(s)"
+            )
+        if from_server:
+            raise ValueError(
+                "Cannot construct OpenPifPafFields from server. This will create"
+                "numpy arrays that are not serializable."
+            )
+
+        files_numpy = [numpy.array(Image.open(file)) for file in files]
+        input_schema = cls(*args, images=files_numpy, **kwargs)
+        return input_schema
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/deepsparse/open_pif_paf/schemas.py
+++ b/src/deepsparse/open_pif_paf/schemas.py
@@ -14,6 +14,7 @@
 
 from typing import List, Tuple
 
+import numpy
 from pydantic import BaseModel, Field
 
 from deepsparse.pipelines.computer_vision import ComputerVisionSchema
@@ -22,6 +23,7 @@ from deepsparse.pipelines.computer_vision import ComputerVisionSchema
 __all__ = [
     "OpenPifPafInput",
     "OpenPifPafOutput",
+    "OpenPifPafFields",
 ]
 
 
@@ -31,6 +33,26 @@ class OpenPifPafInput(ComputerVisionSchema):
     """
 
     pass
+
+
+class OpenPifPafFields(BaseModel):
+    """
+    Open Pif Paf is composed of two stages:
+     - Computing Cif/Caf fields using a parametrized model
+     - Applying a matching algorithm to obtain the final pose
+        predictions
+    In some cases (e.g. for validation), it may be useful to
+    obtain the Cif/Caf fields as output.
+    """
+
+    fields: List[List[numpy.ndarray]] = Field(
+        description="Cif/Caf fields returned by the network. "
+        "The outer list is the batch dimension, while the second "
+        "list contains two numpy arrays: Cif and Caf field values"
+    )
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class OpenPifPafOutput(BaseModel):


### PR DESCRIPTION
## Feature Preview 
```python
from deepsparse import Pipeline
input = "src/deepsparse/yolo/sample_images/basilica.jpg"
pipeline = Pipeline.create(task="open_pif_paf", model_path="openpifpaf-resnet50.onnx", return_cifcaf_fields=True)
output = pipeline(images=input)
```
<img width="348" alt="image" src="https://user-images.githubusercontent.com/97082108/220355120-1bd78c5a-194e-494d-b2c9-a253ca7dbf00.png">

## Feature Description

OpenPifPaf is comprised of two algorithms.
- prediction of CifCaf fields (using a parametrized neural network)
- matching CifCaf fields to actual poses (using a deterministic, algorithm)

I would like to give users an option not only to receive decoded poses (final representation) but also to fetch CifCaf fields (intermediate representation).
The motivation is for easy validation (my validation use case) or the ability to use the pipeline as a component of a larger system (that requires the CifCaf fields and not necessarily the decoded poses).


