### PR TITLE
[YOLOV8] Update version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ _openpifpaf_integration_deps = [
     "pycocotools >=2.0.6",
     "scipy==1.10.1",
 ]
-_yolov8_integration_deps = _yolo_integration_deps + ["ultralytics==8.0.30"]
+_yolov8_integration_deps = _yolo_integration_deps + ["ultralytics==8.0.124"]
 _transformers_integration_deps = [
     f"{'nm-transformers' if is_release else 'nm-transformers-nightly'}"
     f"~={version_base}",

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ _image_classification_deps = [
     "opencv-python<=4.6.0.66",
 ]
 _yolo_integration_deps = [
-    "torchvision>=0.3.0,<0.14",
+    "torchvision>=0.3.0,<=0.15.1",
     "opencv-python<=4.6.0.66",
 ]
 _openpifpaf_integration_deps = [

--- a/src/deepsparse/yolov8/pipelines.py
+++ b/src/deepsparse/yolov8/pipelines.py
@@ -108,12 +108,14 @@ class YOLOv8Pipeline(YOLOPipeline):
             )
 
     def process_engine_outputs_seg(
-        self, engine_outputs: List[numpy.ndarray], **kwargs
+        self, engine_outputs: List[numpy.ndarray], nc: int = 80, **kwargs
     ) -> YOLOSegOutput:
         """
         The pathway for processing the outputs of the engine for YOLOv8 segmentation.
         :param engine_outputs: list of numpy arrays that are the output of the engine
             forward pass
+        : params nc: number of classes. If not provided, calculated as
+            detection.shape[1] - 4
         :return: outputs of engine post-processed into an object in the `output_schema`
             format of this pipeline
         """
@@ -123,6 +125,7 @@ class YOLOv8Pipeline(YOLOPipeline):
         # NMS
         detections_output = self.nms_function(
             outputs=detections,
+            nc=nc,
             iou_thres=kwargs.get("iou_thres", 0.25),
             conf_thres=kwargs.get("conf_thres", 0.45),
             multi_label=kwargs.get("multi_label", False),

--- a/src/deepsparse/yolov8/pipelines.py
+++ b/src/deepsparse/yolov8/pipelines.py
@@ -108,20 +108,12 @@ class YOLOv8Pipeline(YOLOPipeline):
             )
 
     def process_engine_outputs_seg(
-        self, engine_outputs: List[numpy.ndarray], nm: int = 32, **kwargs
+        self, engine_outputs: List[numpy.ndarray], **kwargs
     ) -> YOLOSegOutput:
         """
         The pathway for processing the outputs of the engine for YOLOv8 segmentation.
         :param engine_outputs: list of numpy arrays that are the output of the engine
             forward pass
-        :param nm: number of mask protos. It is information needed to perform NMS on the
-            segmentation output. It can be calculated in the following way:
-                dims = bboxes + classes + nm
-                where:
-                - bboxes = 4
-                - classes = 80 (explicit assumption -> we are using COCO dataset)
-                - dims = 116 (comes from the fact that
-                    detection.shape == [B, dims, 8400])
         :return: outputs of engine post-processed into an object in the `output_schema`
             format of this pipeline
         """
@@ -133,7 +125,6 @@ class YOLOv8Pipeline(YOLOPipeline):
             outputs=detections,
             iou_thres=kwargs.get("iou_thres", 0.25),
             conf_thres=kwargs.get("conf_thres", 0.45),
-            nm=nm,
             multi_label=kwargs.get("multi_label", False),
         )
 

--- a/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
+++ b/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
@@ -9,11 +9,7 @@ from tqdm import tqdm
 
 from deepsparse.yolov8.utils.validation.helpers import schema_to_tensor
 from ultralytics.yolo.data.utils import check_det_dataset
-from ultralytics.yolo.utils import (
-    LOGGER,
-    TQDM_BAR_FORMAT,
-    callbacks,
-)
+from ultralytics.yolo.utils import LOGGER, TQDM_BAR_FORMAT, callbacks
 from ultralytics.yolo.utils.ops import Profile
 from ultralytics.yolo.utils.torch_utils import select_device, smart_inference_mode
 

--- a/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
+++ b/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
@@ -7,6 +7,7 @@ from typing import Dict
 
 from tqdm import tqdm
 
+import torch
 from deepsparse.yolov8.utils.validation.helpers import schema_to_tensor
 from ultralytics.yolo.data.utils import check_det_dataset
 from ultralytics.yolo.utils import LOGGER, TQDM_BAR_FORMAT, callbacks
@@ -34,6 +35,8 @@ class DeepSparseValidator:
         # for validation when self.training is True
         callbacks.add_integration_callbacks(self)
         self.run_callbacks("on_val_start")
+        if not torch.cuda.is_available():
+            self.args.device = "cpu"
         self.device = select_device(self.args.device, self.args.batch)
         self.data = check_det_dataset(self.args.data)
         if isinstance(self.data["path"], str):

