### PR TITLE
[1.5.1] restrict pandas to <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ _transformers_integration_deps = [
     "datasets<=1.18.4",
     "scikit-learn",
     "seqeval",
+    "pandas>=0.25.0,<2.0",
 ]
 
 # haystack dependencies are installed from a requirements file to avoid

--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -39,7 +39,7 @@ try:
     from deepsparse.generated_version import is_enterprise, is_release, splash, version
 except Exception:
     # otherwise, fall back to version info in this file
-    version = "1.5.0"
+    version = "1.5.1"
     is_release = False
     is_enterprise = False
     splash = (


### PR DESCRIPTION
this fixes a bug in the latest NM 1.5 supported transformers datasets that is incompatible with pandas 2.0.  Specifically, a removed kwarg is passed to pandas on `datasets.load_dataset`.

Future releases will support later datasets versions.