### PR TITLE
[Text Generation][Fix] Update the logic from sampling from a distribution when `deterministic=False`

### DIFF
--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -22,7 +22,8 @@ from transformers import AutoTokenizer
 from deepsparse.engine import Context
 from deepsparse.pipeline import DEEPSPARSE_ENGINE, create_engine
 from deepsparse.transformers.utils.decoder_kv_cache import DecoderKVCache
-from deepsparse.transformers.utils.helpers import generate_session_id, softmax
+from deepsparse.transformers.utils.helpers import generate_session_id
+from deepsparse.utils.data import numpy_softmax
 from deepsparse.utils.onnx import translate_onnx_type_to_numpy
 from sparsezoo.utils.onnx import save_onnx
 
@@ -249,7 +250,7 @@ class NLDecoderEngine:
 
         logits /= self.sampling_temperature
 
-        probs = softmax(logits)
+        probs = numpy_softmax(logits)
 
         return numpy.random.choice(len(probs), p=probs)
 

--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -155,7 +155,7 @@ class NLDecoderEngine:
         else:
             logits = out[0]
 
-        token = self.generate_token(logits=logits[:, -1, :])
+        token = self.generate_token(logits=logits[:, -1, :][0])
 
         return token, logits
 

--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -156,6 +156,7 @@ class NLDecoderEngine:
         else:
             logits = out[0]
 
+        # select batch idx 0, batch is always 1
         token = self.generate_token(logits=logits[0, -1, :])
 
         return token, logits

--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -155,7 +155,7 @@ class NLDecoderEngine:
         else:
             logits = out[0]
 
-        token = self.generate_token(logits=logits[:, -1, :][0])
+        token = self.generate_token(logits=logits[0, -1, :])
 
         return token, logits
 

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -17,23 +17,7 @@ import uuid
 import numpy
 
 
-__all__ = ["softmax", "generate_session_id", "pad_to_fixed_length"]
-
-
-def softmax(x: numpy.ndarray) -> numpy.ndarray:
-    """
-    Compute softmax values for x. This function is
-    against overflow/underflow by using the
-    trick of shifting the input vector by subtracting
-    the maximum element in it from all elements
-
-    :param x: input array
-    :return: softmax values
-    """
-    z = x - max(x)
-    numerator = numpy.exp(z)
-    denominator = numpy.sum(numerator)
-    return numerator / denominator
+__all__ = ["generate_session_id", "pad_to_fixed_length"]
 
 
 def generate_session_id() -> str:


### PR DESCRIPTION
The function `self.generate_token` expects to receive a single logits array of size `(vocab_size,)` and not `(batch_size, vocab_size)`.