### PR TITLE
[Feature] Add callback for Text Generation Pipelines

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -469,7 +469,7 @@ class TextGenerationPipeline(TransformersPipeline):
                         break
 
                     if callback is not None and callback(token) is False:
-                        _LOGGER.info(
+                        _LOGGER.debug(
                             "callback %s returned False, stopping generation."
                             % callback.__qualname__
                         )

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -16,7 +16,7 @@ import logging
 import os
 import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import numpy
 import onnx
@@ -90,6 +90,14 @@ class TextGenerationInput(BaseModel):
         "generated sequences. Generated tokens are passed through "
         "`streamer.put(token_ids)` and the streamer is responsible "
         "for any further processing.",
+    )
+    callback: Optional[Callable[[Any], bool]] = Field(
+        default=None,
+        description="Callable that will be invoked "
+        "on each generated token. The callable must return a "
+        "Boolean value. If invocation returns `True`, the "
+        "generation will continue. If the callable returns "
+        "`False`, the generation will stop. Default is `None`.",
     )
 
 
@@ -377,6 +385,7 @@ class TextGenerationPipeline(TransformersPipeline):
             return_logits=inputs.return_logits,
             streamer=inputs.streamer,
             include_prompt_logits=inputs.include_prompt_logits,
+            callback=inputs.callback,
         )
         return engine_input, postprocessing_kwargs
 
@@ -439,7 +448,7 @@ class TextGenerationPipeline(TransformersPipeline):
             generated_logits = (
                 prompt_logits if context.get("include_prompt_logits") else []
             )
-
+            callback = context.get("callback")
             with timer.time(_TextGenerationTimings.TOKEN_GENERATION):
                 while len(generated_tokens) <= max_tokens:
                     with timer.time(_TextGenerationTimings.TOKEN_GENERATION_SINGLE):
@@ -455,6 +464,13 @@ class TextGenerationPipeline(TransformersPipeline):
                         token == self.tokenizer.eos_token_id
                         and not self.force_max_tokens
                     ):
+                        break
+
+                    if callback is not None and not callback(token):
+                        _LOGGER.info(
+                            "callback %s returned False, stopping generation."
+                            % callback.__qualname__
+                        )
                         break
 
             if streamer is not None:

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -91,12 +91,10 @@ class TextGenerationInput(BaseModel):
         "`streamer.put(token_ids)` and the streamer is responsible "
         "for any further processing.",
     )
-    callback: Optional[Callable[[Any], bool]] = Field(
+    callback: Optional[Callable[[Any], Union[bool, Any]]] = Field(
         default=None,
         description="Callable that will be invoked "
-        "on each generated token. The callable must return a "
-        "Boolean value. If invocation returns `True`, the "
-        "generation will continue. If the callable returns "
+        "on each generated token. If the callable returns "
         "`False`, the generation will stop. Default is `None`.",
     )
 
@@ -470,7 +468,7 @@ class TextGenerationPipeline(TransformersPipeline):
                     ):
                         break
 
-                    if callback is not None and not callback(token):
+                    if callback is not None and callback(token) is False:
                         _LOGGER.info(
                             "callback %s returned False, stopping generation."
                             % callback.__qualname__

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -52,7 +52,7 @@ def _initialize_kv_cache_state(model, length=0):
     return kv_cache
 
 
-START = 0 # global variable for dummy_callback
+START = 0  # global variable for dummy_callback
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds a callback attribute to TextGenerationInput

`callback` is a callable that will be invoked on each generated token, and returns a boolean value.

If callback returns false, further generation of tokens is stopped

Test Code:

```python
from deepsparse import Pipeline

start = 0
def dummy_callback(token):
    global start
    start += 1
    return start < 3


if __name__ == "__main__":
    codegen_pipeline = Pipeline.create(
        task="text_generation",
        model_path = "zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none"
    )
    
    inputs = {
        "sequences": ["def fib(a, b, accumulator=0)"]*3,
        "callback": dummy_callback,
        "return_logits": True,
    }
    
    outputs = codegen_pipeline(**inputs)
    assert ( shape:=outputs.logits.shape[1]) == 3, f"Expected 3 tokens, got {shape}"
```

Also added above logic in an automated test (This is not yet active on GHA, but tested locally)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205276886236977