### PR TITLE
update setup.py to allow "wheel" construction on mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ def _check_supported_system():
         )
 
     if sys.platform.startswith("darwin"):
-        if os.getenv("NM_ALLOW_DARWIN", "0"):
+        if os.getenv("NM_ALLOW_DARWIN", "0") != "0":
             # experimental support for mac, allow install to go through
             return
         else:

--- a/setup.py
+++ b/setup.py
@@ -180,13 +180,17 @@ def _check_supported_system():
         )
 
     if sys.platform.startswith("darwin"):
-        # mac is not supported, raise error on install
-        raise OSError(
-            "Native Mac is currently unsupported for DeepSparse. "
-            "Please run on a Linux system or within a Linux container on Mac. "
-            "More info can be found in our docs here: "
-            "https://docs.neuralmagic.com/deepsparse/source/hardware.html"
-        )
+        if os.getenv("NM_ALLOW_DARWIN", "0"):
+            # experimental support for mac, allow install to go through
+            return
+        else:
+            # mac is not supported, raise error on install
+            raise OSError(
+                "Native Mac is currently unsupported for DeepSparse. "
+                "Please run on a Linux system or within a Linux container on Mac. "
+                "More info can be found in our docs here: "
+                "https://docs.neuralmagic.com/deepsparse/source/hardware.html"
+            )
 
     # unknown system, raise error on install
     raise OSError(


### PR DESCRIPTION
SUMMARY:
allows "wheel" generation on `macOS`. reuses the ENV, `NM_ALLOW_DARWIN`.

TEST:
checks after the updating the condition.

```
❯ export NM_ALLOW_DARWIN=0
❯ python3 setup.py sdist bdist_wheel
Loaded version 1.6.0 from /Users/andy/sidelot/wand/deepsparse/src/deepsparse/generated_version.py
Traceback (most recent call last):
  File "/Users/andy/sidelot/wand/deepsparse/setup.py", line 223, in <module>
    _check_supported_system()
  File "/Users/andy/sidelot/wand/deepsparse/setup.py", line 188, in _check_supported_system
    raise OSError(
OSError: Native Mac is currently unsupported for DeepSparse. Please run on a Linux system or within a Linux container on Mac. More info can be found in our docs here: https://docs.neuralmagic.com/deepsparse/source/hardware.html
```

and enabling it 

```
❯ export NM_ALLOW_DARWIN=1
❯ python3 setup.py sdist bdist_wheel
Loaded version 1.6.0 from /Users/andy/sidelot/wand/deepsparse/src/deepsparse/generated_version.py
Checking to see if /Users/andy/sidelot/wand/deepsparse/src/deepsparse/arch.bin exists.. True
running sdist
running egg_info
...
adding 'deepsparse_nightly-1.6.0.dist-info/top_level.txt'
adding 'deepsparse_nightly-1.6.0.dist-info/RECORD'
removing build/bdist.macosx-10.9-universal2/wheel
```