### PR TITLE
[bugfix] qa tests - `KeyError: 'num_cores'`

### DIFF
--- a/src/deepsparse/base_pipeline.py
+++ b/src/deepsparse/base_pipeline.py
@@ -196,7 +196,7 @@ class BasePipeline(ABC):
                     "Overriding input shapes not supported with Bucketing enabled"
                 )
             if not kwargs.get("context", None):
-                context = Context(num_cores=kwargs["num_cores"])
+                context = Context(num_cores=kwargs.get("num_cores"))
                 kwargs["context"] = context
             buckets = pipeline_constructor.create_pipeline_buckets(
                 task=task,

--- a/src/deepsparse/base_pipeline.py
+++ b/src/deepsparse/base_pipeline.py
@@ -196,7 +196,10 @@ class BasePipeline(ABC):
                     "Overriding input shapes not supported with Bucketing enabled"
                 )
             if not kwargs.get("context", None):
-                context = Context(num_cores=kwargs.get("num_cores"))
+                context = Context(
+                    num_cores=kwargs.get("num_cores"),
+                    num_streams=kwargs.get("num_streams"),
+                )
                 kwargs["context"] = context
             buckets = pipeline_constructor.create_pipeline_buckets(
                 task=task,


### PR DESCRIPTION
if num_cores is not an explicit kwarg of a bucketing pipeline it will trigger a key error on the changed line. this PR uses `.get` to default the value to `None` (this is the expected default of `Context`)

adds support for num_streams as well

**test_plan**
covered by pytest tests