### PR TITLE
Dereferencing Node Names for analyze performance results

### DIFF
--- a/src/deepsparse/analyze.py
+++ b/src/deepsparse/analyze.py
@@ -202,6 +202,17 @@ def _get_node_timings_from_analysis_results(
         output: node.name for node in model.graph.node for output in node.output
     }
 
+    # dereference node names
+    for node in model.graph.node:
+        name = node.name
+        if node.op_type == "BatchNormalization":
+            potential_parents = node.input
+            for parent in potential_parents:
+                if "Conv" in canonical_name_to_node_name.get(parent, ""):
+                    name = canonical_name_to_node_name[parent]
+        for output in node.output:
+            canonical_name_to_node_name[output] = name
+
     layer_info = analysis_results["layer_info"]
     node_timings: List[NodeInferenceResult] = []
 


### PR DESCRIPTION
This PR will dereference node names from performance results while running deepsparse:

Essentially changes will be two fold:

- [X] Dereferencing BatchNormalization names to parent Conv if any
- [ ] Dereferencing Quantized nodes to actual node names from parent graph

```bash
deepsparse.analyze ~/models/resnet50.onnx
```

Output: (BatchNorms replaced by parent convs)

Output before this PR:
```bash
023-04-14 10:05:47 __main__     INFO     Starting Analysis ...
INFO:__main__:Starting Analysis ...
2023-04-14 10:05:48 __main__     INFO     Analysis complete, collating results...
INFO:__main__:Analysis complete, collating results...
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.5.0.20230303 COMMUNITY | () (release) (optimized) (system=avx512, binary=avx512)
Node Timings for Benchmark # 1:
 NODE_NAME                      AVG_RUNTIME                    
 BatchNormalization_1           0.16                           
 BatchNormalization_37          0.17                           
 BatchNormalization_40          0.22                           
 BatchNormalization_43          0.08                           
 BatchNormalization_45          0.17                           
 BatchNormalization_49          0.10                           
 BatchNormalization_52          0.20                           
 BatchNormalization_55          0.09                           
 BatchNormalization_59          0.10                           
 BatchNormalization_62          0.21                           
 BatchNormalization_65          0.09                           
 BatchNormalization_69          0.10                           
 BatchNormalization_72          0.20                           
 BatchNormalization_75          0.09                           
 BatchNormalization_79          0.17                           
 BatchNormalization_82          0.24                           
 BatchNormalization_85          0.09                           
 BatchNormalization_87          0.18                           
 BatchNormalization_91          0.11                           
 BatchNormalization_94          0.24                           
 BatchNormalization_97          0.09                           
 BatchNormalization_101         0.11                           
 BatchNormalization_104         0.24                           
 BatchNormalization_107         0.09                           
 BatchNormalization_111         0.11                           
 BatchNormalization_114         0.24                           
 BatchNormalization_117         0.09                           
 BatchNormalization_121         0.11                           
 BatchNormalization_124         0.23                           
 BatchNormalization_127         0.09                           
 BatchNormalization_131         0.11                           
 BatchNormalization_134         0.23                           
 BatchNormalization_137         0.09                           
 BatchNormalization_141         0.19                           
 BatchNormalization_144         0.35                           
 BatchNormalization_147         0.12                           
 BatchNormalization_149         0.24                           
 BatchNormalization_153         0.19                           
 BatchNormalization_156         0.29                           
 BatchNormalization_159         0.12                           
 BatchNormalization_163         0.18                           
 BatchNormalization_166         0.25                           
 BatchNormalization_169         0.12                           
 GlobalAveragePool_172          0.01                           
 Gemm_179                       0.15                           
 Softmax_180                    0.00                           

Params:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 /home/rahul/models/resnet50.on 0.00                           0.00                           25503912                       816125184                      
 nx                                                                                                                                                         

Ops:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 /home/rahul/models/resnet50.on 0.00                           0.00                           25504039                       816129248                      
 nx                                                                                                                                                         

Overall:
 MODEL                          LATENCY                        THROUGHPUT                     SUPPORTED_GRAPH                SPARSITY                       QUANTIZED                      
 /home/rahul/models/resnet50.on 8.68                           115.17                         1.00                           0.00                           0.00                           
 nx                                                                                                                                                                                        

```

```bash
INFO:__main__:Starting Analysis ...
2023-04-14 09:37:43 __main__     INFO     Analysis complete, collating results...
INFO:__main__:Analysis complete, collating results...
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.5.0.20230303 COMMUNITY | () (release) (optimized) (system=avx512, binary=avx512)
Node Timings for Benchmark # 1:
 NODE_NAME                      AVG_RUNTIME                    
 Conv_0                         0.16                           
 Conv_36                        0.17                           
 Conv_39                        0.22                           
 Conv_42                        0.08                           
 Conv_44                        0.17                           
 Conv_48                        0.10                           
 Conv_51                        0.20                           
 Conv_54                        0.09                           
 Conv_58                        0.10                           
 Conv_61                        0.21                           
 Conv_64                        0.09                           
 Conv_68                        0.10                           
 Conv_71                        0.20                           
 Conv_74                        0.09                           
 Conv_78                        0.17                           
 Conv_81                        0.24                           
 Conv_84                        0.09                           
 Conv_86                        0.18                           
 Conv_90                        0.11                           
 Conv_93                        0.23                           
 Conv_96                        0.09                           
 Conv_100                       0.11                           
 Conv_103                       0.23                           
 Conv_106                       0.09                           
 Conv_110                       0.11                           
 Conv_113                       0.24                           
 Conv_116                       0.09                           
 Conv_120                       0.11                           
 Conv_123                       0.23                           
 Conv_126                       0.10                           
 Conv_130                       0.11                           
 Conv_133                       0.23                           
 Conv_136                       0.09                           
 Conv_140                       0.19                           
 Conv_143                       0.35                           
 Conv_146                       0.12                           
 Conv_148                       0.24                           
 Conv_152                       0.17                           
 Conv_155                       0.29                           
 Conv_158                       0.12                           
 Conv_162                       0.17                           
 Conv_165                       0.25                           
 Conv_168                       0.12                           
 GlobalAveragePool_172          0.01                           
 Gemm_179                       0.15                           
 Softmax_180                    0.00                           

Params:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 /home/rahul/models/resnet50.on 0.00                           0.00                           25503912                       816125184                      
 nx                                                                                                                                                         

Ops:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 /home/rahul/models/resnet50.on 0.00                           0.00                           25504039                       816129248                      
 nx                                                                                                                                                         

Overall:
 MODEL                          LATENCY                        THROUGHPUT                     SUPPORTED_GRAPH                SPARSITY                       QUANTIZED                      
 /home/rahul/models/resnet50.on 8.84                           113.08                         1.00                           0.00                           0.00                           
 nx                                                                                                                                                                                        
```