### PR TITLE
[Text Generation] [Fix] Raise error when we use deepsparse engine and `prompt_processing_length == sequence_lenght`

### DIFF
--- a/src/deepsparse/transformers/eval_downstream.py
+++ b/src/deepsparse/transformers/eval_downstream.py
@@ -87,7 +87,6 @@ def perplexity_eval(args, batch_size=16, dataset_name="openai_humaneval"):
         engine_type=args.engine,
         num_cores=args.num_cores,
         sequence_length=args.max_sequence_length,
-        prompt_processing_sequence_length=args.max_sequence_length,
         max_generated_tokens=1,
     )
     perplexity_metrics = Perplexity(pipeline=text_generation, batch_size=batch_size)

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -224,7 +224,7 @@ class TextGenerationPipeline(TransformersPipeline):
                     "process a prompt with a larger processing length. "
                     "However, it is assumed that `prompt_processing_sequence_length` "
                     "is smaller than the `sequence_length`. "
-                    "Please adjust the `prompt_processing_sequence_length` "
+                    "Adjust the `prompt_processing_sequence_length` "
                     "argument accordingly."
                 )
 

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -214,6 +214,20 @@ class TextGenerationPipeline(TransformersPipeline):
         engine, multitoken_engine = None, None
 
         if self.cache_support_enabled:
+            if (
+                self.engine_type == DEEPSPARSE_ENGINE
+                and self.sequence_length <= self.prompt_processing_sequence_length
+                and self.enable_multitoken_prefill
+            ):
+                raise ValueError(
+                    "Attempting to initialize auxiliary DeepSparse engine to "
+                    "process a prompt with a larger processing length. "
+                    "However, it is assumed that `prompt_processing_sequence_length` "
+                    "is smaller than the `sequence_length`. "
+                    "Please adjust the `prompt_processing_sequence_length` "
+                    "argument accordingly."
+                )
+
             # emit the appropriate user message depending whether we are
             # instantiation the multitoken engine or not
             if not self.enable_multitoken_prefill:
@@ -248,7 +262,6 @@ class TextGenerationPipeline(TransformersPipeline):
             )
 
         if self.cache_support_enabled:
-
             engine = NLDecoderEngine(
                 onnx_file_path=self.onnx_file_path,
                 engine_type=self.engine_type,


### PR DESCRIPTION
When we try to create a multi-token deepsparse engine where `prompt_processing_length == sequence_length`, this engine will default to onnxruntime:
```bash
[nm_ort 7f9cd3579740 >WARN<  is_supported_graph src/onnxruntime_neuralmagic/supported/ops.cc:144] Warning: Optimized runtime disabled - Detected dynamic input past_key_values.0.key dim 2. Set inputs to static shapes to enable optimal performance.
```
this is a known issue reported by the runtime team. The crux is: if `prompt_processing_length == sequence_length`, the initial kv cache tensors will be empty, and this is prohibitive in the engine - we cannot have empty kv cache values in there.
