### PR TITLE
Don't load external data for `default_cached_outputs`

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -481,7 +481,7 @@ def default_cached_outputs(model_path: str) -> List[bool]:
     :return A list of bools that indicates caching of all outputs except the first one.
     """
 
-    outputs = list(onnx.load(model_path, load_external_data=False).graph.output)
+    outputs = get_output_names(model_path)
     assert len(outputs) > 0
 
     # Create a boolean list of every output of the

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -481,7 +481,7 @@ def default_cached_outputs(model_path: str) -> List[bool]:
     :return A list of bools that indicates caching of all outputs except the first one.
     """
 
-    outputs = list(onnx.load(model_path).graph.output)
+    outputs = list(onnx.load(model_path, load_external_data=False).graph.output)
     assert len(outputs) > 0
 
     # Create a boolean list of every output of the


### PR DESCRIPTION
It was unnecessary to load in weights to look at the outputs