### PR TITLE
[cherry-pick] default num_cores in `benchmark_model` fn (#1018)

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -346,6 +346,9 @@ def benchmark_model(
     if quiet:
         set_logging_level(logging.WARN)
 
+    if num_cores is None:
+        num_cores = cpu_architecture().num_available_physical_cores
+
     decide_thread_pinning(thread_pinning)
 
     scenario = parse_scenario(scenario.lower())


### PR DESCRIPTION
* default num_cores in `benchmark_model` fn

`num_cores` is properly defaulted in the benchmark model CLI but not python API function call. this can cause errors with operating over the `None` default value in that scenario.

This PR adds a fix to provide a default when `None` is specified

* quality