### PR TITLE
Bugfix: Fraction of supported Ops

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -422,7 +422,7 @@ def benchmark_model(
         "seconds_to_run": time,
         "num_streams": num_streams,
         "benchmark_result": benchmark_result,
-        "fraction_of_supported_ops": model.fraction_of_supported_ops,
+        "fraction_of_supported_ops": getattr(model, "fraction_of_supported_ops", None),
     }
 
     # Export results


### PR DESCRIPTION
This PR fixes a bug introduced in the following commit:
`f9c812958895f509c2c6c0194b839cb47c2faed8`

The bug was caused due to a wrong assumption that all model Engine classes
would have `fraction_of_supported_ops`, however this is not True for `ORTEngine`

This bug led to an `AttributeError` in `deepsparse.benchmark` when `onnxruntime`
engine was used as follows:

```bash
deepsparse.benchmark ~/models/resnet50.
onnx -e onnxruntime
2023-04-19 09:35:45 deepsparse.benchmark.benchmark_model INFO     Thread pinning to cores enabled
2023-04-19 09:35:46 deepsparse.benchmark.benchmark_model INFO     ORTEngine:
	onnx_file_path: ~/models/resnet50.onnx
	batch_size: 1
	num_cores: 10
	providers: ['CPUExecutionProvider']
2023-04-19 09:35:46 deepsparse.utils.onnx INFO     Generating input 'input', type = float32, shape = [1, 3, 224, 224]
2023-04-19 09:35:46 deepsparse.benchmark.benchmark_model INFO     Starting 'singlestream' performance measurements for 10 seconds
Traceback (most recent call last):
  File "~/virtual_environments/deepsparse3.8/bin/deepsparse.benchmark", line 8, in <module>
    sys.exit(main())
  File "~/projects/deepsparse/src/deepsparse/benchmark/benchmark_model.py", line 441, in main
    result = benchmark_model(
  File "~/projects/deepsparse/src/deepsparse/benchmark/benchmark_model.py", line 425, in benchmark_model
    "fraction_of_supported_ops": model.fraction_of_supported_ops,
AttributeError: 'ORTEngine' object has no attribute 'fraction_of_supported_ops'
```

This PR resolves this bug by using `getattr` with the model object to fetch 
`fraction_of_supported_ops`, this change prevents the above error.

```bash
deepsparse.benchmark ~/models/resnet50.onnx -e onnxruntime
2023-04-19 09:46:08 deepsparse.benchmark.benchmark_model INFO     Thread pinning to cores enabled
2023-04-19 09:46:09 deepsparse.benchmark.benchmark_model INFO     ORTEngine:
	onnx_file_path: ~/models/resnet50.onnx
	batch_size: 1
	num_cores: 10
	providers: ['CPUExecutionProvider']
2023-04-19 09:46:09 deepsparse.utils.onnx INFO     Generating input 'input', type = float32, shape = [1, 3, 224, 224]
2023-04-19 09:46:09 deepsparse.benchmark.benchmark_model INFO     Starting 'singlestream' performance measurements for 10 seconds
Original Model Path: ~/models/resnet50.onnx
Batch Size: 1
Scenario: sync
Throughput (items/sec): 109.7202
Latency Mean (ms/batch): 9.1076
Latency Median (ms/batch): 9.0767
Latency Std (ms/batch): 0.3798
Iterations: 1098
```