### PR TITLE
Fix Create Files Unit Test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,21 +82,21 @@ def check_for_created_files():
         "setup.cfg",
         "prometheus_logs.prom",
     ]
-    filtered_end_files_root = [
+    end_files_root = [
         f_path
         for f_path in end_files_root
         if os.path.basename(f_path) not in allowed_created_files
     ]
-    filtered_start_files_root = [
+    start_files_root = [
         f_path
         for f_path in start_files_root
         if os.path.basename(f_path) not in allowed_created_files
     ]
-    assert len(filtered_start_files_root) >= len(filtered_end_files_root), (
-        f"{len(filtered_end_files_root) - len(filtered_start_files_root)} "
+    assert len(start_files_root) >= len(end_files_root), (
+        f"{len(end_files_root) - len(start_files_root)} "
         f"files created in current working "
         f"directory during pytest run. "
-        f"Created files: {set(filtered_end_files_root) - set(filtered_start_files_root)}"
+        f"Created files: {set(end_files_root) - set(start_files_root)}"
     )
     max_allowed_sized_temp_files_megabytes = 150
     size_of_temp_files_bytes = sum(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,9 @@ def cleanup():
 
 @pytest.fixture(scope="session", autouse=True)
 def check_for_created_files():
-    start_files_root = _get_files(directory=r".")
+    start_files_root = [
+        f_path for f_path in _get_files(directory=r".") if "__pycache__" not in f_path
+    ]
     start_files_temp = _get_files(directory=tempfile.gettempdir())
     yield
     # allow creation of __pycache__ directories
@@ -85,11 +87,16 @@ def check_for_created_files():
         for f_path in end_files_root
         if os.path.basename(f_path) not in allowed_created_files
     ]
-    assert len(start_files_root) >= len(filtered_end_files_root), (
-        f"{len(filtered_end_files_root) - len(start_files_root)} "
+    filtered_start_files_root = [
+        f_path
+        for f_path in start_files_root
+        if os.path.basename(f_path) not in allowed_created_files
+    ]
+    assert len(filtered_start_files_root) >= len(filtered_end_files_root), (
+        f"{len(filtered_end_files_root) - len(filtered_start_files_root)} "
         f"files created in current working "
         f"directory during pytest run. "
-        f"Created files: {set(filtered_end_files_root) - set(start_files_root)}"
+        f"Created files: {set(filtered_end_files_root) - set(filtered_start_files_root)}"
     )
     max_allowed_sized_temp_files_megabytes = 150
     size_of_temp_files_bytes = sum(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,19 +66,18 @@ def check_for_created_files():
     start_files_root = _get_files(directory=r".")
     start_files_temp = _get_files(directory=tempfile.gettempdir())
     yield
-    end_files_root = _get_files(directory=r".")
+    # allow creation of __pycache__ directories
+    end_files_root = [f_path for f_path in _get_files(directory=r".") if "__pycache__" not in f_path]
     end_files_temp = _get_files(directory=tempfile.gettempdir())
 
-    max_allowed_number_created_files = 4
     # GHA needs to create following files:
-    # pyproject.toml, CONTRIBUTING.md, LICENSE, setup.cfg
-    assert len(start_files_root) + max_allowed_number_created_files >= len(
-        end_files_root
-    ), (
-        f"{len(end_files_root) - len(start_files_root)} "
+    allowed_created_files = ["pyproject.toml", "CONTRIBUTING.md", "LICENSE", "setup.cfg", "prometheus_logs.prom"]
+    filtered_end_files_root = [f_path for f_path in end_files_root if os.path.basename(f_path) not in allowed_created_files]
+    assert len(start_files_root) >= len(filtered_end_files_root), (
+        f"{len(filtered_end_files_root) - len(start_files_root)} "
         f"files created in current working "
         f"directory during pytest run. "
-        f"Created files: {set(end_files_root) - set(start_files_root)}"
+        f"Created files: {set(filtered_end_files_root) - set(start_files_root)}"
     )
     max_allowed_sized_temp_files_megabytes = 150
     size_of_temp_files_bytes = sum(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,12 +67,24 @@ def check_for_created_files():
     start_files_temp = _get_files(directory=tempfile.gettempdir())
     yield
     # allow creation of __pycache__ directories
-    end_files_root = [f_path for f_path in _get_files(directory=r".") if "__pycache__" not in f_path]
+    end_files_root = [
+        f_path for f_path in _get_files(directory=r".") if "__pycache__" not in f_path
+    ]
     end_files_temp = _get_files(directory=tempfile.gettempdir())
 
     # GHA needs to create following files:
-    allowed_created_files = ["pyproject.toml", "CONTRIBUTING.md", "LICENSE", "setup.cfg", "prometheus_logs.prom"]
-    filtered_end_files_root = [f_path for f_path in end_files_root if os.path.basename(f_path) not in allowed_created_files]
+    allowed_created_files = [
+        "pyproject.toml",
+        "CONTRIBUTING.md",
+        "LICENSE",
+        "setup.cfg",
+        "prometheus_logs.prom",
+    ]
+    filtered_end_files_root = [
+        f_path
+        for f_path in end_files_root
+        if os.path.basename(f_path) not in allowed_created_files
+    ]
     assert len(start_files_root) >= len(filtered_end_files_root), (
         f"{len(filtered_end_files_root) - len(start_files_root)} "
         f"files created in current working "


### PR DESCRIPTION
`check_for_created_files()` is intended to insure large extraneous files(i.e from LLMs) aren't left in the root directory when running tests. This test case was failing due to `__pycache__` files and prometheus logs. These files are small so it should be fine that they are created. To fix the test I filtered out the `__pycache__` directories and `prometheus_logs.prom` files from the added files check, in addition to the GHA files that were already accounted for.

### Testing Instructions
Run `make clean` then `make test`

### Previous Output
```
# root directory: /home/ubuntu/workspace/Github/TestDeepsparse/deepsparse/
E       AssertionError: 5 files created in current working directory during pytest run. Created files: 
{'/home/ubuntu/workspace/Github/TestDeepsparse/deepsparse/tests/deepsparse/pipelines/dynamic_import_modules/__pycache__/valid_dynamic_import.cpython-38.pyc', 
'/home/ubuntu/workspace/Github/TestDeepsparse/deepsparse/tests/deepsparse/pipelines/dynamic_import_modules/__pycache__/no_task.cpython-38.pyc', 
'/home/ubuntu/workspace/Github/TestDeepsparse/deepsparse/test_instantiate_prometheus0/prometheus_logs.prom', 
'/home/ubuntu/workspace/Github/TestDeepsparse/deepsparse/prometheus_logs.prom', 
'/home/ubuntu/workspace/Github/TestDeepsparse/deepsparse/tests/deepsparse/pipelines/dynamic_import_modules/__pycache__/no_register.cpython-38.pyc'}
```

### Updated Output
No assertion thrown