### PR TITLE
[BugFix] Update deepsparse dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,9 +81,6 @@ RUN \
       $VENV/bin/pip install --no-cache-dir "deepsparse[server,yolo,onnxruntime,yolov8,transformers,image_classification]==$VERSION"; \
     fi;
 
-RUN deepsparse.transformers.run_inference --help \
-    && deepsparse.image_classification.annotate --help
-
 
 FROM base AS container_branch_dev
 ARG VENV

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN \
       $VENV/bin/pip install -e  "./deepsparse[dev]"; \
     else \
       echo Installing from main  with editable mode && \
-      git clone https://github.com/neuralmagic/sparseml.git --depth 1 -b main && \
+      git clone https://github.com/neuralmagic/deepsparse.git --depth 1 -b main && \
       $VENV/bin/pip install -e "./deepsparse[dev]"; \
     fi;
 


### PR DESCRIPTION
Update dockerfile to remove autoinstall trigger (old pathway) since then the dockerfile has been updtaed to install from pypi
Update a typo where sparseml was being cloned instead of deepsparse