### PR TITLE
DS eval for OPT on WikiText

### DIFF
--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -109,6 +109,44 @@ def perplexity_eval(args, batch_size=16, dataset_name="openai_humaneval"):
     return perplexity_metrics
 
 
+def perplexity_opt_eval(args, batch_size=16, dataset_name=""):
+    if args.max_samples:
+        batch_size = min(batch_size, args.max_samples)
+
+    dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+
+    text_generation = Pipeline.create(
+        task="text-generation",
+        model_path=args.model_path,
+        engine_type=args.engine,
+        num_cores=args.num_cores,
+        sequence_length=args.max_sequence_length,
+        prompt_processing_sequence_length=args.max_sequence_length,
+        max_generated_tokens=1,
+    )
+    perplexity_metrics = Perplexity(pipeline=text_generation, batch_size=batch_size)
+    active_engines = [
+        engine
+        for engine in [text_generation.engine, text_generation.multitoken_engine]
+        if engine
+    ]
+    print("Engine info: ")
+    [print(f"{engine}\n") for engine in active_engines]
+    predictions = []
+    count = 0
+    for idx, sample in _enumerate_progress(dataset, args.max_samples):
+        if len(sample["text"]) == 0:
+            continue
+        count += 1
+        predictions.append(sample["text"])
+        if len(predictions) == batch_size:
+            perplexity_metrics.add_batch(predictions)
+            predictions = []
+        if args.max_samples and count >= args.max_samples:
+            break
+    return perplexity_metrics
+
+
 def qa_eval(args, dataset_name="squad"):
     # load validation dataset and eval tool
     dataset = load_dataset(dataset_name)["validation"]
@@ -475,6 +513,7 @@ SUPPORTED_DATASETS = {
     "conll2003": conll2003_eval,
     "go_emotions": go_emotions_eval,
     "openai_humaneval": perplexity_eval,
+    "wikitext": perplexity_opt_eval
 }
 
 

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -177,13 +177,6 @@ def perplexity_wikitext_eval(args, batch_size=16, dataset_name=""):
             engine_outputs, **postprocessing_kwargs
         )
         logits = pipeline_outputs.logits
-        if not text_generation.has_cache:
-            logits = [
-                logit[-attn_mask.sum() :, :]
-                for (logit, attn_mask) in zip(logits, attention_mask)
-            ]
-            logits = [pad_to_fixed_length(logit, seq_len) for logit in logits]
-            logits = numpy.stack(logits)
 
         shift_logits = logits[:, :-1, :]
         shift_labels = input_ids[:, 1:]

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -72,9 +72,7 @@ from tqdm.auto import tqdm
 import torch
 from deepsparse import DEEPSPARSE_ENGINE, ORT_ENGINE, Pipeline
 from deepsparse.transformers.metrics import Perplexity, PrecisionRecallF1
-from deepsparse.transformers.utils.helpers import (
-    create_causal_mask
-)
+from deepsparse.transformers.utils.helpers import create_causal_mask
 
 
 from datasets import load_dataset, load_metric  # isort: skip

--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -73,8 +73,7 @@ import torch
 from deepsparse import DEEPSPARSE_ENGINE, ORT_ENGINE, Pipeline
 from deepsparse.transformers.metrics import Perplexity, PrecisionRecallF1
 from deepsparse.transformers.utils.helpers import (
-    create_causal_mask,
-    pad_to_fixed_length,
+    create_causal_mask
 )
 
 

--- a/src/deepsparse/transformers/metrics.py
+++ b/src/deepsparse/transformers/metrics.py
@@ -122,22 +122,6 @@ class Perplexity:
 
             logits = out.logits
 
-            if not self._pipeline.has_cache:
-                # when running inference without cache, we need to apply
-                # analogous transformations to the logits as we did to the labels
-                # and attention mask
-
-                # remove "nonsensical" logits for <PAD> tokens
-                logits = [
-                    logit[-attn_mask.sum() :, :]
-                    for (logit, attn_mask) in zip(logits, attention_mask)
-                ]
-                # pad logits to max length
-                logits = [
-                    pad_to_fixed_length(logit, max_sequence_len) for logit in logits
-                ]
-                logits = numpy.stack(logits)
-
             # shift logits and labels create the input and target for the loss function
             shift_logits = logits[:, :-1, :]
             shift_labels = labels[:, 1:]

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -168,7 +168,7 @@ class TextGenerationPipeline(TransformersPipeline):
             if "WAND_OPT_FLAGS" not in os.environ:
                 os.environ["WAND_OPT_FLAGS"] = "default,~pyramids"
 
-        if not self.cache_support_enabled and self.max_generated_tokens > 1:
+        if not self.cache_support_enabled and max_generated_tokens > 1:
             raise ValueError(
                 "The model used for inference does not support kv cache. It is "
                 "assumed that it maps from the token sequence to predicted logits."


### PR DESCRIPTION
This PR enables verifying perplexity of OPT models on wikitext, matching the numbers in pytorch eval flow after one-shot prune/quantize with SparseGPT.

Qualification: tested with 1.3, 2.7b base, W8A8linear and pruned50_quantW8A8 models.