### PR TITLE
[Fix] Inconsistent number of engine outputs between ONNX models from ultralytics/sparseml export

### DIFF
--- a/src/deepsparse/yolov8/pipelines.py
+++ b/src/deepsparse/yolov8/pipelines.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import warnings
 from typing import Callable, List, Type, Union
 
 import numpy
@@ -93,9 +94,12 @@ class YOLOv8Pipeline(YOLOPipeline):
 
         else:
             if len(engine_outputs) != 1:
-                # if the returns more then 1 output,
-                # we assume that the first one is
-                # the detection output
+                warnings.warn(
+                    "YOLOv8 Detection pipeline expects 1 output from engine, "
+                    "got {}. Assuming first output is detection output".format(
+                        len(engine_outputs)
+                    )
+                )
                 engine_outputs = [engine_outputs[0]]
 
             return super().process_engine_outputs(

--- a/src/deepsparse/yolov8/pipelines.py
+++ b/src/deepsparse/yolov8/pipelines.py
@@ -93,11 +93,11 @@ class YOLOv8Pipeline(YOLOPipeline):
 
         else:
             if len(engine_outputs) != 1:
-                raise ValueError(
-                    "Error: Detection pipeline "
-                    "expects 1 output from engine"
-                    "(detections), got {}".format(len(engine_outputs))
-                )
+                # if the returns more then 1 output,
+                # we assume that the first one is
+                # the detection output
+                engine_outputs = [engine_outputs[0]]
+
             return super().process_engine_outputs(
                 engine_outputs=engine_outputs, **kwargs
             )


### PR DESCRIPTION
## Fix description

Fix to: https://app.asana.com/0/1203126676641557/1204132871838595/f

The solution to the following issue:
When exporting the detection ONNX model directly from ultralytics:
 - the engine returns a single output 
When exporting the detection ONNX model from SparseML:
 -  the engine returns four inputs (single output + three auxiliary inputs (outputs from the intermediate layers).
 
The most proper thing to do would be to standardize the output for both ONNX export pathways. My solution is less correct but should do the job 

## Testing

Testing with ultralytics-exported model:
```bash
python src/deepsparse/yolov8/validation.py --model_path yolov8n.onnx
```
Output:
```bash
...
val: Scanning /home/ubuntu/damian/deepsparse/datasets/coco128/labels/train2017.cache... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:08<00:00,  1.08s/it]
                   all        128        929      0.651      0.532      0.606      0.453
                person        128        254      0.805      0.667      0.764      0.543

...
```

Testing with SparseML-exported model:
```bash
 python src/deepsparse/yolov8/validation.py --model_path Yolov8DetectionModel.onnx 
```
Output:
```bash
...
val: Scanning /home/ubuntu/damian/deepsparse/datasets/coco128/labels/train2017.cache... 126 images, 2 backgrounds, 0 corrupt: 100%|██████████| 128/128 [00:00<?, ?it/s]
                 Class     Images  Instances      Box(P          R      mAP50  mAP50-95): 100%|██████████| 8/8 [00:13<00:00,  1.73s/it]
                   all        128        929      0.739      0.682      0.751      0.578
                person        128        254       0.84      0.697      0.809      0.609
...
```
