### PR TITLE
use max sequence length for tokenization

### DIFF
--- a/src/deepsparse/transformers/pipelines/embedding_extraction.py
+++ b/src/deepsparse/transformers/pipelines/embedding_extraction.py
@@ -330,7 +330,7 @@ class TransformersEmbeddingExtractionPipeline(TransformersPipeline):
         :param pipelines: Different buckets to be used
         :return: The correct Pipeline object (or Bucket) to route input to
         """
-        tokenizer = pipelines[0].tokenizer
+        tokenizer = pipelines[-1].tokenizer
         tokens = tokenizer(
             input_schema.inputs,
             add_special_tokens=True,

--- a/src/deepsparse/transformers/pipelines/question_answering.py
+++ b/src/deepsparse/transformers/pipelines/question_answering.py
@@ -493,7 +493,7 @@ class QuestionAnsweringPipeline(TransformersPipeline):
         :param pipelines: Different buckets to be used
         :return: The correct Pipeline object (or Bucket) to route input to
         """
-        tokenizer = pipelines[0].tokenizer
+        tokenizer = pipelines[-1].tokenizer
         tokens = tokenizer(
             " ".join((input_schema.context, input_schema.question)),
             add_special_tokens=True,

--- a/src/deepsparse/transformers/pipelines/text_classification.py
+++ b/src/deepsparse/transformers/pipelines/text_classification.py
@@ -281,7 +281,7 @@ class TextClassificationPipeline(TransformersPipeline):
         :param pipelines: Different buckets to be used
         :return: The correct Pipeline object (or Bucket) to route input to
         """
-        tokenizer = pipelines[0].tokenizer
+        tokenizer = pipelines[-1].tokenizer
         tokens = tokenizer(
             input_schema.sequences,
             add_special_tokens=True,

--- a/src/deepsparse/transformers/pipelines/token_classification.py
+++ b/src/deepsparse/transformers/pipelines/token_classification.py
@@ -368,7 +368,7 @@ class TokenClassificationPipeline(TransformersPipeline):
         :param pipelines: Different buckets to be used
         :return: The correct Pipeline object (or Bucket) to route input to
         """
-        tokenizer = pipelines[0].tokenizer
+        tokenizer = pipelines[-1].tokenizer
         tokens = tokenizer(
             input_schema.inputs,
             add_special_tokens=True,

--- a/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
+++ b/src/deepsparse/transformers/pipelines/zero_shot_text_classification.py
@@ -299,7 +299,7 @@ class ZeroShotTextClassificationPipelineBase(TransformersPipeline):
         :param pipelines: Different buckets to be used
         :return: The correct Pipeline object (or Bucket) to route input to
         """
-        tokenizer = pipelines[0].tokenizer
+        tokenizer = pipelines[-1].tokenizer
         tokens = tokenizer(
             input_schema.sequences,
             add_special_tokens=True,


### PR DESCRIPTION
Fix bug for  https://neuralmagic.slack.com/archives/C0592FX3215/p1687210067995879

Example:

```python3
from deepsparse import Pipeline


path = "path"

pipeline = Pipeline.create(
    task = "text-classification",
    model_path = path,
    batch_size=8,
    num_cores=None,
    sequence_length = [2, 128],
)

text = "We are flying from Texas to California"
pipeline(text)
```

Before:
```bash
(.venv) ubuntu@quad-mle-2:~/george/nm/deepsparse$ python3 scratch/_p.py 
...
2023-08-04 01:19:39 __main__     INFO     Overwriting in-place the input shapes of the transformer model at /home/ubuntu/.cache/sparsezoo/bert-large-squad_wikipedia_bookcorpus-pruned80.4block_quantized/bert-large-squad_wikipedia_bookcorpus-pruned80.4block_quantized/model.onnx
Token indices sequence length is longer than the specified maximum sequence length for this model (9 > 2). Running this sequence through the model will result in indexing errors
```


After"
```bash
(.venv) ubuntu@quad-mle-2:~/george/nm/deepsparse$ python3 scratch/_p.py 
...
2023-08-04 01:25:44 __main__     INFO     Overwriting in-place the input shapes of the transformer model at /home/ubuntu/.cache/sparsezoo/bert-large-squad_wikipedia_bookcorpus-pruned80.4block_quantized/bert-large-squad_wikipedia_bookcorpus-pruned80.4block_quantized/model.onnx
```