### PR TITLE
Implement `streamer` for text-generation and add `context` arg to `Pipeline.engine_forward`

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -498,6 +498,7 @@ class Pipeline(BasePipeline):
         """
         :param engine_inputs: list of numpy inputs to Pipeline engine forward
             pass
+        :param context: optional dictionary to be used during engine execution
         :return: result of forward pass to Pipeline engine
         """
         return self.engine(engine_inputs)

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -19,9 +19,9 @@ inference engine and include pre/postprocessing
 import os
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
-from functools import partial
 
 import numpy
 from pydantic import BaseModel, Field

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -16,10 +16,12 @@ import logging
 import os
 import warnings
 from dataclasses import dataclass
-from typing import Generator, List, Optional, Tuple, Type, Union
+from typing import Generator, List, Optional, Tuple, Type, Union, Dict
+
 
 import numpy
 from pydantic import BaseModel, Field
+from transformers import TextStreamer
 
 from deepsparse import Pipeline
 from deepsparse.cpu import cpu_avx512_compatible
@@ -46,6 +48,9 @@ class _TextGenerationTimings:
 
 
 class TextGenerationInput(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
     sequences: Union[str, List[str]] = Field(
         description="The input sequences to generate the text from.",
     )
@@ -70,6 +75,13 @@ class TextGenerationInput(BaseModel):
         "of tokens. Useful, when a batch of predictions needs "
         "to have consistent length so one "
         "can compute metric in a batched fashion. ",
+    )
+    streamer: Optional[TextStreamer] = Field(
+        default=None,
+        description="Streamer object that will be used to stream the "
+        "generated sequences. Generated tokens are passed through "
+        "`streamer.put(token_ids)` and the streamer is responsible "
+        "for any further processing.",
     )
 
 
@@ -290,7 +302,9 @@ class TextGenerationPipeline(TransformersPipeline):
             self.engine.session_id = inputs.session_id
             self.multitoken_engine.session_id = inputs.session_id
 
-        postprocessing_kwargs = dict(return_logits=inputs.return_logits)
+        postprocessing_kwargs = dict(
+            return_logits=inputs.return_logits, streamer=inputs.streamer
+        )
         return engine_input, postprocessing_kwargs
 
     def process_engine_outputs(
@@ -311,7 +325,7 @@ class TextGenerationPipeline(TransformersPipeline):
         return TextGenerationOutput(sequences=sequences, logits=logits)
 
     def engine_forward(
-        self, engine_inputs: List[numpy.ndarray], **kwargs
+        self, engine_inputs: List[numpy.ndarray], context: Dict
     ) -> Tuple[numpy.ndarray, numpy.ndarray]:
         """
         Run the forward pass on the engine.
@@ -327,6 +341,8 @@ class TextGenerationPipeline(TransformersPipeline):
         # main thread. That is why `engine_` is prepended to each of the timer phase
         # names in this context
         with self.timer_manager.new_timer_context(total_inference=False) as timer:
+            streamer = context.get("streamer")
+
             if not self.multitoken_engine.kv_cache_enabled:
                 tokens, prompt_logits = self.multitoken_engine(engine_inputs)
                 return numpy.array([tokens]), prompt_logits
@@ -335,6 +351,9 @@ class TextGenerationPipeline(TransformersPipeline):
                 # run the prompt through
                 with timer.time(_TextGenerationTimings.PROMPT_PREFILL):
                     tokens, prompt_logits = self.prompt_inference(engine_inputs)
+
+            if streamer is not None:
+                streamer.put(numpy.array(tokens))
 
             # create the generated output
             max_tokens = (
@@ -354,11 +373,17 @@ class TextGenerationPipeline(TransformersPipeline):
                     generated_tokens.append(token)
                     generated_logits.append(logits)
 
+                    if streamer is not None:
+                        streamer.put(numpy.array([token]))
+
                     if (
                         token == self.tokenizer.eos_token_id
                         and not self.force_max_tokens
                     ):
                         break
+
+            if streamer is not None:
+                streamer.end()
 
         return numpy.array([generated_tokens]), numpy.concatenate(
             generated_logits, axis=1

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -16,8 +16,7 @@ import logging
 import os
 import warnings
 from dataclasses import dataclass
-from typing import Generator, List, Optional, Tuple, Type, Union, Dict
-
+from typing import Dict, Generator, List, Optional, Tuple, Type, Union
 
 import numpy
 from pydantic import BaseModel, Field

--- a/tests/deepsparse/pipelines/test_pipeline.py
+++ b/tests/deepsparse/pipelines/test_pipeline.py
@@ -132,7 +132,7 @@ def test_pipeline_call_is_async(engine_mock):
     executor = ThreadPoolExecutor(max_workers=1)
     pipeline = Pipeline.create("token_classification", batch_size=1, executor=executor)
 
-    def sleep_then_engine_forward(xs):
+    def sleep_then_engine_forward(xs, context):
         # each call to engine_forward also sleeps
         time.sleep(20 / 1000)
         return pipeline.engine(xs)


### PR DESCRIPTION
Allows usage of the [Transformers TextStreamer and TextIteratorStreamer classes](https://huggingface.co/docs/transformers/internal/generation_utils#transformers.TextStreamer) with DeepSparse

```python
from deepsparse import Pipeline
from transformers import TextStreamer

pipe = Pipeline.create(
    task="codegen",
    model_path="zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none",
    max_generated_tokens=64,
    prompt_processing_sequence_length=1,
    use_deepsparse_cache=False,
)

streamer = TextStreamer(pipe.tokenizer)

# While also returning the usual output, the streamer will also print the generated text to stdout
_ = pipe(sequences="def fib():", streamer=streamer)
```

https://github.com/neuralmagic/deepsparse/assets/3195154/ef17fd95-a54f-4709-98df-1ce6412a2911

===

This also extends beyond printing to stdout by using TextIteratorStreamer

```python
from deepsparse import Pipeline
from transformers import TextIteratorStreamer
from threading import Thread

pipe = Pipeline.create(
    task="codegen",
    model_path="zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none",
    max_generated_tokens=64,
    prompt_processing_sequence_length=1,
    use_deepsparse_cache=False,
)

streamer = TextIteratorStreamer(pipe.tokenizer)

generation_kwargs = dict(sequences="def fib():", streamer=streamer)
thread = Thread(target=pipe, kwargs=generation_kwargs)
thread.start()
generated_text = ""
for new_text in streamer:
    generated_text += new_text
print(generated_text)

"""
def fib():
    a, b = 0, 1
    while True:
        yield a
        a, b = b, a + b

def fib2(n):
    a, b = 0, 1
    while a < n:
        yield a
        a, b
"""
```
