### PR TITLE
[Text Generation] Detect dtype of kv cache (float32/uint8) for text generation models

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import logging
-import warnings
 from typing import List, Optional, Tuple, Type, Union
 
 import numpy
 from pydantic import BaseModel, Field
 
 from deepsparse import Pipeline
-from deepsparse.cpu import cpu_avx512_compatible
 from deepsparse.pipeline import DEEPSPARSE_ENGINE
 from deepsparse.transformers.engines import NLDecoderEngine
 from deepsparse.transformers.pipelines import TransformersPipeline
@@ -117,19 +115,9 @@ class TextGenerationPipeline(TransformersPipeline):
         # TODO: Set this to 64 once we modify the OPT injection logic
         prompt_processing_sequence_length: int = 128,
         force_max_tokens: bool = False,
-        use_deepsparse_cache: bool = True,
+        use_deepsparse_cache: bool = False,
         **kwargs,
     ):
-        print(cpu_avx512_compatible())
-        if not cpu_avx512_compatible() and kwargs["engine_type"] == DEEPSPARSE_ENGINE:
-            warnings.warn(
-                "Detected CPU is not AVX512 compatible. "
-                "The kv cache management will not be supported "
-                "by the optimized engine. The user may experience "
-                "non optimal performance."
-            )
-            use_deepsparse_cache = False
-
         if use_deepsparse_cache:
             if kwargs["engine_type"] != DEEPSPARSE_ENGINE:
                 raise ValueError(
@@ -138,6 +126,10 @@ class TextGenerationPipeline(TransformersPipeline):
                     f"is {kwargs['engine_type']}. "
                     f"Make sure to set `engine_type` to {DEEPSPARSE_ENGINE}"
                 )
+            raise NotImplementedError(
+                "The deepsparse kv cache is not yet "
+                "supported for text generation pipelines"
+            )
 
         super().__init__(
             **kwargs, _delay_engine_initialize=True, _delay_overwriting_inputs=True

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import logging
+import warnings
 from typing import List, Optional, Tuple, Type, Union
 
 import numpy
 from pydantic import BaseModel, Field
 
 from deepsparse import Pipeline
+from deepsparse.cpu import cpu_avx512_compatible
 from deepsparse.pipeline import DEEPSPARSE_ENGINE
 from deepsparse.transformers.engines import NLDecoderEngine
 from deepsparse.transformers.pipelines import TransformersPipeline
@@ -115,9 +117,19 @@ class TextGenerationPipeline(TransformersPipeline):
         # TODO: Set this to 64 once we modify the OPT injection logic
         prompt_processing_sequence_length: int = 128,
         force_max_tokens: bool = False,
-        use_deepsparse_cache: bool = False,
+        use_deepsparse_cache: bool = True,
         **kwargs,
     ):
+        print(cpu_avx512_compatible())
+        if not cpu_avx512_compatible() and kwargs["engine_type"] == DEEPSPARSE_ENGINE:
+            warnings.warn(
+                "Detected CPU is not AVX512 compatible. "
+                "The kv cache management will not be supported "
+                "by the optimized engine. The user may experience "
+                "non optimal performance."
+            )
+            use_deepsparse_cache = False
+
         if use_deepsparse_cache:
             if kwargs["engine_type"] != DEEPSPARSE_ENGINE:
                 raise ValueError(
@@ -126,10 +138,6 @@ class TextGenerationPipeline(TransformersPipeline):
                     f"is {kwargs['engine_type']}. "
                     f"Make sure to set `engine_type` to {DEEPSPARSE_ENGINE}"
                 )
-            raise NotImplementedError(
-                "The deepsparse kv cache is not yet "
-                "supported for text generation pipelines"
-            )
 
         super().__init__(
             **kwargs, _delay_engine_initialize=True, _delay_overwriting_inputs=True


### PR DESCRIPTION
The `NLDecoderEngine` can now infer the dtype of the kv cache input from the onnx graph. This is necessary in order to enforce the adequate dtype when creating an initial kv cache arrays.

The PR is complementary to https://github.com/neuralmagic/sparseml/pull/1648. Refer to that PR for manual tests description.