### PR TITLE
Fix text_generation pipeline failure without engine_type specified

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -120,7 +120,8 @@ class TextGenerationPipeline(TransformersPipeline):
         use_deepsparse_cache: bool = True,
         **kwargs,
     ):
-        if not cpu_avx512_compatible() and kwargs["engine_type"] == DEEPSPARSE_ENGINE:
+        kwargs_engine_type = kwargs.get("engine_type", DEEPSPARSE_ENGINE)
+        if not cpu_avx512_compatible() and kwargs_engine_type == DEEPSPARSE_ENGINE:
             warnings.warn(
                 "AVX512 support not detected, disabling internal management "
                 "of KV cache which may affect performance. To enable full "
@@ -129,11 +130,11 @@ class TextGenerationPipeline(TransformersPipeline):
             use_deepsparse_cache = False
 
         if use_deepsparse_cache:
-            if kwargs["engine_type"] != DEEPSPARSE_ENGINE:
+            if kwargs_engine_type != DEEPSPARSE_ENGINE:
                 raise ValueError(
                     "`use_deepsparse_cache` is set to True "
                     "but the chosen `engine_type` "
-                    f"is {kwargs['engine_type']}. "
+                    f"is {kwargs_engine_type}. "
                     f"Make sure to set `engine_type` to {DEEPSPARSE_ENGINE}"
                 )
 

--- a/src/deepsparse/yolov8/pipelines.py
+++ b/src/deepsparse/yolov8/pipelines.py
@@ -17,14 +17,14 @@ import warnings
 from typing import Callable, List, Type, Union
 
 import numpy
-import torch
-from ultralytics.yolo.utils.ops import non_max_suppression as non_max_supression_torch
-from ultralytics.yolo.utils.ops import process_mask_upsample
 
+import torch
 from deepsparse import Pipeline
 from deepsparse.yolo import YOLOOutput as YOLODetOutput
 from deepsparse.yolo import YOLOPipeline
 from deepsparse.yolov8.schemas import YOLOSegOutput
+from ultralytics.yolo.utils.ops import non_max_suppression as non_max_supression_torch
+from ultralytics.yolo.utils.ops import process_mask_upsample
 
 
 LOGGER = logging.getLogger(__name__)
@@ -86,9 +86,7 @@ class YOLOv8Pipeline(YOLOPipeline):
                 warnings.warn(
                     "YOLOv8 Segmentation pipeline expects 2 outputs from engine, "
                     "got {}. Assuming first output is detection output, and last "
-                    "is segmentation output".format(
-                        len(engine_outputs)
-                    )
+                    "is segmentation output".format(len(engine_outputs))
                 )
                 engine_outputs = [engine_outputs[0], engine_outputs[5]]
             return self.process_engine_outputs_seg(


### PR DESCRIPTION
```python
from deepsparse import Pipeline

pipe = Pipeline.create(
    task="codegen",
    model_path="zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/pruned50_quant-none",
)
```

```
deepsparse/transformers/pipelines/text_generation.py", line 132, in __init__
    if kwargs["engine_type"] != DEEPSPARSE_ENGINE:
KeyError: 'engine_type'
```