### PR TITLE
[YOLOv8] re-add examples directory with pointer to src/deepsparse docs

### DIFF
--- a/examples/ultralytics-yolov8/README.md
+++ b/examples/ultralytics-yolov8/README.md
@@ -1,0 +1,21 @@
+<!--
+Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Ultralytics YOLOv8 DeepSparse Inference
+
+Ultralytics YOLOv8 integration and example has been moved to the main
+deepsparse package.  See docs, code, and examples at
+https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/yolov8.

--- a/examples/ultralytics-yolov8/README.md
+++ b/examples/ultralytics-yolov8/README.md
@@ -18,4 +18,4 @@ limitations under the License.
 
 Ultralytics YOLOv8 integration and example has been moved to the main
 deepsparse package.  See docs, code, and examples at
-https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/yolov8.
+[src/deepsparse/yolov8](https://github.com/neuralmagic/deepsparse/tree/main/src/deepsparse/yolov8).


### PR DESCRIPTION
the examples directory was removed when the integration was productionized. moving forward going to standardize to updating example directories to point to the src/ documentation rather than removing completely