--- a/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
+++ b/src/deepsparse/yolov8/utils/validation/deepsparse_validator.py
@@ -10,9 +10,7 @@ from tqdm import tqdm
 from deepsparse.yolov8.utils.validation.helpers import schema_to_tensor
 from ultralytics.yolo.data.utils import check_det_dataset
 from ultralytics.yolo.utils import (
-    DEFAULT_CFG,
     LOGGER,
-    SETTINGS,
     TQDM_BAR_FORMAT,
     callbacks,
 )
@@ -38,10 +36,9 @@ class DeepSparseValidator:
         """
         # deepsparse edit: removed the if-statement responsible
         # for validation when self.training is True
-        callbacks.add_integration_callbacks(self)  # TODO: Missing inputs?
+        callbacks.add_integration_callbacks(self)
         self.run_callbacks("on_val_start")
-        self.device = select_device(self.args.device, self.args.batch)  # TODO: Fix
-        # self.args.half &= self.device.type != "cpu" # TODO: not commented out here?
+        self.device = select_device(self.args.device, self.args.batch)
         self.data = check_det_dataset(self.args.data)
         if isinstance(self.data["path"], str):
             self.data["path"] = Path(self.data["path"])

--- a/src/deepsparse/yolov8/utils/validation/detection_validator.py
+++ b/src/deepsparse/yolov8/utils/validation/detection_validator.py
@@ -23,10 +23,9 @@ class DeepSparseDetectionValidator(DeepSparseValidator, DetectionValidator):
         dataloader=None,
         save_dir=None,
         pbar=None,
-        logger=None,
         args=None,
     ):
-        DetectionValidator.__init__(self, dataloader, save_dir, pbar, logger, args)
+        DetectionValidator.__init__(self, dataloader, save_dir, pbar, args)
         DeepSparseValidator.__init__(self, pipeline)
 
     # deepsparse edit: replaced argument `model` with `classes`

--- a/src/deepsparse/yolov8/utils/validation/segmentation_validator.py
+++ b/src/deepsparse/yolov8/utils/validation/segmentation_validator.py
@@ -27,7 +27,7 @@ class DeepSparseSegmentationValidator(DeepSparseValidator, SegmentationValidator
         logger=None,
         args=None,
     ):
-        SegmentationValidator.__init__(self, dataloader, save_dir, pbar, logger, args)
+        SegmentationValidator.__init__(self, dataloader, save_dir, pbar, args)
         DeepSparseValidator.__init__(self, pipeline)
 
     # deepsparse edit: replaced argument `model` with `classes`

--- a/src/deepsparse/yolov8/validation.py
+++ b/src/deepsparse/yolov8/validation.py
@@ -84,7 +84,7 @@ SUPPORTED_DATASET_CONFIGS = ["coco128.yaml", "coco.yaml", "coco128-seg.yaml"]
 @click.option(
     "--subtask",
     default="detection",
-    type=click.Choice(["detection", "classification", "segmentation"]),
+    type=click.Choice(["detection", "segmentation"]),
     show_default=True,
     help="A subtask of YOLOv8 to run. Default is `detection`.",
 )


### PR DESCRIPTION
### Summary
- Updated deepsparse support for yolov8
- Small similar changes to the ones made for sparseml's yolov8 update
- `process_engine_outputs` has a slight change. Previously providing `nm` for number of masks, which is no longer used by the yolov8 `non_max_suppression` function.

### Testing:

- Tested locally using both sparsezoo and yolov8 models for both segmentation and detection
- Workflows tested: pipeline creation and forward pass, annotation, eval and benchmarking 
 
### sparsezoo models tested:

1. detection: `"zoo:cv/detection/yolov8-m/pytorch/ultralytics/coco/base_quant-none"`
2. segmentation: `"zoo:cv/segmentation/yolov8-n/pytorch/ultralytics/coco/base-none"`

### yolov8 models tested:

1. detection: `yolov8n.pt`
2. segmentation: `yolov8n-seg.pt`

### Pipeline creation + forward pass:

Detection
```
from deepsparse import Pipeline
model_path = "yolov8n.onnx" 
images = ["basilica.jpg"]
yolo_pipeline = Pipeline.create(
    task="yolov8",
    model_path=model_path,
)
pipeline_outputs = yolo_pipeline(images=images)
```

Segmentation:

```
from deepsparse import Pipeline
model_path = "yolov8n-seg.onnx" 
images = ["basilica.jpg"]
yolo_pipeline = Pipeline.create(
    task="yolov8",
    subtask="segmentation",
    model_path=model_path,
)

pipeline_outputs = yolo_pipeline(images=images)
```
### Annotation:

Detection:
`deepsparse.yolov8.annotate --source basilica.jpg --model_filepath "yolov8n.onnx"`
Segmentation:
`deepsparse.yolov8.annotate --source basilica.jpg --model_filepath "yolov8n-seg.onnx" --subtask segmentation`

Results verified for outputs produced by both workflows above

## Eval

Detection:
`deepsparse.yolov8.eval --model_path yolov8n.onnx`
Segementation:
`deepsparse.yolov8.eval --model_path yolov8n-seg.onnx --subtask segmentation`