### PR TITLE
[Fix] Do not fetch cache dtype if the model does not have kv cache support

### DIFF
--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -229,11 +229,13 @@ class NLDecoderEngine:
         output_indices_to_be_cached = [
             1 if inp.name.startswith("present") else 0 for inp in model.graph.output
         ]
-
-        kv_cache_elem_type = next(
-            inp for inp in model.graph.input if inp.name.startswith(_CACHE_INPUT_NAME)
-        ).type.tensor_type.elem_type
-        self.kv_cache_data_type = translate_onnx_type_to_numpy(kv_cache_elem_type)
+        if sum(output_indices_to_be_cached):
+            kv_cache_elem_type = next(
+                inp
+                for inp in model.graph.input
+                if inp.name.startswith(_CACHE_INPUT_NAME)
+            ).type.tensor_type.elem_type
+            self.kv_cache_data_type = translate_onnx_type_to_numpy(kv_cache_elem_type)
 
         return onnx_file_path, output_indices_to_be_cached
 


### PR DESCRIPTION
...otherwise, we get a very unclear error message:

```
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
2023-07-20 14:42:36 deepsparse.transformers.pipelines.text_generation WARNING  The support for deepsparse engine is limited for TextGenerationPipeline. The multi-token engine will not be used for prompt processing.
2023-07-20 14:42:36 deepsparse.transformers.engines.nl_decoder_engine INFO     Overwriting in-place the input shapes of the transformer model at /home/sage/harddisk/models/opt67/model.onnx
Traceback (most recent call last):
  File "/home/sage/script.py", line 5, in <module>
    opt = Pipeline.create(
  File "/home/sage/git/wand/deepsparse/src/deepsparse/base_pipeline.py", line 207, in create
    return pipeline_constructor(**kwargs)
  File "/home/sage/git/wand/deepsparse/src/deepsparse/transformers/pipelines/text_generation.py", line 165, in __init__
    self.multitoken_engine = NLDecoderEngine(
  File "/home/sage/git/wand/deepsparse/src/deepsparse/transformers/engines/nl_decoder_engine.py", line 73, in __init__
    onnx_file_path, output_indices_to_be_cached = self.overwrite_onnx_model_inputs(
  File "/home/sage/git/wand/deepsparse/src/deepsparse/transformers/engines/nl_decoder_engine.py", line 233, in overwrite_onnx_model_inputs
    kv_cache_elem_type = next(
StopIteration
```