### PR TITLE
include dylib in search for package contents

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include utils/artifacts.py
 include src/deepsparse/transformers/haystack/haystack_reqs.txt
 recursive-include src/deepsparse/avx2 *
 recursive-include src/deepsparse/avx512 *
+recursive-include src/deepsparse/neon *

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if is_enterprise:
     os.remove(license_nm_path)
 
 # File regexes for binaries to include in package_data
-binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin"]
+binary_regexes = ["*/*.so", "*/*.so.*", "*.bin", "*/*.bin", "*/*.dylib"]
 
 # regexes for things to include as license files in the .dist-info
 # see https://github.com/pypa/setuptools/blob/v65.6.0/docs/references/keywords.rst


### PR DESCRIPTION
SUMMARY:
This enables packaging of the "dylib" files into `mac` "wheel" file. Updates `setup.py` to include files with extension `.dylib` and adds `src/deepsparse/neon` to the manifest via `recursive-include`.

TEST:
* verified the "wheel" package is built and installable.

* looked through "wheel" package contents and verified our magic bits are present.
```
steve_jobs@wontkins deepsparse % ls neon 
total 366928
drwxr-xr-x   5 steve_jobs  staff        160 Jun 26 15:20 .
drwxr-xr-x  29 steve_jobs  staff        928 Jun 26 15:20 ..
-rwxr-xr-x   1 steve_jobs  staff    1400372 Jun 26  2023 deepsparse_engine.so
-rwxr-xr-x   1 steve_jobs  staff    1195712 Jun 26  2023 libdeepsparse.dylib
-rwxr-xr-x   1 steve_jobs  staff  185267880 Jun 26  2023 libonnxruntime.1.12.0.dylib
```

* installed on multiple `mac` machines and ran simple benchmarks, e.g. 
```
deepsparse.benchmark zoo:nlp/sentiment_analysis/obert-base/pytorch/huggingface/sst2/base-none --batch_size 64
```
