### PR TITLE
Require `torchvision<0.14` rather than `torchvision<=0.13`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,11 +130,11 @@ _onnxruntime_deps = [
     "onnxruntime>=1.7.0",
 ]
 _image_classification_deps = [
-    "torchvision>=0.3.0,<=0.13",
+    "torchvision>=0.3.0,<0.14",
     "opencv-python<=4.6.0.66",
 ]
 _yolo_integration_deps = [
-    "torchvision>=0.3.0,<=0.13",
+    "torchvision>=0.3.0,<0.14",
     "opencv-python<=4.6.0.66",
 ]
 _openpifpaf_integration_deps = [

--- a/tests/utils/test_engine_mocking.py
+++ b/tests/utils/test_engine_mocking.py
@@ -38,7 +38,7 @@ def test_mock_engine_calls(engine_mock: MagicMock):
     engine_mock.assert_called_once_with(
         os.path.join(
             os.path.expanduser("~"),
-            ".cache/sparsezoo/84774c96-ab7d-4b3b-ab8c-2509d7bfcb09/model.onnx",
+            ".cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned85.4block_quantized/model.onnx",
         ),
         3,
         1,

--- a/tests/utils/test_engine_mocking.py
+++ b/tests/utils/test_engine_mocking.py
@@ -38,7 +38,8 @@ def test_mock_engine_calls(engine_mock: MagicMock):
     engine_mock.assert_called_once_with(
         os.path.join(
             os.path.expanduser("~"),
-            ".cache/sparsezoo/neuralmagic/resnet_v1-50-imagenet-pruned85.4block_quantized/model.onnx",
+            ".cache/sparsezoo/neuralmagic/",
+            "resnet_v1-50-imagenet-pruned85.4block_quantized/model.onnx",
         ),
         3,
         1,


### PR DESCRIPTION
DeepSparse integration tests have been failing because we are restrictive on hotfix version for torchvision
We require torch==1.12.1 but restrict to torchvision==0.13 rather than allow 0.13.1
```
The conflict is caused by:
    deepsparse-nightly[dev,haystack,image-classification,server,transformers] 1.5.0 depends on torch==1.12.1; extra == "haystack"
    sentence-transformers 2.2.0 depends on torch>=1.6.0
    torchvision 0.13.0 depends on torch==1.12.0
```
https://github.com/neuralmagic/deepsparse/actions/runs/5010952108/jobs/8981291327

My proposed fix is to change `torchvision>=0.3.0,<=0.13` to `torchvision>=0.3.0,<0.14`

Also, fix the SparseZoo change to use repo_name rather than model_id for the cache filepath