### PR TITLE
Deprecate Py37

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ A clear and concise description of what you expected to happen.
 **Environment**
 Include all relevant environment information:
 1. OS [e.g. Ubuntu 18.04]:
-2. Python version [e.g. 3.7]:
+2. Python version [e.g. 3.8]:
 3. DeepSparse version or commit hash [e.g. 0.1.0, `f7245c8`]:
 4. ML framework version(s) [e.g. torch 1.7.1]:
 5. Other Python package versions [e.g. SparseML, Sparsify, numpy, ONNX]:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Developing DeepSparse
 
-The DeepSparse Python API is developed and tested using Python 3.7-3.10.
+The DeepSparse Python API is developed and tested using Python 3.8-3.10.
 To develop the Python API, you will also need the development dependencies and to follow the styling guidelines.
 
 Here's some details to get started.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ pip install deepsparse
 
 [Supported Hardware for DeepSparse](https://github.com/neuralmagic/deepsparse/tree/main/docs/user-guide/hardware-support.md)
 
-DeepSparse is tested on Python versions 3.7-3.10, ONNX versions 1.5.0-1.12.0, ONNX opset version 11 or higher, and manylinux compliant systems. Please note that DeepSparse is only supported natively on Linux. For those using Mac or Windows, running Linux in a Docker or virtual machine is necessary to use DeepSparse.
+DeepSparse is tested on Python versions 3.8-3.10, ONNX versions 1.5.0-1.12.0, ONNX opset version 11 or higher, and manylinux compliant systems. Please note that DeepSparse is only supported natively on Linux. For those using Mac or Windows, running Linux in a Docker or virtual machine is necessary to use DeepSparse.
 
 ## Deployment APIs
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # DeepSparse Installation
 
-DeepSparse is tested on Python 3.7-3.10, ONNX 1.5.0-1.10.1, ONNX opset version 11+ and is [manylinux compliant](https://peps.python.org/pep-0513/). 
+DeepSparse is tested on Python 3.8-3.10, ONNX 1.5.0-1.10.1, ONNX opset version 11+ and is [manylinux compliant](https://peps.python.org/pep-0513/). 
 
 It currently supports Intel and AMD AVX2, AVX-512, and VNNI x86 instruction sets.
 

--- a/examples/sparsestream/README.md
+++ b/examples/sparsestream/README.md
@@ -32,7 +32,7 @@ The purpose of this app is for you to familiarize yourself with the high perform
 
 ## `INSTALL`
 
-Supports Python >= 3.7
+Supports Python >= 3.8
 
 ```bash
 git clone https://github.com/neuralmagic/deepsparse.git

--- a/setup.py
+++ b/setup.py
@@ -334,12 +334,11 @@ setup(
     install_requires=_setup_install_requires(),
     extras_require=_setup_extras(),
     entry_points=_setup_entry_points(),
-    python_requires=">=3.7, <3.11",
+    python_requires=">=3.8, <3.11",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Python 3.7 reaches it's EOL in ~2 weeks, this PR deprecates it's support

https://endoflife.date/python