### PR TITLE
[Bugfix] `deepsparse.server` IC model_path

### DIFF
--- a/src/deepsparse/image_classification/pipelines.py
+++ b/src/deepsparse/image_classification/pipelines.py
@@ -16,6 +16,7 @@
 Image classification pipeline
 """
 import json
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Type, Union
 
 import numpy
@@ -134,6 +135,10 @@ class ImageClassificationPipeline(Pipeline):
 
         :return: file path to the ONNX file for the engine to compile
         """
+
+        model_path_: Path = Path(self.model_path)
+        if model_path_.is_dir():
+            return model_to_path(str(model_path_ / "model.onnx"))
 
         return model_to_path(self.model_path)
 


### PR DESCRIPTION
Fix a bug where in image_classification pipelines, a model_dir with `model.onnx` was not being accepted properly