### PR TITLE
[bug] Add out of the box support for deployment_directories

### DIFF
--- a/src/deepsparse/image_classification/pipelines.py
+++ b/src/deepsparse/image_classification/pipelines.py
@@ -16,7 +16,6 @@
 Image classification pipeline
 """
 import json
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Type, Union
 
 import numpy
@@ -135,11 +134,6 @@ class ImageClassificationPipeline(Pipeline):
 
         :return: file path to the ONNX file for the engine to compile
         """
-
-        model_path_: Path = Path(self.model_path)
-        if model_path_.is_dir():
-            return model_to_path(str(model_path_ / "model.onnx"))
-
         return model_to_path(self.model_path)
 
     def process_inputs(self, inputs: ImageClassificationInput) -> List[numpy.ndarray]:

--- a/src/deepsparse/open_pif_paf/pipelines.py
+++ b/src/deepsparse/open_pif_paf/pipelines.py
@@ -28,6 +28,7 @@ from deepsparse.open_pif_paf.schemas import (
     OpenPifPafOutput,
 )
 from deepsparse.pipeline import Pipeline
+from deepsparse.utils import model_to_path
 from deepsparse.yolact.utils import preprocess_array
 from openpifpaf import decoder, network
 
@@ -100,7 +101,7 @@ class OpenPifPafPipeline(Pipeline):
 
         :return: file path to the ONNX file for the engine to compile
         """
-        return self.model_path
+        return model_to_path(self.model_path)
 
     def process_inputs(self, inputs: OpenPifPafInput) -> List[numpy.ndarray]:
 

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -16,6 +16,7 @@ import contextlib
 import logging
 import os
 import tempfile
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Optional, Tuple, Union
 
@@ -96,9 +97,10 @@ def translate_onnx_type_to_numpy(tensor_type: int):
 def model_to_path(model: Union[str, Model, File]) -> str:
     """
     Deals with the various forms a model can take. Either an ONNX file,
-    a SparseZoo model stub prefixed by 'zoo:', a SparseZoo Model object,
-    or a SparseZoo ONNX File object that defines the neural network. Noting
-    the model will be downloaded automatically if a SparseZoo stub is passed
+    a directory containing model.onnx, a SparseZoo model stub prefixed by
+    'zoo:', a SparseZoo Model object, or a SparseZoo ONNX File object that
+    defines the neural network. Noting the model will be downloaded automatically
+    if a SparseZoo stub is passed
 
     :param model: Either a local str path or SparseZoo stub to the model. Can
         also be a sparsezoo.Model or sparsezoo.File object
@@ -125,6 +127,10 @@ def model_to_path(model: Union[str, Model, File]) -> str:
 
     if not os.path.exists(model):
         raise ValueError("model path must exist: given {}".format(model))
+
+    model_path = Path(model)
+    if model_path.is_dir():
+        return str(model_path / "model.onnx")
 
     return model
 


### PR DESCRIPTION
Some of our pipelines did not support using directories(with `model.onnx`) out of the box for deployment with server; Noting this used to work with certain tasks as a few pipelines did implement the logic to process  deployment directories.

Current PR propagates this support to all Pipelines; essentially it updates `model_to_path` function (used by all pipelines) to accept model directories as valid inputs; The test was performed using yolov5 model (as OD pipelines did not support model_directories initially)

Test:

model: 
```bash
$ sparsezoo.download "zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/pruned30-none-vnni" --save-dir ~/test-model
INFO:root:Downloading files from model 'zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/pruned30-none-vnni'
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.70M/3.70M [00:00<00:00, 7.56MB/s]
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.24M/7.24M [00:00<00:00, 10.8MB/s]
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 19.0M/19.0M [00:01<00:00, 11.2MB/s]
downloading...: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 292M/292M [00:27<00:00, 11.2MB/s]
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 926/926 [00:00<00:00, 58.0kB/s]
downloading...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.09k/1.09k [00:00<00:00, 407kB/s]
downloading...: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.72k/1.72k [00:00<00:00, 648kB/s]
downloading...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7.24M/7.24M [00:00<00:00, 11.0MB/s]
Download results
====================

Model(stub=zoo:cv/detection/yolov5-n/pytorch/ultralytics/coco/pruned30-none-vnni) downloaded to /home/rahul/test-model
```


deepsparse.server:

```bash
$ deepsparse.server --task yolo --model_path ~/test-model/deployment
2023-07-20 11:21:28 deepsparse.server.server INFO     config_path: /tmp/tmpnn7b8zkv/server-config.yaml
2023-07-20 11:21:28 deepsparse.server.server INFO     Using config: ServerConfig(num_cores=None, num_workers=None, integration='local', engine_thread_pinning='core', pytorch_num_threads=1, endpoints=[EndpointConfig(name='yolo', route='/predict', task='yolo', model='/home/rahul/test-model/deployment', batch_size=1, logging_config=PipelineSystemLoggingConfig(enable=True, inference_details=SystemLoggingGroup(enable=False, target_loggers=[]), prediction_latency=SystemLoggingGroup(enable=True, target_loggers=[])), data_logging=None, bucketing=None, kwargs={})], loggers={}, system_logging=ServerSystemLoggingConfig(enable=True, request_details=SystemLoggingGroup(enable=False, target_loggers=[]), resource_utilization=SystemLoggingGroup(enable=False, target_loggers=[])))
2023-07-20 11:21:28 deepsparse.server.server INFO     torch.set_num_threads(1)
2023-07-20 11:21:28 deepsparse.server.server INFO     NM_BIND_THREADS_TO_CORES=1
2023-07-20 11:21:28 deepsparse.server.server INFO     NM_BIND_THREADS_TO_SOCKETS=0
2023-07-20 11:21:28 deepsparse.server.server INFO     Built context: Context(num_cores=10, num_streams=1, scheduler=Scheduler.elastic)
2023-07-20 11:21:28 deepsparse.server.server INFO     Built ThreadPoolExecutor with 1 workers
2023-07-20 11:21:28 deepsparse.loggers.build_logger INFO     Created default logger: PythonLogger
2023-07-20 11:21:28 deepsparse.loggers.build_logger INFO     System Logging: enabled for groups: ['yolo/prediction_latency']
2023-07-20 11:21:29 deepsparse.server.server INFO     Initializing pipeline for 'yolo'
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0.20230607 COMMUNITY | (7a67b14b) (release) (optimized) (system=avx512, binary=avx512)
2023-07-20 11:21:30 deepsparse.server.server INFO     Adding endpoints for 'yolo'
2023-07-20 11:21:30 deepsparse.server.server INFO     Added '/predict' endpoint
2023-07-20 11:21:30 deepsparse.server.server INFO     Added '/predict/from_files' endpoint
2023-07-20 11:21:30 deepsparse.server.server INFO     Added endpoints: ['/openapi.json', '/docs', '/docs/oauth2-redirect', '/redoc', '/', '/config', '/status', '/healthcheck', '/health', '/ping', '/endpoints', '/endpoints', '/predict', '/predict/from_files']
INFO:     Started server process [94072]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:5543 (Press CTRL+C to quit)
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [94072]
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205093179981239