### PR TITLE
[Cherry Pick] Support for dynamic input YOLO models (1.4.2)

### DIFF
--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -39,7 +39,7 @@ try:
     from deepsparse.generated_version import is_enterprise, is_release, splash, version
 except Exception:
     # otherwise, fall back to version info in this file
-    version = "1.4.1"
+    version = "1.4.2"
     is_release = False
     is_enterprise = False
     splash = (

--- a/src/deepsparse/yolo/pipelines.py
+++ b/src/deepsparse/yolo/pipelines.py
@@ -158,6 +158,12 @@ class YOLOPipeline(Pipeline):
         model_path = model_to_path(self.model_path)
         if self._image_size is None:
             self._image_size = get_onnx_expected_image_shape(onnx.load(model_path))
+            if self._image_size == (0, 0):
+                raise ValueError(
+                    "The model does not have a static image size shape. "
+                    "Specify the expected image size by passing the"
+                    "`image_size` argument to the pipeline."
+                )
         else:
             # override model input shape to given image size
             if isinstance(self._image_size, int):

--- a/src/deepsparse/yolo/utils/utils.py
+++ b/src/deepsparse/yolo/utils/utils.py
@@ -359,6 +359,8 @@ def modify_yolo_onnx_input_shape(
     model_input = model.graph.input[0]
 
     initial_x, initial_y = get_onnx_expected_image_shape(model)
+    if initial_x == initial_y == 0:
+        initial_x, initial_y = image_shape
 
     if not (isinstance(initial_x, int) and isinstance(initial_y, int)):
         return model_path, None  # model graph does not have static integer input shape

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -75,7 +75,7 @@ def test_benchmark_help():
         ),
         (
             "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/base-none",
-            ["-pin", "numa"],
+            ["-pin", "numa", "-shapes", "[1,3,640,640]"],
         ),
         (
             "zoo:cv/detection/yolov5-s/pytorch/ultralytics/coco/pruned-aggressive_96",


### PR DESCRIPTION
This cherry pick combines:
https://github.com/neuralmagic/deepsparse/pull/964
https://github.com/neuralmagic/deepsparse/pull/965
https://github.com/neuralmagic/deepsparse/pull/967

And applies the net of them to 1.4 release