### PR TITLE
[Fix] Bring back `join_engine_outputs` to be a `pipeline` method

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -249,7 +249,7 @@ class Pipeline(BasePipeline):
             batch_outputs = list(self.executor.map(self.engine_forward, batches))
 
             # join together the batches of size `self._batch_size`
-            engine_outputs = join_engine_outputs(batch_outputs, orig_batch_size)
+            engine_outputs = self.join_engine_outputs(batch_outputs, orig_batch_size)
             timer.stop(InferenceStages.ENGINE_FORWARD)
 
             self.log(
@@ -457,6 +457,19 @@ class Pipeline(BasePipeline):
             alias=self.alias,
             kwargs=kwargs,
         )
+
+    def join_engine_outputs(
+        self, batch_outputs: List[List[numpy.ndarray]], orig_batch_size: int
+    ) -> List[numpy.ndarray]:
+        """
+        Joins list of engine outputs together into one list.
+        This is the opposite of `split_engine_inputs` and is meant to be used in tandem.
+
+        :param batch_outputs: list of engine outputs
+        :param orig_batch_size: original batch size of the inputs
+        :return: list of engine outputs joined together
+        """
+        return join_engine_outputs(batch_outputs, orig_batch_size)
 
     def engine_forward(self, engine_inputs: List[numpy.ndarray]) -> List[numpy.ndarray]:
         """

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -241,7 +241,7 @@ class Pipeline(BasePipeline):
             # ------ INFERENCE ------
             # split inputs into batches of size `self._batch_size`
             timer.start(InferenceStages.ENGINE_FORWARD)
-            batches, orig_batch_size = split_engine_inputs(
+            batches, orig_batch_size = self.split_engine_inputs(
                 engine_inputs, self._batch_size
             )
 
@@ -470,6 +470,20 @@ class Pipeline(BasePipeline):
         :return: list of engine outputs joined together
         """
         return join_engine_outputs(batch_outputs, orig_batch_size)
+
+    def split_engine_inputs(
+        self, items: List[numpy.ndarray], batch_size: int
+    ) -> List[List[numpy.ndarray]]:
+        """
+        Splits each item into numpy arrays with the first dimension == `batch_size`.
+        This is the opposite of `join_engine_outputs` and is meant to be used in tandem.
+
+        :param items: size of each batch to split into
+        :param batch_size: size of each batch to enforce
+
+        :return: list of batches, where each batch is a list of numpy arrays
+        """
+        return split_engine_inputs(items, batch_size)
 
     def engine_forward(self, engine_inputs: List[numpy.ndarray]) -> List[numpy.ndarray]:
         """

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -440,7 +440,7 @@ class TextGenerationPipeline(TransformersPipeline):
 
     @staticmethod
     def join_engine_outputs(
-        batch_outputs: List[List[numpy.ndarray]],
+        batch_outputs: List[List[numpy.ndarray]], orig_batch_size: int
     ) -> List[numpy.ndarray]:
         """
         Takes a list of outputs (batches) from the engine
@@ -449,6 +449,7 @@ class TextGenerationPipeline(TransformersPipeline):
         they can be concatenated.
 
         :param batch_outputs: A list of outputs from the engine
+        :param orig_batch_size: The original batch size
         :return: A list of joined outputs
         """
         tokens, logits = zip(*batch_outputs)

--- a/src/deepsparse/utils/data.py
+++ b/src/deepsparse/utils/data.py
@@ -242,6 +242,10 @@ def join_engine_outputs(
     the remainder as padding.
 
     This is the opposite of `split_engine_inputs` and is meant to be used in tandem.
+
+    :param batch_outputs: List of engine outputs
+    :param orig_batch_size: The original batch size of the inputs
+    :return: List of engine outputs joined together
     """
     assert all(isinstance(item, (List, Tuple)) for item in batch_outputs)
 

--- a/src/deepsparse/utils/data.py
+++ b/src/deepsparse/utils/data.py
@@ -168,7 +168,7 @@ def numpy_softmax(x: numpy.ndarray, axis: int = 0):
 
 def split_engine_inputs(
     items: List[numpy.ndarray], batch_size: int
-) -> Tuple[List[List[numpy.ndarray]], int]:
+) -> List[List[numpy.ndarray]]:
     """
     Splits each item into numpy arrays with the first dimension == `batch_size`.
 
@@ -200,6 +200,11 @@ def split_engine_inputs(
 
     In the case where the total input batch size isn't divisble by `batch_size`, it
     will pad the last mini batch. Look at `padding_is_needed`
+
+    :param items: list of numpy arrays to split
+    :param batch_size: size of each batch to split into
+
+    :return: list of batches, where each batch is a list of numpy arrays
     """
     # The engine expects to recieve data in numpy format, so at this point it should be
     assert all(isinstance(item, numpy.ndarray) for item in items)


### PR DESCRIPTION
This PR: https://github.com/neuralmagic/deepsparse/pull/1100 has moved `joint_engine_outputs` from the method of a `pipeline` to a separate helper function. This has broken the text generation pipeline, as it implements its own `self.joint_engine_outputs`. This PR fixes this issue, without implicitly falling back to the previous design. 