### PR TITLE
[YOLOv8-Seg] Refactor YOLACT annotation and pipeline

### DIFF
--- a/src/deepsparse/yolact/annotate.py
+++ b/src/deepsparse/yolact/annotate.py
@@ -29,9 +29,9 @@ Options:
                                   Inference engine backend to run on. Choices
                                   are 'deepsparse', 'onnxruntime', and
                                   'torch'. Default is 'deepsparse'
-  --image_shape, --image_shape INTEGER
-                                  Image shape to use for inference, must be
-                                  two integers  [default: 550, 550]
+  --model_input_image_shape, --model-input-shape INTEGER...
+                                  Image shape to override model with for
+                                  inference, must be two integers
   --num_cores, --num-cores INTEGER
                                   The number of physical cores to run the
                                   annotations with, defaults to using all
@@ -114,12 +114,12 @@ _LOGGER = logging.getLogger(__name__)
     "'onnxruntime', and 'torch'. Default is 'deepsparse'",
 )
 @click.option(
-    "--image_shape",
-    "--image-shape",
+    "--model_input_image_shape",
+    "--model-input-image-shape",
     type=int,
     nargs=2,
-    default=(550, 550),
-    help="Image shape to use for inference, must be two integers",
+    default=None,
+    help="Image shape to override model with for inference, must be two integers",
     show_default=True,
 )
 @click.option(
@@ -172,7 +172,7 @@ def main(
     model_filepath: str,
     source: str,
     engine: str,
-    image_shape: Tuple[int, int],
+    model_input_image_shape: Optional[Tuple[int, ...]],
     num_cores: Optional[int],
     save_dir: str,
     name: Optional[str],
@@ -191,7 +191,7 @@ def main(
     loader, saver, is_video = get_image_loader_and_saver(
         path=source,
         save_dir=save_dir,
-        image_shape=image_shape,
+        image_shape=None,
         target_fps=target_fps,
         no_save=no_save,
     )
@@ -203,6 +203,7 @@ def main(
         class_names="coco",
         engine_type=engine,
         num_cores=num_cores,
+        image_size=model_input_image_shape,
     )
 
     for iteration, (input_image, source_image) in enumerate(loader):


### PR DESCRIPTION
This PR refactors the YOLACT pipeline. Noteworthy changes:
  - endow the pipeline with the ability to resize the output masks and bounding boxes so that they correspond to the original image size (reimplementation of the functionality introduced by @rahul-tuli to the YOLO pipeline)
  - removing the `_resize_to_fit_img` function from the yolact annotation function. The motivation here is to make `src/deepsparse/yolact/utils/annotate.py` annotation function easily handle both YOLACT and YOLOv8Seg outputs. In the future, when the long-awaited refactor of CV pipelines happens, we could hopefully use this function to annotate any object/instance segmentation models.

Testing:
```bash
deepsparse.instance_segmentation.annotate  --source src/deepsparse/yolact/sample_images/thailand.jpg
```
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/97082108/221184843-32a7592f-f601-4731-8e83-2a9c94ef562e.png">Result in an image that corresponds to my expectations:


