### PR TITLE
Restrict `pydantic<2.0.0` due to breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def _parse_requirements_file(file_path):
 _deps = [
     "numpy>=1.16.3",
     "onnx>=1.5.0,<1.15.0",
-    "pydantic>=1.8.2",
+    "pydantic>=1.8.2,<2.0.0",
     "requests>=2.0.0",
     "tqdm>=4.0.0",
     "protobuf>=3.12.2,<=3.20.1",
@@ -120,7 +120,6 @@ _dev_deps = [
 _server_deps = [
     "uvicorn>=0.15.0",
     "fastapi>=0.70.0,<0.87.0",
-    "pydantic>=1.8.2",
     "requests>=2.26.0",
     "python-multipart>=0.0.5",
     "prometheus-client>=0.14.1",


### PR DESCRIPTION
> Pydantic V2 is a ground-up rewrite that offers many new features, performance improvements, and some breaking changes compared to Pydantic V1.

```
deepsparse/pipeline.py:822: in <module>
    class PipelineConfig(BaseModel):
...
NameError: Field "model_path" has conflict with protected namespace "model_"
```

testing and support for latest pydantic to be added in future release