### PR TITLE
Migrate analyze functionality to `deepsparse.debug_analysis`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,7 @@ def _setup_entry_points() -> Dict:
         "console_scripts": [
             f"deepsparse.transformers.run_inference={data_api_entrypoint}",
             f"deepsparse.transformers.eval_downstream={eval_downstream}",
-            "deepsparse.analyze=deepsparse.analyze:main",
+            "deepsparse.debug_analysis=deepsparse.debug_analysis:main",
             "deepsparse.check_hardware=deepsparse.cpu:print_hardware_capability",
             "deepsparse.benchmark=deepsparse.benchmark.benchmark_model:main",
             "deepsparse.benchmark_sweep=deepsparse.benchmark.benchmark_sweep:main",

--- a/src/deepsparse/debug_analysis.py
+++ b/src/deepsparse/debug_analysis.py
@@ -17,7 +17,7 @@ Analysis script for ONNX models with the DeepSparse engine.
 
 ##########
 Command help:
-usage: deepsparse.analyze [-h] [-wi NUM_WARMUP_ITERATIONS]
+usage: deepsparse.debug_analysis [-h] [-wi NUM_WARMUP_ITERATIONS]
                           [-bi NUM_ITERATIONS] [-ncores NUM_CORES]
                           [-b BATCH_SIZE] [-ks KERNEL_SPARSITY]
                           [-ksf KERNEL_SPARSITY_FILE]
@@ -62,7 +62,7 @@ import argparse
 import json
 import os
 
-from deepsparse import analyze_model
+from deepsparse import model_debug_analysis
 from deepsparse.utils import (
     generate_random_inputs,
     model_to_path,
@@ -301,7 +301,7 @@ def main():
     else:
         input_list = generate_random_inputs(model_path, args.batch_size)
 
-    result = analyze_model(
+    result = model_debug_analysis(
         model_path,
         input_list,
         batch_size=args.batch_size,

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -44,7 +44,7 @@ __all__ = [
     "Engine",
     "compile_model",
     "benchmark_model",
-    "analyze_model",
+    "model_debug_analysis",
     "Scheduler",
     "Context",
     "MultiModelEngine",
@@ -813,7 +813,7 @@ def benchmark_model(
     )
 
 
-def analyze_model(
+def model_debug_analysis(
     model: Union[str, "Model", "File"],
     inp: List[numpy.ndarray],
     batch_size: int = 1,


### PR DESCRIPTION
This PR migrates existing `deepsparse.analyze` utility to `deepsparse.debug_analysis` namespace

Test:

```bash
deepsparse deepsparse.debug_analysis --help
usage: deepsparse.debug_analysis [-h] [-wi NUM_WARMUP_ITERATIONS] [-bi NUM_ITERATIONS] [-ncores NUM_CORES] [-b BATCH_SIZE]
                                 [-ks KERNEL_SPARSITY] [-ksf KERNEL_SPARSITY_FILE] [--optimization OPTIMIZATION] [-i INPUT_SHAPES] [-q]
                                 [-x EXPORT_PATH]
                                 model_path

Analyze ONNX models in the DeepSparse Engine

positional arguments:
  model_path            Path to an ONNX model file or SparseZoo model stub

optional arguments:
  -h, --help            show this help message and exit
  -wi NUM_WARMUP_ITERATIONS, --num_warmup_iterations NUM_WARMUP_ITERATIONS
                        The number of warmup runs that will be executed before the actual benchmarking
  -bi NUM_ITERATIONS, --num_iterations NUM_ITERATIONS
                        The number of times the benchmark will be run
  -ncores NUM_CORES, --num_cores NUM_CORES
                        The number of physical cores to run the analysis on, defaults to all physical cores available on the system
  -b BATCH_SIZE, --batch_size BATCH_SIZE
                        The number of inputs that will run through the model at a time
  -ks KERNEL_SPARSITY, --kernel_sparsity KERNEL_SPARSITY
                        Impose kernel sparsity for all convolutions. [0.0-1.0]
  -ksf KERNEL_SPARSITY_FILE, --kernel_sparsity_file KERNEL_SPARSITY_FILE
                        Filepath to per-layer kernel sparsities JSON
  --optimization OPTIMIZATION
                        To enable or disable optimizations (Tensor Columns)
  -i INPUT_SHAPES, --input_shapes INPUT_SHAPES
                        Override the shapes of the inputs, i.e. -shapes "[1,2,3],[4,5,6],[7,8,9]" results in input0=[1,2,3]
                        input1=[4,5,6] input2=[7,8,9]
  -q, --quiet           Lower logging verbosity
  -x EXPORT_PATH, --export_path EXPORT_PATH
                        Store results into a JSON file
```