### PR TITLE
Update misleading comment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
-# Can be have the following values: all, server, transformers,
-#  ultralytics, base
 ARG VERSION
+# Can have the following values: all, base, dev
 ARG DEPS="all"
 ARG VENV="/venv"
 ARG BRANCH


### PR DESCRIPTION
Updates misleading comment from dockerfile, this comment should have been updated when we moved to remove autoinstalls