### PR TITLE
Fix for using dataset-path w/ coco

### DIFF
--- a/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
+++ b/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
@@ -3,6 +3,7 @@
 
 import json
 from typing import Dict
+from pathlib import Path
 
 from tqdm import tqdm
 
@@ -43,6 +44,9 @@ class DeepSparseValidator:
         self.device = select_device(self.args.device, self.args.batch)
         self.args.half &= self.device.type != "cpu"
         self.data = check_det_dataset(self.args.data)
+        if isinstance(self.data["path"], str):
+            self.data["path"] = Path(self.data["path"])
+
         if self.device.type == "cpu":
             self.args.workers = (
                 0  # faster CPU val as time dominated by inference, not dataloading

--- a/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
+++ b/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
@@ -2,8 +2,8 @@
 # flake8: noqa
 
 import json
-from typing import Dict
 from pathlib import Path
+from typing import Dict
 
 from tqdm import tqdm
 


### PR DESCRIPTION
Using dataset-path triggers the override of the data entry w/ a path to a local file. This pathway leads to an internal path in a string format, wheareas pycocotools expects a Path object. This PR fixes this issue by always making this path a "Path" object.

Testing plan:
Tested by evaluating YOLOv8-s:
`deepsparse.yolov8.eval --model-path zoo:cv/detection/yolov8-s/pytorch/ultralytics/coco/base-none --dataset-yaml coco.yaml  --dataset-path ~/datasets/coco
`