### PR TITLE
Bug Fix: Make Numpy Array Outputs JSON Serializable for Server

### DIFF
--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -64,7 +64,8 @@ def server_logger_from_config(config: ServerConfig) -> BaseLogger:
 def prep_outputs_for_serialization(pipeline_outputs: BaseModel):
     """
     Prepares a pipeline output for JSON serialization by converting any numpy array
-    field to a list. In-place operation.
+    field to a list. In-place operation. For large numpy arrays, this operation 
+    will take a while to run.
 
     :param pipeline_outputs: output data to clean
     """

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -64,7 +64,7 @@ def server_logger_from_config(config: ServerConfig) -> BaseLogger:
 def prep_outputs_for_serialization(pipeline_outputs: BaseModel):
     """
     Prepares a pipeline output for JSON serialization by converting any numpy array
-    field to a list. In-place operation. For large numpy arrays, this operation 
+    field to a list. In-place operation. For large numpy arrays, this operation
     will take a while to run.
 
     :param pipeline_outputs: output data to clean

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from typing import Dict, List, Optional
-from pydantic import BaseModel
+
 import numpy
+from pydantic import BaseModel
 
 from deepsparse import (
     BaseLogger,

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -61,19 +61,24 @@ def server_logger_from_config(config: ServerConfig) -> BaseLogger:
     )
 
 
-def prep_outputs_for_serialization(pipeline_outputs: BaseModel):
+def prep_outputs_for_serialization(pipeline_outputs: any):
     """
     Prepares a pipeline output for JSON serialization by converting any numpy array
-    field to a list. In-place operation. For large numpy arrays, this operation
-    will take a while to run.
+    field to a list. For large numpy arrays, this operation will take a while to run.
 
     :param pipeline_outputs: output data to clean
+    :return: cleaned pipeline_outputs
     """
-    for field_name in pipeline_outputs.__fields__.keys():
-        field_value = getattr(pipeline_outputs, field_name)
-        if isinstance(field_value, numpy.ndarray):
-            # numpy arrays aren't JSON serializable
-            setattr(pipeline_outputs, field_name, field_value.tolist())
+    if isinstance(pipeline_outputs, BaseModel):
+        for field_name in pipeline_outputs.__fields__.keys():
+            field_value = getattr(pipeline_outputs, field_name)
+            if isinstance(field_value, numpy.ndarray):
+                # numpy arrays aren't JSON serializable
+                setattr(pipeline_outputs, field_name, field_value.tolist())
+    elif isinstance(pipeline_outputs, numpy.ndarray):
+        pipeline_outputs = pipeline_outputs.tolist()
+
+    return pipeline_outputs
 
 
 def _extract_system_logging_from_endpoints(

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy
 from pydantic import BaseModel
@@ -61,7 +61,7 @@ def server_logger_from_config(config: ServerConfig) -> BaseLogger:
     )
 
 
-def prep_outputs_for_serialization(pipeline_outputs: any):
+def prep_outputs_for_serialization(pipeline_outputs: Any):
     """
     Prepares a pipeline output for JSON serialization by converting any numpy array
     field to a list. For large numpy arrays, this operation will take a while to run.

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -35,8 +35,8 @@ from deepsparse.server.config import (
 )
 from deepsparse.server.config_hot_reloading import start_config_watcher
 from deepsparse.server.helpers import (
-    server_logger_from_config,
     prep_outputs_for_serialization,
+    server_logger_from_config,
 )
 from deepsparse.server.system_logging import (
     SystemLoggingMiddleware,

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -34,7 +34,10 @@ from deepsparse.server.config import (
     SystemLoggingConfig,
 )
 from deepsparse.server.config_hot_reloading import start_config_watcher
-from deepsparse.server.helpers import server_logger_from_config
+from deepsparse.server.helpers import (
+    server_logger_from_config,
+    prep_outputs_for_serialization,
+)
 from deepsparse.server.system_logging import (
     SystemLoggingMiddleware,
     log_system_information,
@@ -261,6 +264,7 @@ def _add_pipeline_endpoint(
                 server_logger=server_logger,
                 system_logging_config=system_logging_config,
             )
+        prep_outputs_for_serialization(pipeline_outputs)
         return pipeline_outputs
 
     def _predict_from_files(request: List[UploadFile]):

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -264,7 +264,7 @@ def _add_pipeline_endpoint(
                 server_logger=server_logger,
                 system_logging_config=system_logging_config,
             )
-        prep_outputs_for_serialization(pipeline_outputs)
+        pipeline_outputs = prep_outputs_for_serialization(pipeline_outputs)
         return pipeline_outputs
 
     def _predict_from_files(request: List[UploadFile]):


### PR DESCRIPTION
**Asana Ticket:** https://app.asana.com/0/1205229323407165/1205248270105783/f 

When a TextGeneration pipeline is run through DeepSparse Server with `return_logits=true`, the request fails because the logits are returned as `numpy.ndarray` which is not JSON serializable. To fix this, I added a helper function that converts numpy arrays to lists before returning them to the client

### Testing
Launch a server:
`deepsparse.server --config_file server_error_config.yaml`

server_error_config.yaml:
```
{
  "name": "opt_model_server_config",
  "endpoints": [
    {
      "task": "text_generation",
      "model": "zoo:nlg/text_generation/codegen_multi-350m/pytorch/huggingface/bigquery_thepile/base-none",
      "route": "/gen",
    }
  ]
}
```

Send request from python, it should now be processed correctly
```
>>> r = requests.post("http://0.0.0.0:5543/gen", json={"sequences": ["def is_palindrome(word):"], "return_logits": True})
>>> r.status_code
200
>>>r.text
(This will print the very long logits array)
```
