### PR TITLE
[token classification] only require 'index' on output when aggregation_strategy=none

### DIFF
--- a/src/deepsparse/transformers/pipelines/token_classification.py
+++ b/src/deepsparse/transformers/pipelines/token_classification.py
@@ -93,7 +93,6 @@ class TokenClassificationResult(BaseModel):
 
     entity: str = Field(description="entity predicted for that token/word")
     score: float = Field(description="The corresponding probability for `entity`")
-    index: int = Field(description="index of the corresponding token in the sentence")
     word: str = Field(description="token/word classified")
     start: Optional[int] = Field(
         description=(
@@ -106,6 +105,13 @@ class TokenClassificationResult(BaseModel):
             "index of the end of the corresponding entity in the sentence. "
             "Only exists if the offsets are available within the tokenizer"
         )
+    )
+    index: Optional[int] = Field(
+        description=(
+            "index of the corresponding token in the sentence. "
+            "Only supplied when aggregation_strategy='none'"
+        ),
+        default=None,
     )
     is_grouped: bool = Field(
         default=False,


### PR DESCRIPTION
`index` is only supplied on output of token classification pipelines when the aggregation strategy is None. This caused a pydantic bug due to `index` being required. This PR makes `index` not required.

HF source on the topic: https://github.com/huggingface/transformers/blob/8abe4930d39d9fb379fe89ee19327d371daee29f/src/transformers/pipelines/token_classification.py#L202

fixes: #937 

**test_plan:**
manual