### PR TITLE
Server accepts file for pre-/post-processing functions

### DIFF
--- a/docs/user-guide/deepsparse-server.md
+++ b/docs/user-guide/deepsparse-server.md
@@ -272,7 +272,60 @@ Check out the [Use Case](../use-cases) page for detailed documentation on task-s
 
 ## Custom Use Cases
 
-Stay tuned for documentation on using a custom DeepSparse Pipeline within the Server!
+The endpoints can also take in a custom task, along with custom preprocess and postprocessing functions
+
+```yaml
+# custom-processing-config.yaml
+
+endpoints:
+  - task: custom
+    model: ~/models/resnet50.onnx
+    kwargs:
+      processing_file: ~/processing.py
+```
+
+Where `model` must be a valid onnx model that exists on the system, and `processing_file` must be a
+ valid python file contain pre- and/or post-processing functions, for example:
+
+(make sure you have torchvision installed for this exact example)
+
+```python
+# processing.py
+
+from torchvision import transforms
+from PIL import Image
+import torch
+
+IMAGENET_RGB_MEANS = [0.485, 0.456, 0.406]
+IMAGENET_RGB_STDS = [0.229, 0.224, 0.225]
+preprocess_transforms = transforms.Compose([
+    transforms.Resize(256),
+    transforms.CenterCrop(224),
+    transforms.ToTensor(),
+    transforms.Normalize(mean=IMAGENET_RGB_MEANS, std=IMAGENET_RGB_STDS),
+])
+
+def preprocess(img_file):
+    with open(img_file, "rb") as img_file:
+        img = Image.open(img_file)
+        img = img.convert("RGB")
+    img = preprocess_transforms(img)
+    batch = torch.stack([img])
+    return [batch.numpy()]
+
+def postprocess(outputs):
+    return outputs
+```
+
+Spinning up:
+
+```bash
+deepsparse.server \
+  --config-file custom-processing-config.yaml
+```
+
+Now the custom preprocess and postprocess functions will be used when
+requests are made to this server!
 
 ## Multi-Stream
 


### PR DESCRIPTION
This PR makes code changes such that a custom pipeline, with custom pre-/post-processing functions can be created using the `deepsparse.server` directly. This enables a user to use our system without knowing anything about custom pipelines

Additionally this PR also makes documentation updates, to expose this pathway.

```yaml
# custom-processing-functions-config.yaml

endpoints:
  - task: custom
    model: /home/rahul/models/resnet50.onnx
    kwargs:
      processing_file: /home/rahul/projects/deepsparse/processing.py
```

```python
# processing.py

from torchvision import transforms
from PIL import Image
import torch

IMAGENET_RGB_MEANS = [0.485, 0.456, 0.406]
IMAGENET_RGB_STDS = [0.229, 0.224, 0.225]
preprocess_transforms = transforms.Compose([
    transforms.Resize(256),
    transforms.CenterCrop(224),
    transforms.ToTensor(),
    transforms.Normalize(mean=IMAGENET_RGB_MEANS, std=IMAGENET_RGB_STDS),
])

def preprocess(img_file):
    with open(img_file, "rb") as img_file:
        img = Image.open(img_file)
        img = img.convert("RGB")
    img = preprocess_transforms(img)
    batch = torch.stack([img])
    return [batch.numpy()]

def postprocess(outputs):
    return outputs
```

Invocation:

```bash
deepsparse.server --config_file custom-processing-functions-config.yaml
```

 And Voila! Now the server creates a custom pipeline, with custom pre-/post- processing functions from the specified `processing.py`

Special thanks to @bfineran for thinking about this pathway
And @dbogunowicz for #821 from which the loading functions code is inspired from
 