### PR TITLE
Update: old references of python3.6 --> 3.7

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Developing the DeepSparse Engine
 
-The DeepSparse Python API is developed and tested using Python 3.6-3.10.
+The DeepSparse Python API is developed and tested using Python 3.7-3.10.
 To develop the Python API, you will also need the development dependencies and to follow the styling guidelines.
 
 Here's some details to get started.


### PR DESCRIPTION
This PR updates missed references of python3.6 to python3.7