### PR TITLE
`deepsparse.analyze`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,7 @@ def _setup_entry_points() -> Dict:
             f"deepsparse.transformers.run_inference={data_api_entrypoint}",
             f"deepsparse.transformers.eval_downstream={eval_downstream}",
             "deepsparse.debug_analysis=deepsparse.debug_analysis:main",
+            "deepsparse.analyze=deepsparse.analyze:main",
             "deepsparse.check_hardware=deepsparse.cpu:print_hardware_capability",
             "deepsparse.benchmark=deepsparse.benchmark.benchmark_model:main",
             "deepsparse.benchmark_sweep=deepsparse.benchmark.benchmark_sweep:main",

--- a/src/deepsparse/analyze.py
+++ b/src/deepsparse/analyze.py
@@ -24,8 +24,8 @@ import pandas as pd
 from deepsparse import model_debug_analysis
 from deepsparse.benchmark.benchmark_model import benchmark_model
 from deepsparse.utils import generate_random_inputs, model_to_path
-from sparseml.benchmark import BenchmarkResult
 from sparsezoo.analyze import (
+    BenchmarkResult,
     BenchmarkScenario,
     ImposedSparsificationInfo,
     ModelAnalysis,
@@ -85,12 +85,11 @@ def main(
         onnx_model=model_to_path(model_path),
         scenario=scenario,
     )
-    analysis.benchmark_results = performance_summary
+    analysis.benchmark_results = [performance_summary]
     summary = analysis.summary()
 
     summary["MODEL"] = model_path
     _display_summary_as_table(summary)
-    print(analysis.benchmark_results)
 
     if save:
         LOGGER.info(f"Writing results to {save}")
@@ -128,6 +127,7 @@ def run_benchmark_and_analysis(
     :return: A `BenchmarkResult` object encapsulating results from running
         specified benchmark and performance analysis
     """
+
     benchmark_results = benchmark_model(
         model_path=onnx_model,
         batch_size=scenario.batch_size,
@@ -146,6 +146,8 @@ def run_benchmark_and_analysis(
         inp=input_list,
         batch_size=scenario.batch_size,
         num_cores=scenario.num_cores,
+        imposed_ks=sparsity,
+        num_warmup_iterations=scenario.warmup_duration,
     )
 
     items_per_second: float = benchmark_results.get("benchmark_result", {}).get(
@@ -159,10 +161,10 @@ def run_benchmark_and_analysis(
         onnx_model_file=onnx_model, analysis_results=analysis_results
     )
 
-    # recipe = str(manager)
+    # TODO: Add recipe info
     imposed_sparsification = ImposedSparsificationInfo(
         sparsity=sparsity,
-        quantization=quantization,  # recipe=recipe
+        quantization=quantization,
     )
     results = BenchmarkResult(
         setup=scenario,

--- a/src/deepsparse/analyze.py
+++ b/src/deepsparse/analyze.py
@@ -34,7 +34,7 @@ from sparsezoo.analyze import (
 from sparsezoo.analyze.cli import analyze_options, analyze_performance_options
 
 
-LOGGER = logging.getLogger()
+LOGGER = logging.getLogger(__name__)
 
 
 @click.command()

--- a/src/deepsparse/analyze.py
+++ b/src/deepsparse/analyze.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import logging
+
+import click
+
+import pandas as pd
+from sparsezoo.analyze import ModelAnalysis
+from sparsezoo.analyze.cli import analyze_options, analyze_performance_options
+
+
+LOGGER = logging.getLogger()
+
+
+@click.command()
+@analyze_options
+@analyze_performance_options
+def main(
+    model_path: str,
+    save: str,
+    **kwargs,
+):
+    """
+    DeepSparse Performance analysis for ONNX models.
+
+    MODEL_PATH: can be a SparseZoo stub, or local path to a
+    deployment-directory or ONNX model
+
+    Examples:
+
+    - Run model analysis on resnet
+
+        deepsparse.analyze ~/models/resnet50.onnx
+    """
+    logging.basicConfig(level=logging.INFO)
+
+    for unimplemented_feat in (
+        "compare",
+        "by_layer",
+        "by_types",
+        "save_graphs",
+        "impose",
+    ):
+        if kwargs.get(unimplemented_feat):
+            raise NotImplementedError(
+                f"--{unimplemented_feat} has not been implemented yet"
+            )
+
+    LOGGER.info("Starting Analysis ...")
+    analysis = ModelAnalysis.create(model_path)
+    LOGGER.info("Analysis complete, collating results...")
+    summary = analysis.summary()
+
+    summary["MODEL"] = model_path
+    _display_summary_as_table(summary)
+
+    if save:
+        LOGGER.info(f"Writing results to {save}")
+        analysis.yaml(file_path=save)
+
+
+def _display_summary_as_table(summary):
+    summary_copy = copy.copy(summary)
+    print(f"MODEL: {summary_copy.pop('MODEL')}", end="\n\n")
+    footer = summary_copy.pop("Summary")
+
+    for section_name, section_dict in summary_copy.items():
+        print(f"{section_name.upper()}:")
+        print(pd.DataFrame(section_dict).T.to_string(), end="\n\n")
+
+    print("SUMMARY:")
+    for footer_key, footer_value in footer.items():
+        print(f"{footer_key}: {footer_value}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR represents the base feature branch for `deepsparse.analyze`

- [X] `deepsparse.analyze` CLI
- [X] use sparsezoo for sparsity information
- [x] Performance info

Relies on SparseZoo `ModelAnalysis.create` diff: https://github.com/neuralmagic/sparsezoo/pull/281
And summary updates diff: https://github.com/neuralmagic/sparsezoo/pull/285

```bash
Usage: deepsparse.analyze [OPTIONS] MODEL_PATH

  DeepSparse Performance analysis for ONNX models.

  MODEL_PATH: can be a SparseZoo stub, or local path to a deployment-directory
  or ONNX model

  Examples:

  - Run model analysis on resnet

      deepsparse.analyze ~/models/resnet50.onnx

Options:
  --compare TEXT                  A multi-arg comma separated list of model
                                  paths to compare against; can accept local
                                  path to an onnx model, a path to deployment
                                  folder containing a onnx model, a SparseZoo
                                  stub, or a previously run analysis yaml
                                  file. No comparision is run if omitted
  --save TEXT                     File path or directory to save the results
                                  as yaml to Note: file will be overwritten if
                                  exists, if a directory path is passed
                                  results will be stored under the directory
                                  as `analysis.yaml`, if set to True the file
                                  will be saved under CWD as `analysis.yaml`
  --save-graphs TEXT              Directory to save the generated graphs to.
                                  if not specified (default) no files will be
                                  saved. If set or boolean string, saves the
                                  graphs in the CWD under `analysis-graphs`;
                                  If set as directory path, graphs are saved
                                  in the specified directory
  --by-types TEXT                 A flag to enable analysis results by
                                  operator type. If set or boolean string,
                                  generates and records the results by
                                  operator type
  --by-layer TEXT                 A flag to enable analysis results by layer
                                  type. If set or boolean string, generates
                                  and records the results across all layers
  --batch-size-latency INTEGER    The batch size to run latency benchmarks at
  --impose TEXT                   The sparsification options to impose on the
                                  model and run as a comparison; this is a
                                  multi arg list of any of the following,
                                  `sparse` or `pruned` to set the sparsity for
                                  all prunable layers to 85%, #.## a float
                                  [0,1] to set the sparsity for all prunable
                                  layers to, `quant` or `quantized` to enable
                                  quantization with int8 activations and
                                  weights for all quantizable layers,
                                  {precision} to enable quantization with
                                  {precision: int16, int8, int4, int2}
                                  activations and weights for all quantizable
                                  layers w_{precision} to enable quantization
                                  with {precision: int16, int8, int4, int2}
                                  weights for all quantizable layers
                                  a_{precision} to enable quantization with
                                  {precision: int16, int8, int4, int2}
                                  activations for all quantizable layers
  --batch-size-throughput INTEGER
                                  The batch size to run throughput benchmarks
                                  at
  --benchmark-engine [deepsparse|onnxruntime]
                                  The engine to run the benchmarks through
  --help                          Show this message and exit.
```

```bash
deepsparse.analyze ~/models/resnet50-quac.onnx
INFO:root:Starting Analysis ...
INFO:root:Analysis complete, collating results...
2023-03-23 09:27:12 deepsparse.benchmark.benchmark_model INFO     Thread pinning to cores enabled
INFO:deepsparse.benchmark.benchmark_model:Thread pinning to cores enabled
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.5.0.20230303 COMMUNITY | () (release) (optimized) (system=avx512, binary=avx512)
[7f6d994a0700 >WARN<  operator() ./src/include/wand/utility/warnings.hpp:14] Generating emulated code for quantized (INT8) operations since no VNNI instructions were detected. Set NM_FAST_VNNI_EMULATION=1 to increase performance at the expense of accuracy.
2023-03-23 09:27:12 deepsparse.benchmark.benchmark_model INFO     deepsparse.engine.Engine:
	onnx_file_path: /home/rahul/models/resnet50-quac.onnx
	batch_size: 1
	num_cores: 10
	num_streams: 1
	scheduler: Scheduler.default
	fraction_of_supported_ops: 1.0
	cpu_avx_type: avx512
	cpu_vnni: False
INFO:deepsparse.benchmark.benchmark_model:deepsparse.engine.Engine:
	onnx_file_path: /home/rahul/models/resnet50-quac.onnx
	batch_size: 1
	num_cores: 10
	num_streams: 1
	scheduler: Scheduler.default
	fraction_of_supported_ops: 1.0
	cpu_avx_type: avx512
	cpu_vnni: False
2023-03-23 09:27:12 deepsparse.utils.onnx INFO     Generating input 'input', type = float32, shape = [1, 3, 224, 224]
INFO:deepsparse.utils.onnx:Generating input 'input', type = float32, shape = [1, 3, 224, 224]
2023-03-23 09:27:12 deepsparse.benchmark.benchmark_model INFO     Starting 'singlestream' performance measurements for 10 seconds
INFO:deepsparse.benchmark.benchmark_model:Starting 'singlestream' performance measurements for 10 seconds
2023-03-23 09:27:32 deepsparse.utils.onnx INFO     Generating input 'input', type = float32, shape = [1, 3, 224, 224]
INFO:deepsparse.utils.onnx:Generating input 'input', type = float32, shape = [1, 3, 224, 224]
MODEL: /home/rahul/models/resnet50-quac.onnx

PARAMETERS:
             Total  Percent Total %  Sparsity %  FP32 Precision %  INT8 Precision %
Weight  25502912.0            99.89        95.0              8.03             91.97
Bias       27560.0             0.11         0.0              3.63             96.37
Total   25530472.0           100.00        94.9              8.03             91.97

PARAMETERIZED OPS:
                  Total  Percent Total %  Sparsity %  FP32 Precision %  INT8 Precision %
Gemm          2049000.0             8.03       87.42            100.00              0.00
QLinearConv  23481472.0            91.97       95.55              0.00            100.00
Total        25530472.0           100.00       94.90              8.03             91.97

NON PARAMETERIZED OPS:
                   Total  Percent Total %  Sparsity %  FP32 Precision %  INT8 Precision %
Reshape              1.0             1.15         0.0             100.0               0.0
Unsqueeze            1.0             1.15         0.0             100.0               0.0
Concat               1.0             1.15         0.0             100.0               0.0
Relu                13.0            14.94         0.0             100.0               0.0
GlobalAveragePool    1.0             1.15         0.0             100.0               0.0
Add                 16.0            18.39         0.0             100.0               0.0
QuantizeLinear      17.0            19.54         0.0             100.0               0.0
Gather               1.0             1.15         0.0             100.0               0.0
MaxPool              1.0             1.15         0.0             100.0               0.0
Softmax              1.0             1.15         0.0             100.0               0.0
Shape                1.0             1.15         0.0             100.0               0.0
DequantizeLinear    33.0            37.93         0.0             100.0               0.0
Total               87.0           100.00         0.0             100.0               0.0

OVERALL:
            Latency(ms) Quantized Non-Parameterized Ops % Quantized Parameterized Ops % Sparsity % Supported Graph % Throughput(itm/sec)
Benchmark 1    2.445059                               0.0                         91.97       95.0                             408.98815

SUMMARY:
Number of Parameters: 25530472
Number of Operations: 25530559
Weight Sparsity %: 95.0
Quantized Parameterized Ops %: 91.97
Quantized Non-Parameterized Ops %: 0.0
```


MORE FEATURES (that will be added in subsequent PRs):
- [ ] De-referencing folded and Quantized Node names
- [ ] Prettier Output
- [ ] Cleanup -> Add and use analyze function from sparsezoo + add func to pretty print summary in sparsezoo
- [ ] Read/Writes support
- [ ] Compare support