### PR TITLE
Add [input,output]_[names,shapes] to Engine

### DIFF
--- a/src/deepsparse/benchmark/ort_engine.py
+++ b/src/deepsparse/benchmark/ort_engine.py
@@ -19,8 +19,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy
 
 from deepsparse.utils import (
-    get_input_names,
-    get_output_names,
     model_to_path,
     override_onnx_batch_size,
     override_onnx_input_shapes,
@@ -101,9 +99,6 @@ class ORTEngine(object):
         self._batch_size = _validate_batch_size(batch_size)
         self._num_cores = num_cores
         self._input_shapes = input_shapes
-
-        self._input_names = get_input_names(self._model_path)
-        self._output_names = get_output_names(self._model_path)
 
         if providers is None:
             providers = onnxruntime.get_available_providers()
@@ -213,6 +208,34 @@ class ORTEngine(object):
         :return: The kind of scheduler to execute with
         """
         return None
+
+    @property
+    def input_names(self) -> List[str]:
+        """
+        :return: The ordered names of the inputs.
+        """
+        return [node_arg.name for node_arg in self._eng_net.get_inputs()]
+
+    @property
+    def input_shapes(self) -> List[Tuple]:
+        """
+        :return: The ordered shapes of the inputs.
+        """
+        return [node_arg.shape for node_arg in self._eng_net.get_inputs()]
+
+    @property
+    def output_names(self) -> List[str]:
+        """
+        :return: The ordered names of the outputs.
+        """
+        return [node_arg.name for node_arg in self._eng_net.get_outputs()]
+
+    @property
+    def output_shapes(self) -> List[Tuple]:
+        """
+        :return: The ordered shapes of the outputs.
+        """
+        return [node_arg.shape for node_arg in self._eng_net.get_outputs()]
 
     @property
     def providers(self) -> List[str]:

--- a/src/deepsparse/benchmark/ort_engine.py
+++ b/src/deepsparse/benchmark/ort_engine.py
@@ -282,8 +282,8 @@ class ORTEngine(object):
         """
         if val_inp:
             self._validate_inputs(inp)
-        inputs_dict = {name: value for name, value in zip(self._input_names, inp)}
-        return self._eng_net.run(self._output_names, inputs_dict)
+        inputs_dict = {name: value for name, value in zip(self.input_names, inp)}
+        return self._eng_net.run(self.output_names, inputs_dict)
 
     def timed_run(
         self, inp: List[numpy.ndarray], val_inp: bool = False

--- a/src/deepsparse/benchmark/ort_engine.py
+++ b/src/deepsparse/benchmark/ort_engine.py
@@ -221,7 +221,7 @@ class ORTEngine(object):
         """
         :return: The ordered shapes of the inputs.
         """
-        return [node_arg.shape for node_arg in self._eng_net.get_inputs()]
+        return [tuple(node_arg.shape) for node_arg in self._eng_net.get_inputs()]
 
     @property
     def output_names(self) -> List[str]:
@@ -235,7 +235,7 @@ class ORTEngine(object):
         """
         :return: The ordered shapes of the outputs.
         """
-        return [node_arg.shape for node_arg in self._eng_net.get_outputs()]
+        return [tuple(node_arg.shape) for node_arg in self._eng_net.get_outputs()]
 
     @property
     def providers(self) -> List[str]:

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -304,6 +304,34 @@ class Engine(object):
         return round(self._eng_net.fraction_of_supported_ops(), 4)
 
     @property
+    def input_names(self) -> List[str]:
+        """
+        :return: The ordered names of the inputs.
+        """
+        return self._eng_net.input_names()
+
+    @property
+    def input_shapes(self) -> List[str]:
+        """
+        :return: The ordered shapes of the inputs.
+        """
+        return self._eng_net.input_dims()
+
+    @property
+    def output_names(self) -> List[str]:
+        """
+        :return: The ordered names of the outputs.
+        """
+        return self._eng_net.output_names()
+
+    @property
+    def output_shapes(self) -> List[str]:
+        """
+        :return: The ordered shapes of the outputs.
+        """
+        return self._eng_net.output_dims()
+
+    @property
     def cpu_avx_type(self) -> str:
         """
         :return: The detected cpu avx type that neural magic is running with.

--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -311,7 +311,7 @@ class Engine(object):
         return self._eng_net.input_names()
 
     @property
-    def input_shapes(self) -> List[str]:
+    def input_shapes(self) -> List[Tuple]:
         """
         :return: The ordered shapes of the inputs.
         """
@@ -325,7 +325,7 @@ class Engine(object):
         return self._eng_net.output_names()
 
     @property
-    def output_shapes(self) -> List[str]:
+    def output_shapes(self) -> List[Tuple]:
         """
         :return: The ordered shapes of the outputs.
         """


### PR DESCRIPTION
```python
import deepsparse
e = deepsparse.Engine("zoo:cv/classification/efficientnet-b0/pytorch/sparseml/imagenet/base-none")
print(f"{e.input_names}\n{e.input_shapes}\n{e.output_names}\n{e.output_shapes}")

# ['input']
# [(1, 3, 224, 224)]
# ['output_0', 'output_1']
# [(1, 1000), (1, 1000)]
```