### PR TITLE
optionally add logits to model output

### DIFF
--- a/src/deepsparse/image_classification/pipelines.py
+++ b/src/deepsparse/image_classification/pipelines.py
@@ -75,6 +75,7 @@ class ImageClassificationPipeline(Pipeline):
         *,
         class_names: Union[None, str, Dict[str, str]] = None,
         top_k: int = 1,
+        return_logits: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -88,6 +89,7 @@ class ImageClassificationPipeline(Pipeline):
 
         self._image_size = self._infer_image_size()
         self.top_k = top_k
+        self.return_logits = return_logits
 
         # torchvision transforms for raw inputs
         non_rand_resize_scale = 256.0 / 224.0  # standard used
@@ -112,7 +114,7 @@ class ImageClassificationPipeline(Pipeline):
             mapping class ids to class labels
         """
         return self._class_names
-
+    
     @property
     def input_schema(self) -> Type[ImageClassificationInput]:
         """
@@ -241,7 +243,13 @@ class ImageClassificationPipeline(Pipeline):
             labels = labels[0]
             scores = scores[0]
 
-        return self.output_schema(
+        if self.return_logits:
+            return self.output_schema(
+            scores=scores,
+            labels=labels,
+            logits=engine_outputs[0])
+        else:
+            return self.output_schema(
             scores=scores,
             labels=labels,
         )

--- a/src/deepsparse/image_classification/schemas.py
+++ b/src/deepsparse/image_classification/schemas.py
@@ -15,8 +15,8 @@
 """
 Input/Output Schemas for Image Classification.
 """
-from typing import List, Union
-
+from typing import List, Union, Optional 
+import numpy
 from pydantic import BaseModel, Field
 
 from deepsparse.pipelines.computer_vision import ComputerVisionSchema
@@ -38,6 +38,10 @@ class ImageClassificationOutput(BaseModel):
     """
     Output model for image classification
     """
+    ndarray: numpy.ndarray = numpy.ndarray
+
+    class Config:
+        arbitrary_types_allowed = True
 
     labels: List[Union[int, str, List[int], List[str]]] = Field(
         description="List of labels, one for each prediction"
@@ -45,3 +49,4 @@ class ImageClassificationOutput(BaseModel):
     scores: List[Union[float, List[float]]] = Field(
         description="List of scores, one for each prediction"
     )
+    logits: Optional[ndarray] = Field(description="Raw model outputs")


### PR DESCRIPTION
```
from deepsparse import Pipeline
cv_pipeline = Pipeline.create(
  task='image_classification',
  model_path='zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none',  # Path to checkpoint or SparseZoo stub
  top_k=3,
  return_logits = True,
)
input_image = "cheetah.jpeg" # path to input image
inference = cv_pipeline(images=input_image)
inference

# ImageClassificationOutput(labels=None, scores=None, logits=array([[ 1.8277559 ,  4.486894  ,  2.4551017 ,  4.777242  ,  # 2.744733  ,.... 8.45131   ]],
 #  dtype=float32))
```