### PR TITLE
Nightly Docker Images

### DIFF
--- a/.github/workflows/publish-nightly-docker.yaml
+++ b/.github/workflows/publish-nightly-docker.yaml
@@ -1,0 +1,79 @@
+name: Publish Nightly Docker Images
+
+on:
+  push:
+    branches:
+      - 'main'
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+jobs:
+  push-nightly-docker-image:
+    name: Push Version Tagged Nightly Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Get version tag
+        id: extract_tag
+        run: echo "tag=$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+
+      - name: Current Version Name
+        run: |
+          echo ${{ steps.extract_tag.outputs.tag }}
+
+      - name: DeepSparse-Nightly latest
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker
+          build-args: |
+            DEPS=all
+            BRANCH=main
+          push: true
+          tags: |
+            ghcr.io/neuralmagic/deepsparse-nightly:latest
+
+      - name: Today's DeepSparse-Nightly
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker
+          build-args: |
+            DEPS=all
+            BRANCH=main
+          push: true
+          tags: |
+            ghcr.io/neuralmagic/deepsparse-nightly:${{ steps.extract_tag.outputs.tag }}
+
+      - name: Today's DeepSparse-Nightly Base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker
+          build-args: |
+            DEPS=base
+            BRANCH=main
+          push: true
+          tags: |
+            ghcr.io/neuralmagic/deepsparse-nightly:base-${{ steps.extract_tag.outputs.tag }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This PR adds support to build and push deepsparse-nightly docker images to github container registry

The workflow will be run once everyday at 1:00 am, and includes the following images:
 - deepsparse-nightly  Latest deepsparse-nightly from main, will all dependencies installed
 - deepsparse-nightly:latest Same as above
 - deepsparse-nightly:YYYYMMDD deepsparse-nightly from YYYYMMDD with all dependencies installed
 - deepsparse-nightly:base-YYYYMMDD deepsparse-nightly from YYYYMMDD with only base dependencies installed
 
 These images will live under the https://github.com/orgs/neuralmagic/packages?repo_name=deepsparse
 and can be pulled using:
 
 ```bash
 docker pull <IMAGE-NAME>
 ```
 
 Equivalent in purpose to Sparseml Diff: https://github.com/neuralmagic/sparseml/pull/1684