### PR TITLE
allow spaces in task names to match

### DIFF
--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -122,7 +122,8 @@ INTEGRATION_OPTION = click.option(
 @click.group(
     invoke_without_command=True,
     context_settings=dict(
-        token_normalize_func=lambda x: x.replace("-", "_"), show_default=True
+        token_normalize_func=lambda x: "_".join(x.replace("-", "_").split()),
+        show_default=True,
     ),
 )
 @click.option(

--- a/src/deepsparse/tasks.py
+++ b/src/deepsparse/tasks.py
@@ -61,10 +61,14 @@ class AliasedTask:
         """
         :param task: the name of the task to check whether the given instance matches.
             Checks the current name as well as any aliases.
-            Everything is compared at lower case and "-" are replaced with "_".
+            Everything is compared at lower case and "-" and whitespace
+            are replaced with "_".
         :return: True if task does match the current instance, False otherwise
         """
         task = task.lower().replace("-", "_")
+
+        # replace whitespace with "_"
+        task = "_".join(task.split())
 
         return task == self.name or task in self.aliases
 


### PR DESCRIPTION
request from product - allows whitespaces to be ignored when matching task names. specifically allows `text generation` to be a valid task name

**test_plan:**
previously failing command now works:
```
deepsparse.server --task "text generation"
```