### PR TITLE
Add Engine.generate_random_inputs()

### DIFF
--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -25,7 +25,11 @@ import numpy
 from tqdm.auto import tqdm
 
 from deepsparse.benchmark import BenchmarkResults
-from deepsparse.utils import model_to_path, override_onnx_input_shapes
+from deepsparse.utils import (
+    generate_random_inputs,
+    model_to_path,
+    override_onnx_input_shapes,
+)
 
 
 try:
@@ -313,6 +317,13 @@ class Engine(object):
             VNNI gives performance benefits for quantized networks.
         """
         return self._cpu_vnni
+
+    def generate_random_inputs(self) -> List[numpy.ndarray]:
+        """
+        Generate random data that matches the type and shape of the ONNX model
+        :return: List of random tensors
+        """
+        return generate_random_inputs(self.model_path, self.batch_size)
 
     def run(
         self,


### PR DESCRIPTION
An ease of use improvement to simplify demo code and reduce chance for errors.

Now we can do

```python
from deepsparse import Engine

bert_engine = Engine(model="zoo:nlp/text_classification/obert-base/pytorch/huggingface/mnli/pruned90_quant-none")

inputs = bert_engine.generate_random_inputs()
output = bert_engine(inputs)
```

instead of

```python
from deepsparse import Engine
from deepsparse.utils import generate_random_inputs, model_to_path

sparsezoo_stub = "zoo:nlp/text_classification/obert-base/pytorch/huggingface/mnli/pruned90_quant-none"
bert_engine = Engine(model=sparsezoo_stub)

inputs = generate_random_inputs(model_to_path(sparsezoo_stub), batch_size)
output = bert_engine(inputs)
```