### PR TITLE
[Fix] Explicitly specify the shape for the benchmarking model

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -214,6 +214,11 @@ def generate_random_inputs(
         input_tensor_type = external_input.type.tensor_type
         elem_type = translate_onnx_type_to_numpy(input_tensor_type.elem_type)
         in_shape = [int(d.dim_value) for d in input_tensor_type.shape.dim]
+        if 0 in in_shape:
+            raise ValueError(
+                "Attempting to benchmark a model with dynamic shape using"
+                "randomly generated inputs. Please set the inputs to static"
+            )
 
         if batch_size is not None:
             in_shape[0] = batch_size

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -216,7 +216,7 @@ def generate_random_inputs(
         in_shape = [int(d.dim_value) for d in input_tensor_type.shape.dim]
         if 0 in in_shape:
             raise ValueError(
-                "Attempting to benchmark a model with dynamic shape using"
+                "Attempting to benchmark a model with dynamic shape using "
                 "randomly generated inputs. Please set the inputs to static"
             )
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -75,7 +75,7 @@ def test_benchmark_help():
         ),
         (
             "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/base-none",
-            ["-pin", "numa"],
+            ["-pin", "numa", "-shapes", "[1,3,640,640]"],
         ),
         (
             "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned-aggressive_96",


### PR DESCRIPTION
Because the onnx model had at least one dynamic axis (batch, h,w), it was failing in the benchmarking logic.
I fixed the test plus added a warning to avoid using models with dynamic shapes in `generate_random_inputs`.