### PR TITLE
[Fix] Make `test_logging_only_system_info` flaky

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ _dev_deps = [
     "m2r2~=0.2.7",
     "mistune==0.8.4",
     "myst-parser~=0.14.0",
+    "flaky~=3.7.0",
     "ndjson>=0.3.1",
     "rinohtype>=0.4.2",
     "sphinx>=3.4.0",

--- a/tests/server/test_loggers.py
+++ b/tests/server/test_loggers.py
@@ -26,6 +26,7 @@ from deepsparse.server.config import (
 from deepsparse.server.helpers import server_logger_from_config
 from deepsparse.server.server import _build_app
 from fastapi.testclient import TestClient
+from flaky import flaky
 from tests.deepsparse.loggers.helpers import fetch_leaf_logger
 from tests.helpers import find_free_port
 from tests.test_data.server_test_data import SAMPLE_LOGS_DICT
@@ -98,6 +99,7 @@ def test_data_logging_from_predefined():
         assert log == expected_log
 
 
+@flaky(max_runs=4, min_passes=3)
 def test_logging_only_system_info():
     server_config = ServerConfig(
         endpoints=[EndpointConfig(task=task, name=name, model=stub)],


### PR DESCRIPTION
Well, once in a blue moon, simple tests for server logging fail. I am moderately sure that this is because the test completes before the log "gets" (asynchronously) to the leaf logger. This is a very rare event, a flaky test should account for that.

I think that alternatively, we could put the "sleep" function before `_test_logger_contents(...)`, but I think that making the test flaky is more elegant.