### PR TITLE
[BugFix]: `force_max_tokens` not respected by text-gen pipelines

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -429,7 +429,7 @@ class TextGenerationPipeline(TransformersPipeline):
             generated_logits = prompt_logits
 
             with timer.time(_TextGenerationTimings.TOKEN_GENERATION):
-                while len(generated_tokens) < max_tokens:
+                while len(generated_tokens) <= max_tokens:
                     with timer.time(_TextGenerationTimings.TOKEN_GENERATION_SINGLE):
                         token, logits = self.autoregressive_inference(tokens)
                     tokens.append(token)

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -60,6 +60,14 @@ class TextGenerationInput(BaseModel):
         "the logits for the input text sequence and the "
         "generated text sequence. ",
     )
+    include_prompt_logits: bool = Field(
+        default=False,
+        description="A flag that indicates whether to return "
+        "the logits for the prompt. If set, prompt_logits are "
+        "`prepended` to the logits for the generated text sequence."
+        "Note: This flag is only applicable when return_logits "
+        "is `True`.",
+    )
     session_id: Optional[str] = Field(
         default=None,
         description="A user may set a string identifier "
@@ -366,7 +374,9 @@ class TextGenerationPipeline(TransformersPipeline):
             self.multitoken_engine.session_id = inputs.session_id
 
         postprocessing_kwargs = dict(
-            return_logits=inputs.return_logits, streamer=inputs.streamer
+            return_logits=inputs.return_logits,
+            streamer=inputs.streamer,
+            include_prompt_logits=inputs.include_prompt_logits,
         )
         return engine_input, postprocessing_kwargs
 
@@ -426,7 +436,9 @@ class TextGenerationPipeline(TransformersPipeline):
             )  # set safety for absolute max generation
 
             generated_tokens = [tokens[-1]]
-            generated_logits = prompt_logits
+            generated_logits = (
+                prompt_logits if context.get("include_prompt_logits") else []
+            )
 
             with timer.time(_TextGenerationTimings.TOKEN_GENERATION):
                 while len(generated_tokens) <= max_tokens:


### PR DESCRIPTION
This PR fixes the following issues with text-generation Pipelines:

- [X] Fix off by one error in number of tokens generated
- [x] Fix length of logits returned (off by 14 consistently): IN PROGRESS


Test code for 1:
```python
from deepsparse import Pipeline

ZOO_STUB = "zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none"
PIPELINE_INPUT = {
    "sequences": "Write a function in Python to find the factorial of a given number."
}
TASK = "text_generation"
_MAX_TOKENS = 512


if __name__ == "__main__":
    pipeline_args = {
        "task": TASK,
        "model_path": ZOO_STUB,
        "max_generated_tokens": _MAX_TOKENS,
        "force_max_tokens": True,
    }
    pipeline = Pipeline.create(**pipeline_args)
    result = pipeline(**PIPELINE_INPUT)
    token_count = len(pipeline.tokenizer.tokenize(result.sequences[0]))
    assert token_count == _MAX_TOKENS, f"want: {_MAX_TOKENS}, got: {token_count}"
    print(f"SUCCESS! got {token_count} number of tokens")
    print("result.sequence[0]:", result.sequences[0])
```

Before this PR the assertion in test code was raised; after this PR the test code executes successfully

Output:
```bash
python reproduction.py                                                                                                         (bugfix-max-tokens-not-respected|✚1…6⚑1)
2023-08-24 12:14:45 deepsparse.transformers WARNING  The neuralmagic fork of transformers may not be installed. It can be installed via `pip install nm_transformers`
Using pad_token, but it is not set yet.
2023-08-24 12:14:57 deepsparse.transformers.pipelines.text_generation INFO     Compiling an auxiliary engine to process a prompt with a larger processing length. This improves performance, but may result in additional memory consumption.
2023-08-24 12:14:58 deepsparse.transformers.utils.helpers INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/model.onnx
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0.20230821 COMMUNITY | (458b4ccd) (release) (optimized) (system=avx512, binary=avx512)
2023-08-24 12:15:07 deepsparse.transformers.utils.helpers INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/model.onnx
Token indices sequence length is longer than the specified maximum sequence length for this model (512 > 128). Running this sequence through the model will result in indexing errors
SUCCESS! got 512 number of tokens
result.sequence[0]: 

# def factorial(n):
#     if n == 0:
#         return 1
#     else:
#         return n * factorial(n-1)
#
# print(factorial(5))

# Write a function in Python to find the factorial of a given number.
#
# def factorial(n):
#     if n == 0:
#         return 1
#     else:
#         return n * factorial(n-1)
#
# print(factorial(5))

# Write a function in Python to find the factorial of a given number.
#
# def factorial(n):
#     if n == 0:
#         return 1
#     else:
#         return n * factorial(n-1)
#
# print(factorial(5))
```

## PART 2:
The logit length was off as the prompt logits were included; this PR added a flag to turn this feature on/off;
The flag is called `include_prompt_logits` and must be specified as a boolean with input during inference.
 
Test code:
```python
from deepsparse import Pipeline

ZOO_STUB = "zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none"
PIPELINE_INPUT = {
    "sequences": "Write a function in Python to find the factorial of a given number.",
    "return_logits": True,
    "include_prompt_logits": False, # default is False
}
TASK = "text_generation"
_MAX_TOKENS = 512


if __name__ == "__main__":
    pipeline_args = {
        "task": TASK,
        "model_path": ZOO_STUB,
        "max_generated_tokens": _MAX_TOKENS,
        "force_max_tokens": True,
        
    }
    pipeline = Pipeline.create(**pipeline_args)
    result = pipeline(**PIPELINE_INPUT)
    logits = result.logits
    
    logits_sequence_length = logits.shape[1]
    assert logits_sequence_length == _MAX_TOKENS, f"expected {_MAX_TOKENS}  found {logits_sequence_length}"
    print("Success!")
```

Output:
```bash
rahul at office-desktop in ~/projects/deepsparse (bugfix-max-tokens-not-respected●●) (.venv) 
$  cd /home/rahul/projects/deepsparse ; /usr/bin/env /home/rahul/projects/.venv/bin/python /home/rahul/.vscode-server/extensions/ms-python.python-2023.14
.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher 52445 -- /home/rahul/projects/deepsparse/reproduction.py 
2023-08-24 13:12:10 deepsparse.transformers WARNING  The neuralmagic fork of transformers may not be installed. It can be installed via `pip install nm_transformers`
Using pad_token, but it is not set yet.
2023-08-24 13:12:22 deepsparse.transformers.pipelines.text_generation INFO     Compiling an auxiliary engine to process a prompt with a larger processing length. This improves performance, but may result in additional memory consumption.
2023-08-24 13:12:23 deepsparse.transformers.utils.helpers INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/model.onnx
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0.20230821 COMMUNITY | (458b4ccd) (release) (optimized) (system=avx512, binary=avx512)
2023-08-24 13:12:32 deepsparse.transformers.utils.helpers INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/model.onnx
Success!
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205258885552373