### PR TITLE
allow Tuple type in join_engine_outputs

### DIFF
--- a/src/deepsparse/utils/data.py
+++ b/src/deepsparse/utils/data.py
@@ -243,7 +243,7 @@ def join_engine_outputs(
 
     This is the opposite of `split_engine_inputs` and is meant to be used in tandem.
     """
-    assert all(isinstance(item, List) for item in batch_outputs)
+    assert all(isinstance(item, (List, Tuple)) for item in batch_outputs)
 
     candidate_output = list(map(numpy.concatenate, zip(*batch_outputs)))
 


### PR DESCRIPTION
`join_engine_outputs` currently requires the outputs of `engine_forward` to be a list to comply with `Engine` forward calls, the `TextGeneration` pipeline breaks from this by returning tuples with for the join function is functionally the same. 