### PR TITLE
Fix Flake 6.1 Quality Errors

### DIFF
--- a/src/deepsparse/utils/data.py
+++ b/src/deepsparse/utils/data.py
@@ -101,7 +101,7 @@ def verify_outputs(
             raise Exception(
                 f"Output shapes don't match, {output.shape} != {gt_output.shape}"
             )
-        if type(output) != type(gt_output):
+        if type(output) is not type(gt_output):
             raise Exception(
                 f"Output types don't match, {type(output)} != {type(gt_output)}"
             )

--- a/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
+++ b/tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py
@@ -35,7 +35,7 @@ _BATCH_SIZES = [2, 4, 8]
 
 
 def compare(expected, actual):
-    assert type(expected) == type(actual)
+    assert type(expected) is type(actual)
 
     if isinstance(expected, (list, float, numpy.ndarray)):
         expected_np = numpy.asarray(expected, dtype=float)


### PR DESCRIPTION
flake8 was updated from 6.0 to 6.1, causing a new error when running `make quality`. I updated the offending lines to compare types with `is`/`is not` rather than `==`/`!=`

### Before Change:
```
(.venv) sadkins@nmgpuserver3:~/deepsparse$ make quality
Running copyright checks
python3 utils/copyright.py quality 'examples/**/*.py' 'scripts/**/*.py' 'src/**/*.py' 'tests/**/*.py' 'utils/**/*.py' setup.py 'docs/**/*.md' 'docs/**/*.rst' 'examples/**/*.md' 'scripts/**/*.md' CODE_OF_CONDUCT.md CONTRIBUTING.md DEVELOPING.md README.md
314 files have copyrights
Running python quality checks
black --check examples tests src utils setup.py;
All done! ✨ 🍰 ✨
249 files would be left unchanged.
isort --check-only examples tests src utils setup.py;
Skipped 6 files
flake8 examples tests src utils setup.py;
src/deepsparse/utils/data.py:104:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
tests/deepsparse/pipelines/test_dynamic_batch_pipeline.py:38:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```

### After Change
`make quality` Completes without errors

### Testing
Covered already by existing unit tests

