### PR TITLE
Update transformers/__init__.py warning

### DIFF
--- a/src/deepsparse/transformers/__init__.py
+++ b/src/deepsparse/transformers/__init__.py
@@ -44,7 +44,7 @@ def _check_transformers_install():
     if not getattr(_transformers, "NM_INTEGRATED", False):
         _LOGGER.warning(
             "The neuralmagic fork of transformers may not be installed. It can be "
-            f"installed via `pip install {nm_transformers}`"
+            f"installed via `pip install nm_transformers`"
         )
 
 

--- a/src/deepsparse/transformers/__init__.py
+++ b/src/deepsparse/transformers/__init__.py
@@ -44,7 +44,7 @@ def _check_transformers_install():
     if not getattr(_transformers, "NM_INTEGRATED", False):
         _LOGGER.warning(
             "The neuralmagic fork of transformers may not be installed. It can be "
-            f"installed via `pip install nm_transformers`"
+            "installed via `pip install nm_transformers`"
         )
 
 


### PR DESCRIPTION
Needed to actually use the string `nm_transformers` rather than some variable

This was causing an error when hitting the warning:
```
File "deepsparse/transformers/__init__.py", line 47, in _check_transformers_install
    f"installed via `pip install {nm_transformers}`"
NameError: name 'nm_transformers' is not defined. Did you mean: '_transformers'?
```