### PR TITLE
[Text Generation] Optimize the slow `update` method in the KVCacheDecoder

### DIFF
--- a/src/deepsparse/transformers/utils/decoder_kv_cache.py
+++ b/src/deepsparse/transformers/utils/decoder_kv_cache.py
@@ -91,7 +91,7 @@ class DecoderKVCache:
     ):
         """
         Updating the session is identical with taking the kv cache
-        output of from the forward pass and restructuring it, so it
+        output from the forward pass and restructuring it, so it 
         can be directly used as input for the next forward pass.
 
         :param state: The state of the cache. This is a dictionary

--- a/src/deepsparse/transformers/utils/decoder_kv_cache.py
+++ b/src/deepsparse/transformers/utils/decoder_kv_cache.py
@@ -91,7 +91,7 @@ class DecoderKVCache:
     ):
         """
         Updating the session is identical with taking the kv cache
-        output from the forward pass and restructuring it, so it 
+        output from the forward pass and restructuring it, so it
         can be directly used as input for the next forward pass.
 
         :param state: The state of the cache. This is a dictionary


### PR DESCRIPTION
As reported by @mgoin and investigated by myself, the `update` method in the KVCacheDecoder is very slow.
Profiling has shown that this is due to the repeated use of the `numpy.delete` function:

![image](https://github.com/neuralmagic/deepsparse/assets/97082108/e2f4b2b0-1953-4433-ac03-b6f67647149c)

This discussion:
https://stackoverflow.com/questions/30399534/shift-elements-in-a-numpy-array
hints that the most elegant and quite efficient replacement for `numpy.delete` would be slicing the arrays. This is the change that this PR introduces.

Short benchmarking numbers:

<img width="1184" alt="image" src="https://github.com/neuralmagic/deepsparse/assets/97082108/f133bc25-f70f-44d8-8f1f-7c000fbc2411">