### PR TITLE
[Text Generation] Run deepsparse engine without the LIB.kv_cache object

### DIFF
--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -212,7 +212,6 @@ class BaseEngine(object):
         num_streams: int = None,
         scheduler: Scheduler = None,
         input_shapes: List[List[int]] = None,
-        cache_input_bools: Optional[List[bool]] = None,
     ):
         _analytics.send_event("python__engine__init")
         self._model_path = model_to_path(model)
@@ -223,7 +222,6 @@ class BaseEngine(object):
         self._input_shapes = input_shapes
         self._cpu_avx_type = AVX_TYPE
         self._cpu_vnni = VNNI
-        self._cache_input_bools = cache_input_bools
 
     def construct_with_context(
         self,
@@ -276,17 +274,9 @@ class Engine(BaseEngine):
         num_streams: int = None,
         scheduler: Scheduler = None,
         input_shapes: List[List[int]] = None,
-        cache_input_bools: Optional[List[bool]] = None,
     ):
         BaseEngine.construct(
-            self,
-            model,
-            batch_size,
-            num_cores,
-            num_streams,
-            scheduler,
-            input_shapes,
-            cache_input_bools,
+            self, model, batch_size, num_cores, num_streams, scheduler, input_shapes
         )
 
         if self._input_shapes:
@@ -300,7 +290,6 @@ class Engine(BaseEngine):
                     self._num_streams,
                     self._scheduler.value,
                     None,
-                    self._cache_input_bools,
                 )
         else:
             self._eng_net = LIB.deepsparse_engine(
@@ -310,7 +299,6 @@ class Engine(BaseEngine):
                 self._num_streams,
                 self._scheduler.value,
                 None,
-                self._cache_input_bools,
             )
 
     def __call__(

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -1013,7 +1013,6 @@ def create_engine(
         return Engine(onnx_file_path, **engine_args)
 
     if engine_type == ORT_ENGINE:
-        engine_args.pop("cache_input_bools", None)
         return ORTEngine(onnx_file_path, **engine_args)
 
     raise ValueError(

--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -20,7 +20,7 @@ import onnx
 from transformers import AutoTokenizer
 
 from deepsparse.engine import Context
-from deepsparse.pipeline import create_engine
+from deepsparse.pipeline import DEEPSPARSE_ENGINE, create_engine
 from deepsparse.transformers.utils.decoder_kv_cache import DecoderKVCache
 from deepsparse.transformers.utils.helpers import generate_session_id, softmax
 from sparsezoo.utils.onnx import save_onnx
@@ -75,9 +75,10 @@ class NLDecoderEngine:
         )
         kv_cache_enabled = False
         if input_indices_to_be_cached:
-            # inform the engine, that are using the kv cache
-            engine_args["cache_input_bools"] = input_indices_to_be_cached
             kv_cache_enabled = True
+            if use_deepsparse_cache and engine_type == DEEPSPARSE_ENGINE:
+                # inform the engine, that are using the kv cache
+                engine_args["cache_input_bools"] = input_indices_to_be_cached
 
         self.engine = create_engine(
             onnx_file_path=onnx_file_path,


### PR DESCRIPTION
A small adjustment that enables running the text generation pipeline with the deepsparse engine in the absence of `LIB.kv_cache` object.

Note:
- the inference confirms the correctness of the results (for the single-token engine to be precise, see notes below)
- because of the pending engine support for the operations that sit between the cache input and concat / concat and cache outputs, the data movement that happens on those branches is very time-consuming. This is why the initialization of the engines takes lot of time (up to 200s, see below)
- because the engine is unable to accept "empty" kv cache, multi-token engine defaults automatically to onnxruntime (this manifests itself through the warning: `Warning: Optimized runtime disabled - Detected dynamic input past_key_values.0.key dim 2. Set inputs to static shapes to enable optimal performance.`). This means that only single-token engine uses deepsparse runtime.

## Feature Preview
```python
from deepsparse import Pipeline
import time

start = time.time()
opt = Pipeline.create(task="opt",
                      model_path="/home/ubuntu/damian/sparseml/deployment",
                      max_generated_tokens=num_generated_tokens)
print(f"Time to create pipeline: {time.time() - start}")

output = opt(sequences="Who is the president of the United States?")
print(output)
output = opt(sequences="Who is the president of the United States?" * 20)
print(output)
```

```bash
2023-07-06 13:09:54 deepsparse.transformers.engines.nl_decoder_engine INFO     Overwriting in-place the input shapes of the transformer model at /home/ubuntu/damian/sparseml/deployment/model.onnx
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0.20230703 COMMUNITY | (3f60317c) (release) (optimized) (system=avx2, binary=avx2)
[nm_ort 7f889abf9740 >WARN<  is_supported_graph src/onnxruntime_neuralmagic/supported/ops.cc:144] Warning: Optimized runtime disabled - Detected dynamic input past_key_values.0.key dim 2. Set inputs to static shapes to enable optimal performance.
2023-07-06 13:09:58 deepsparse.transformers.engines.nl_decoder_engine INFO     Overwriting in-place the input shapes of the transformer model at /home/ubuntu/damian/sparseml/deployment/model.onnx
Time to create pipeline: 209.01430249214172
sequences=['\n\nThe president of the United States is the head of the executive branch of government. The president is the head of the executive branch of government, and the'] logits=None session_id=None
sequences=['Who is the president of the United States?Who is the president of the United States?Who is the president of the United States?Who is the president of'] logits=None session_id=None
```
