### PR TITLE
[Bug] Add text_generation as a valid pipeline task

### DIFF
--- a/src/deepsparse/tasks.py
+++ b/src/deepsparse/tasks.py
@@ -95,7 +95,10 @@ class SupportedTasks:
         ),
     )
 
-    text_generation = namedtuple("text_generation", ["opt", "codegen", "bloom"])(
+    text_generation = namedtuple(
+        "text_generation", ["text_generation", "opt", "codegen", "bloom"]
+    )(
+        text_generation=AliasedTask("text_generation", []),
         codegen=AliasedTask("codegen", []),
         opt=AliasedTask("opt", []),
         bloom=AliasedTask("bloom", []),


### PR DESCRIPTION
`text_generation` was missed as a valid task name for deepsparse `Pipeline`, this PR adds that

Test code:
```python
from deepsparse import Pipeline

pipe = Pipeline.create(
    task="text_generation",
    model_path="zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none",
    max_generated_tokens=128,
    prompt_processing_sequence_length=1,
    engine_type="deepsparse",
    use_deepsparse_cache=False,
)
inference = pipe(sequences="def fib():")
print(inference)
)

```

Before: (ERROR)
```bash
    raise ValueError(
ValueError: Unknown Pipeline task text_generation. Currently supported tasks are ['zero_shot_text_classification', 'glue', 'embedding_extraction', 'yolact', 'sentiment_analysis', 'yolov8', 'open_pif_paf', 'yolo', 'ner', 'question_answering', 'token_classification', 'information_retrieval_haystack', 'haystack', 'image_classification', 'transformers_embedding_extraction', 'qa', 'text_classification', 'custom']

``` 

Now: (Creation is successful)
```bash
/home/rahul/venvs/deepsparse3.8/bin/python3.8 /home/rahul/projects/deepsparse/local1.py 
2023-07-21 12:20:46 deepsparse.transformers.pipelines.text_generation WARNING  The support for deepsparse engine is limited for TextGenerationPipeline. The multi-token engine will not be used for prompt processing.
Using pad_token, but it is not set yet.
2023-07-21 12:20:48 deepsparse.transformers.engines.nl_decoder_engine INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/model.onnx
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0.20230607 COMMUNITY | (7a67b14b) (release) (optimized) (system=avx512, binary=avx512)
2023-07-21 12:21:02 deepsparse.transformers.engines.nl_decoder_engine INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/model.onnx
sequences=['\n    a, b = 0, 1\n    while True:\n        yield a\n        a, b = b, a + b\n\ndef fib2(n):\n    a, b = 0, 1\n    while a < n:\n        yield a\n        a, b = b, a + b\n\ndef primes():\n    yield 2\n    it = fib()\n    while True:\n        try:\n            yield next(it)\n        except StopIteration:\n            return\n\ndef primes_up_to(n):\n    '] logits=None session_id=None

Process finished with exit code 0

```