### PR TITLE
[TextGeneration][Timer] text gen specific timings + improved timing tooling

### DIFF
--- a/src/deepsparse/utils/timer.py
+++ b/src/deepsparse/utils/timer.py
@@ -128,11 +128,8 @@ class StagedTimer:
         :param stage: the name of the stage to time
         """
         self.start(stage)
-
-        try:
-            yield
-        finally:
-            self.stop(stage)
+        yield
+        self.stop(stage)
 
     def start(self, stage: str):
         """
@@ -363,9 +360,6 @@ class TimerManager:
             self._timers = [timer]
 
         timer_context.set(timer)
-
-        try:
-            yield timer
-        finally:
-            if total_inference:
-                timer.stop(InferenceStages.TOTAL_INFERENCE)
+        yield timer
+        if total_inference:
+            timer.stop(InferenceStages.TOTAL_INFERENCE)

--- a/src/deepsparse/utils/timer.py
+++ b/src/deepsparse/utils/timer.py
@@ -114,6 +114,26 @@ class StagedTimer:
         """
         return stage in self.stages
 
+    @contextmanager
+    def time(self, stage: str):
+        """
+        Context Manager to record the time for a stage in the given context
+
+        example:
+        ```
+        with timer.time(STAGE_NAME):
+            # do something...
+        ```
+
+        :param stage: the name of the stage to time
+        """
+        self.start(stage)
+
+        try:
+            yield
+        finally:
+            self.stop(stage)
+
     def start(self, stage: str):
         """
         Start the timer for a specific stage. If the stage doesn't exist,
@@ -322,16 +342,22 @@ class TimerManager:
         return all_times
 
     @contextmanager
-    def new_timer_context(self) -> StagedTimer:
+    def new_timer_context(self, total_inference: bool = True) -> StagedTimer:
         """
         Create a new StagedTimer object and set it as the current context.
 
+        :param total_inference: if True, measures the entire context as total inference
+            automatically and assumes this is the main inference thread. if False,
+            assumes this is not the main inference thread and will not overwrite
+            any other timers in non-multi/benchmark mode. Default True
         :return: the new StagedTimer object.
         """
         timer = StagedTimer(enabled=self.enabled)
-        timer.start(InferenceStages.TOTAL_INFERENCE)
 
-        if self.multi:
+        if total_inference:
+            timer.start(InferenceStages.TOTAL_INFERENCE)
+
+        if self.multi or not total_inference:
             self._timers.append(timer)
         else:
             self._timers = [timer]
@@ -341,4 +367,5 @@ class TimerManager:
         try:
             yield timer
         finally:
-            timer.stop(InferenceStages.TOTAL_INFERENCE)
+            if total_inference:
+                timer.stop(InferenceStages.TOTAL_INFERENCE)


### PR DESCRIPTION
adds:
* bugfix for `TimerManager` workflow for `engine_forward` subtimings
    * since `engine_forward` is always called in a child thread for batch splitting, it will not have access to the `current` timer contextvar
    * see changes in `timer.py` `new_timer_context` for this
* adds `timer.time` helper contextmanager; see docstring for usage
* adds subtimings for prefill, generation and the individual autoregressive passes for each in the text generation pipeline
    * see example in test plan for what these timings may look like


**test_plan:**
Manually for now - once we have more text gen pipeline tests, we can add assertions that the proper stages are generated in the timer manager:

```python
# running text gen / opt pipeline
from deepsparse import Pipeline
opt = Pipeline.create(task="opt", model_path=MODEL_PATH, engine_type="onnxruntime", max_generated_tokens=128)
output = opt(sequences="Who is the president of the United States?", return_logits=True)

print(opt.timer_manger)
print(opt.timer_manager.stages)
```

Manager and stages:
```python
TimerManager({'engine_token_generation': 4.507111581042409, 'engine_prompt_prefill_single': 0.03916543936356902, 'engine_prompt_prefill': 0.3927434356883168, 'pre_process': 0.001995994709432125, 'engine_token_generation_single': 0.035451228459050334, 'engine_forward': 4.909945313818753, 'total_inference': 4.912277169525623, 'post_process': 0.00030374620109796524})
```

```python
['engine_token_generation', 'engine_prompt_prefill_single', 'engine_prompt_prefill', 'pre_process', 'engine_token_generation_single', 'engine_forward', 'total_inference', 'post_process']
```