### PR TITLE
Update ONNX utilities to ingest filepath or loaded model

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -131,7 +131,7 @@ def model_to_path(model: Union[str, Model, File]) -> str:
 def get_external_inputs(onnx_model: Union[str, ModelProto]) -> List:
     """
     Gather external inputs of ONNX model
-    :param onnx_filepath: File path to ONNX model or ONNX model object
+    :param onnx_model: File path to ONNX model or ONNX model object
     :return: List of input objects
     """
     model = onnx_model if isinstance(onnx_model, ModelProto) else onnx.load(onnx_model)
@@ -143,20 +143,20 @@ def get_external_inputs(onnx_model: Union[str, ModelProto]) -> List:
     return external_inputs
 
 
-def get_external_outputs(onnx_filepath: str) -> List:
+def get_external_outputs(onnx_model: Union[str, ModelProto]) -> List:
     """
     Gather external outputs of ONNX model
-    :param onnx_filepath: File path to ONNX model
+    :param onnx_model: File path to ONNX model or ONNX model object
     :return: List of output objects
     """
-    model = onnx.load(onnx_filepath)
+    model = onnx_model if isinstance(onnx_model, ModelProto) else onnx.load(onnx_model)
     return [output for output in model.graph.output]
 
 
-def get_input_names(onnx_filepath: str) -> List[str]:
+def get_input_names(onnx_filepath: Union[str, ModelProto]) -> List[str]:
     """
     Gather names of all external inputs of ONNX model
-    :param onnx_filepath: File path to ONNX model
+    :param onnx_filepath: File path to ONNX model or ONNX model object
     :return: List of string names
     """
     return [input_.name for input_ in get_external_inputs(onnx_filepath)]
@@ -165,7 +165,7 @@ def get_input_names(onnx_filepath: str) -> List[str]:
 def get_output_names(onnx_filepath: str) -> List[str]:
     """
     Gather names of all external outputs of ONNX model
-    :param onnx_filepath: File path to ONNX model
+    :param onnx_filepath: File path to ONNX model or ONNX model object
     :return: List of string names
     """
     return [output.name for output in get_external_outputs(onnx_filepath)]
@@ -177,7 +177,7 @@ def generate_random_inputs(
     """
     Generate random data that matches the type and shape of ONNX model,
     with a batch size override
-    :param onnx_filepath: File path to ONNX model
+    :param onnx_filepath: File path to ONNX model or ONNX model object
     :param batch_size: If provided, override for the batch size dimension
     :return: List of random tensors
     """

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy
 import onnx
+from onnx import ModelProto
 from onnx.mapping import TENSOR_TYPE_TO_NP_TYPE
 
 from deepsparse.utils.extractor import Extractor
@@ -127,13 +128,13 @@ def model_to_path(model: Union[str, Model, File]) -> str:
     return model
 
 
-def get_external_inputs(onnx_filepath: str) -> List:
+def get_external_inputs(onnx_model: Union[str, ModelProto]) -> List:
     """
     Gather external inputs of ONNX model
-    :param onnx_filepath: File path to ONNX model
+    :param onnx_filepath: File path to ONNX model or ONNX model object
     :return: List of input objects
     """
-    model = onnx.load(onnx_filepath)
+    model = onnx_model if isinstance(onnx_model, ModelProto) else onnx.load(onnx_model)
     all_inputs = model.graph.input
     initializer_input_names = [node.name for node in model.graph.initializer]
     external_inputs = [
@@ -171,7 +172,7 @@ def get_output_names(onnx_filepath: str) -> List[str]:
 
 
 def generate_random_inputs(
-    onnx_filepath: str, batch_size: int = None
+    onnx_filepath: Union[str, ModelProto], batch_size: int = None
 ) -> List[numpy.array]:
     """
     Generate random data that matches the type and shape of ONNX model,

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -134,7 +134,11 @@ def get_external_inputs(onnx_model: Union[str, ModelProto]) -> List:
     :param onnx_model: File path to ONNX model or ONNX model object
     :return: List of input objects
     """
-    model = onnx_model if isinstance(onnx_model, ModelProto) else onnx.load(onnx_model)
+    model = (
+        onnx_model
+        if isinstance(onnx_model, ModelProto)
+        else onnx.load(onnx_model, load_external_data=False)
+    )
     all_inputs = model.graph.input
     initializer_input_names = [node.name for node in model.graph.initializer]
     external_inputs = [
@@ -149,7 +153,11 @@ def get_external_outputs(onnx_model: Union[str, ModelProto]) -> List:
     :param onnx_model: File path to ONNX model or ONNX model object
     :return: List of output objects
     """
-    model = onnx_model if isinstance(onnx_model, ModelProto) else onnx.load(onnx_model)
+    model = (
+        onnx_model
+        if isinstance(onnx_model, ModelProto)
+        else onnx.load(onnx_model, load_external_data=False)
+    )
     return [output for output in model.graph.output]
 
 


### PR DESCRIPTION
This PR updates a number of DeepSparse utilities specific to ONNX model handling to be able to ingest a model file path (nominal behavior) or a ModelProto