### PR TITLE
[Fix] Add a patch that fixes the issue introduced by revamped `save_onnx` function

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -58,8 +58,10 @@ def save_onnx_to_temp_files(model: Model) -> str:
     Save model to a temporary file.  Works for models with external data.
     """
     shaped_model = tempfile.NamedTemporaryFile(mode="w", delete=False)
-    external_data = next(tempfile._get_candidate_names())
-    has_external_data = save_onnx(model, shaped_model.name, external_data)
+    external_data = os.path.join(
+        tempfile.tempdir, next(tempfile._get_candidate_names())
+    )
+    has_external_data = save_onnx(model, shaped_model.name)
 
     try:
         yield shaped_model.name
@@ -67,10 +69,7 @@ def save_onnx_to_temp_files(model: Model) -> str:
         os.unlink(shaped_model.name)
         shaped_model.close()
         if has_external_data:
-            external_data_path = os.path.join(
-                os.path.dirname(shaped_model.name), external_data
-            )
-            os.unlink(external_data_path)
+            os.unlink(external_data)
 
 
 def translate_onnx_type_to_numpy(tensor_type: int):


### PR DESCRIPTION
The reason why the tests were failing is twofold:

1. the external data for the tensors was not saved in the same directory as the onnx model (`save_onnx_to_temp_files` function). Solution:
```python
external_data = os.path.join(
            tempfile.tempdir, next(tempfile._get_candidate_names())
        )
``` 
Before:
```python
shaped_model.name -> /tmp/i_am_a_model.onnx
external_data -> i_am_data
```

Now:
```python
shaped_model.name -> /tmp/i_am_a_model.onnx
external_data -> /tmp/i_am_data
```
2. we need to stop generating new external data files when using functions:
`override_onnx_input_shapes`
`override_onnx_batch_size`.

Not only it is wasteful and memory intensive for larger ONNX models (which will be soon ubiquitous in our SparseZoo), but also leads to accidental braking of the relationship between the model graph and its external data.
The current solution unblocks the QA, but I cannot guarantee that they will be solving all the problems coming from the logic governing the manipulation (saving/loading) of the big ONNX models with external tensors.

The bottom line is to:
- refrain from saving models to temporary files if not absolutely necessary
- always operating (overriding input shapes etc.)  on lightweight model graphs only, while their external data stays untouched.