### PR TITLE
[TextGeneration] fixes to support text gen pipeline in server

### DIFF
--- a/src/deepsparse/engine.py
+++ b/src/deepsparse/engine.py
@@ -290,6 +290,8 @@ class Engine(BaseEngine):
         concurrently.
     :param scheduler: The kind of scheduler to execute with. Pass None for the default.
     :param input_shapes: The list of shapes to set the inputs to. Pass None to use model as-is.
+    :param cached_outputs: List of bools corresponding to which model outputs are
+        included in KV cache
     """
 
     def __init__(
@@ -878,6 +880,8 @@ class MultiModelEngine(Engine):
     :param context: See above. This object should be constructed with the desired number of
         cores and passed into each instance of the MultiModelEngine.
     :param input_shapes: The list of shapes to set the inputs to. Pass None to use model as-is.
+    :param cached_outputs: List of bools corresponding to which model outputs are
+        included in KV cache
     """
 
     def __init__(
@@ -886,6 +890,7 @@ class MultiModelEngine(Engine):
         batch_size: int,
         context: Context,
         input_shapes: List[List[int]] = None,
+        cached_outputs: List[bool] = None,
     ):
         BaseEngine.construct_with_context(
             self, model, batch_size, context, input_shapes
@@ -902,6 +907,7 @@ class MultiModelEngine(Engine):
                     self._num_streams,
                     self._scheduler.value,
                     context.value,
+                    cached_outputs,
                 )
         else:
             self._eng_net = LIB.deepsparse_engine(
@@ -911,6 +917,7 @@ class MultiModelEngine(Engine):
                 self._num_streams,
                 self._scheduler.value,
                 context.value,
+                cached_outputs,
             )
 
 

--- a/src/deepsparse/tasks.py
+++ b/src/deepsparse/tasks.py
@@ -144,6 +144,7 @@ class SupportedTasks:
         haystack,
         embedding_extraction,
         open_pif_paf,
+        text_generation,
     ]
 
     @classmethod

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -16,7 +16,7 @@ import logging
 import os
 import warnings
 from dataclasses import dataclass
-from typing import Dict, Generator, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import numpy
 import onnx
@@ -89,7 +89,7 @@ class TextGenerationOutput(BaseModel):
     sequences: Union[str, List[str]] = Field(
         description="The generated text sequences.",
     )
-    logits: Optional[numpy.ndarray] = Field(
+    logits: Optional[Any] = Field(  # numpy array, set to Any for FastAPI compatibility
         default=None,
         description="The logits for the generated text sequence."
         "The logits have dimensions "


### PR DESCRIPTION
Includes the following fixes:
* adds support for internal KV cache in multi model engine (multi stream)
* adds text generation to complete list of supported tasks (CLI)
* removes numpy.ndarray from output schema (FastAPI requirement)

**test_plan:**
verify the following command (previously failing) now works:

```bash
deepsparse.server --task text-generation --config_file config.yaml
```

where `config.yaml` includes:

```yaml
{
  "name": "opt_model_server_config",
  "num_cores": 2,
  "num_workers": 2,
  "endpoints": [
      {
          "task": "text_generation",
          "model": "zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none",
          "route": "/predict",
      },
  ],
}
```