### PR TITLE
[BugFix] Add  opencv to IC AutoInstalls

### DIFF
--- a/src/deepsparse/image_classification/__init__.py
+++ b/src/deepsparse/image_classification/__init__.py
@@ -20,12 +20,23 @@ from collections import namedtuple
 
 
 _LOGGER = _logging.getLogger(__name__)
-_Dependency = namedtuple("_Dependency", ["name", "version", "necessary"])
+_Dependency = namedtuple("_Dependency", ["name", "import_name", "version", "necessary"])
 
 
 def _auto_install_dependencies():
     dependencies = [
-        _Dependency(name="torchvision", version=">=0.3.0,<=0.14.0", necessary=True),
+        _Dependency(
+            name="torchvision",
+            import_name="torchvision",
+            version=">=0.3.0,<=0.14.0",
+            necessary=True,
+        ),
+        _Dependency(
+            name="opencv-python",
+            import_name="cv2",
+            version="<=4.6.0.66",
+            necessary=True,
+        ),
     ]
 
     for dependency in dependencies:
@@ -70,7 +81,7 @@ def _check_and_install_dependency(dependency: _Dependency):
     except Exception as dependency_exception:
         if dependency.necessary:
             raise ValueError(
-                f"Unable to import or install {install_name}, a requirement of "
+                f"Unable to import {dependency.import_name} or install {install_name}, a requirement of "
                 f"deepsparse.image_classification. Failed with exception: "
                 f"{dependency_exception}"
             )
@@ -83,7 +94,7 @@ def _check_and_install_dependency(dependency: _Dependency):
 
 def _check_if_dependency_installed(dependency: _Dependency, raise_on_fail=False):
     try:
-        _dep = importlib.import_module(dependency.name)
+        _dep = importlib.import_module(dependency.import_name)
         return None
     except Exception as dependency_import_error:
         if raise_on_fail:


### PR DESCRIPTION
Right now deepsparse ic auto installs are broken:
Steps to reproduce

```bash
python3.8 -m venv test-venv
source test-venv/bin/activate
pip install deepsparse
deepsparse.image_classification.annotate --help
```

Relevant Traceback:
```bash
Traceback (most recent call last):
  File "/home/rahul/test-venv/bin/deepsparse.image_classification.annotate", line 5, in <module>
    from deepsparse.image_classification.annotate import main
  File "/home/rahul/test-venv/lib/python3.8/site-packages/deepsparse/image_classification/annotate.py", line 72, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'
```

This PR fixes the error by auto-installing cv2 in IC `__init__.py` file

Noting that this is a quick temporary fix as eventually we will move away from autoinstalls and rely on deepsparse[integration] to install all integration specific dependencies, however I would like to get this in, to have a working source of truth when doing that migration