### PR TITLE
Update: Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,7 +113,7 @@ COPY --from=build $VENV $VENV
 COPY --from=build deepsparse deepsparse
 ENV PATH="${VENV}/bin:$PATH"
 HEALTHCHECK CMD python -c 'import deepsparse'
-ENTRYPOINT bash
+CMD bash
 
 
 FROM base as prod
@@ -121,5 +121,5 @@ ARG VENV
 COPY --from=build $VENV $VENV
 ENV PATH="${VENV}/bin:$PATH"
 HEALTHCHECK CMD python -c 'import deepsparse'
-ENTRYPOINT bash
+CMD bash
 


### PR DESCRIPTION
This PR updates the dockerfile to use
`CMD` over `ENTRYPOINT` to allow easier overriding of commands for users

for example
Now the `deepsparse.server` can be run directly with one command

```bash
docker container run -it -p 5543:5543 ghcr.io/neuralmagic/deepsparse:1.4.2 \
  deepsparse.server --task image-classification
```