### PR TITLE
default num_cores in `benchmark_model` fn

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -345,7 +345,7 @@ def benchmark_model(
 ) -> Dict:
     if quiet:
         set_logging_level(logging.WARN)
-        
+
     if num_cores is None:
         num_cores = cpu_architecture().num_available_physical_cores
 

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -345,6 +345,9 @@ def benchmark_model(
 ) -> Dict:
     if quiet:
         set_logging_level(logging.WARN)
+        
+    if num_cores is None:
+        num_cores = cpu_architecture().num_available_physical_cores
 
     decide_thread_pinning(thread_pinning)
 


### PR DESCRIPTION
`num_cores` is properly defaulted in the benchmark model CLI but not python API function call. this can cause errors with operating over the `None` default value in that scenario.

This PR adds a fix to provide a default when `None` is specified