### PR TITLE
Add example for side-by-side chat comparison

### DIFF
--- a/examples/chat-compare/app.py
+++ b/examples/chat-compare/app.py
@@ -77,10 +77,14 @@ def main():
         streamer = TextStreamer(ds_pipe.tokenizer)
 
         print("\n<DeepSparse output>\n")
-        _ = ds_pipe(sequences=user_input, max_tokens=args.max_new_tokens, streamer=streamer)
+        _ = ds_pipe(
+            sequences=user_input, max_tokens=args.max_new_tokens, streamer=streamer
+        )
 
         print("\n<ORT output>\n")
-        _ = ort_pipe(sequences=user_input, max_tokens=args.max_new_tokens, streamer=streamer)
+        _ = ort_pipe(
+            sequences=user_input, max_tokens=args.max_new_tokens, streamer=streamer
+        )
 
 
 if __name__ == "__main__":

--- a/examples/chat-compare/app.py
+++ b/examples/chat-compare/app.py
@@ -54,8 +54,6 @@ def main():
         sequence_length=args.sequence_length,
         max_generated_tokens=args.max_new_tokens,
         prompt_processing_sequence_length=1,
-        sampling_temperature=0,
-        use_deepsparse_cache=False,
         engine_type="deepsparse",
         trust_remote_code=True,
     )
@@ -65,8 +63,6 @@ def main():
         sequence_length=args.sequence_length,
         max_generated_tokens=args.max_new_tokens,
         prompt_processing_sequence_length=1,
-        sampling_temperature=0,
-        use_deepsparse_cache=False,
         engine_type="onnxruntime",
         trust_remote_code=True,
     )

--- a/examples/chat-compare/app.py
+++ b/examples/chat-compare/app.py
@@ -1,15 +1,37 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
+
 from transformers import TextStreamer
+
 from deepsparse import Pipeline
+
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Simulate an interactive text-generation interface to evaluate a model."
+        description=(
+            "Simulate an interactive text-generation interface " "to evaluate a model."
+        )
     )
     parser.add_argument(
         "model_path",
         type=str,
-        help="Path to SparseZoo stub or model directory containing model.onnx, config.json, and tokenizer.json",
+        help=(
+            "Path to SparseZoo stub or model directory containing "
+            "model.onnx, config.json, and tokenizer.json"
+        ),
     )
     parser.add_argument(
         "--max_new_tokens",
@@ -17,24 +39,34 @@ def main():
         default=16,
         help="Maximum number of new tokens to generate",
     )
+    parser.add_argument(
+        "--sequence_length",
+        type=int,
+        default=128,
+        help="Total sequence and context length",
+    )
     args = parser.parse_args()
 
     # Construct pipelines
     ds_pipe = Pipeline.create(
         task="text-generation",
         model_path=args.model_path,
+        sequence_length=args.sequence_length,
         max_generated_tokens=args.max_new_tokens,
         prompt_processing_sequence_length=1,
         use_deepsparse_cache=False,
-        engine_type="deepsparse"
+        engine_type="deepsparse",
+        trust_remote_code=True,
     )
     ort_pipe = Pipeline.create(
         task="text-generation",
         model_path=args.model_path,
+        sequence_length=args.sequence_length,
         max_generated_tokens=args.max_new_tokens,
         prompt_processing_sequence_length=1,
         use_deepsparse_cache=False,
-        engine_type="onnxruntime"
+        engine_type="onnxruntime",
+        trust_remote_code=True,
     )
 
     print("Welcome to the interactive text generation interface!")
@@ -54,7 +86,6 @@ def main():
 
         print("ORT output:")
         _ = ort_pipe(sequences=user_input, streamer=streamer)
-        
 
 
 if __name__ == "__main__":

--- a/examples/chat-compare/app.py
+++ b/examples/chat-compare/app.py
@@ -54,6 +54,7 @@ def main():
         sequence_length=args.sequence_length,
         max_generated_tokens=args.max_new_tokens,
         prompt_processing_sequence_length=1,
+        sampling_temperature=0,
         use_deepsparse_cache=False,
         engine_type="deepsparse",
         trust_remote_code=True,
@@ -64,6 +65,7 @@ def main():
         sequence_length=args.sequence_length,
         max_generated_tokens=args.max_new_tokens,
         prompt_processing_sequence_length=1,
+        sampling_temperature=0,
         use_deepsparse_cache=False,
         engine_type="onnxruntime",
         trust_remote_code=True,
@@ -81,10 +83,10 @@ def main():
 
         streamer = TextStreamer(ds_pipe.tokenizer)
 
-        print("DeepSparse output:")
+        print("\n<DeepSparse output>\n")
         _ = ds_pipe(sequences=user_input, streamer=streamer)
 
-        print("ORT output:")
+        print("\n<ORT output>\n")
         _ = ort_pipe(sequences=user_input, streamer=streamer)
 
 

--- a/examples/chat-compare/app.py
+++ b/examples/chat-compare/app.py
@@ -22,7 +22,7 @@ from deepsparse import Pipeline
 def main():
     parser = argparse.ArgumentParser(
         description=(
-            "Simulate an interactive text-generation interface " "to evaluate a model."
+            "Simulate an interactive text-generation interface to evaluate a model."
         )
     )
     parser.add_argument(
@@ -36,7 +36,7 @@ def main():
     parser.add_argument(
         "--max_new_tokens",
         type=int,
-        default=16,
+        default=64,
         help="Maximum number of new tokens to generate",
     )
     parser.add_argument(

--- a/examples/chat-compare/app.py
+++ b/examples/chat-compare/app.py
@@ -36,13 +36,13 @@ def main():
     parser.add_argument(
         "--max_new_tokens",
         type=int,
-        default=64,
+        default=128,
         help="Maximum number of new tokens to generate",
     )
     parser.add_argument(
         "--sequence_length",
         type=int,
-        default=128,
+        default=512,
         help="Total sequence and context length",
     )
     args = parser.parse_args()
@@ -52,8 +52,6 @@ def main():
         task="text-generation",
         model_path=args.model_path,
         sequence_length=args.sequence_length,
-        max_generated_tokens=args.max_new_tokens,
-        prompt_processing_sequence_length=1,
         engine_type="deepsparse",
         trust_remote_code=True,
     )
@@ -61,8 +59,7 @@ def main():
         task="text-generation",
         model_path=args.model_path,
         sequence_length=args.sequence_length,
-        max_generated_tokens=args.max_new_tokens,
-        prompt_processing_sequence_length=1,
+        prompt_sequence_length=1,
         engine_type="onnxruntime",
         trust_remote_code=True,
     )
@@ -80,10 +77,10 @@ def main():
         streamer = TextStreamer(ds_pipe.tokenizer)
 
         print("\n<DeepSparse output>\n")
-        _ = ds_pipe(sequences=user_input, streamer=streamer)
+        _ = ds_pipe(sequences=user_input, max_tokens=args.max_new_tokens, streamer=streamer)
 
         print("\n<ORT output>\n")
-        _ = ort_pipe(sequences=user_input, streamer=streamer)
+        _ = ort_pipe(sequences=user_input, max_tokens=args.max_new_tokens, streamer=streamer)
 
 
 if __name__ == "__main__":

--- a/examples/chat-compare/app.py
+++ b/examples/chat-compare/app.py
@@ -1,0 +1,61 @@
+import argparse
+from transformers import TextStreamer
+from deepsparse import Pipeline
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Simulate an interactive text-generation interface to evaluate a model."
+    )
+    parser.add_argument(
+        "model_path",
+        type=str,
+        help="Path to SparseZoo stub or model directory containing model.onnx, config.json, and tokenizer.json",
+    )
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=16,
+        help="Maximum number of new tokens to generate",
+    )
+    args = parser.parse_args()
+
+    # Construct pipelines
+    ds_pipe = Pipeline.create(
+        task="text-generation",
+        model_path=args.model_path,
+        max_generated_tokens=args.max_new_tokens,
+        prompt_processing_sequence_length=1,
+        use_deepsparse_cache=False,
+        engine_type="deepsparse"
+    )
+    ort_pipe = Pipeline.create(
+        task="text-generation",
+        model_path=args.model_path,
+        max_generated_tokens=args.max_new_tokens,
+        prompt_processing_sequence_length=1,
+        use_deepsparse_cache=False,
+        engine_type="onnxruntime"
+    )
+
+    print("Welcome to the interactive text generation interface!")
+    print("Type 'exit' to end the session.")
+
+    while True:
+        user_input = input("> ")
+
+        if user_input.lower() == "exit":
+            print("Ending the session. Goodbye!")
+            break
+
+        streamer = TextStreamer(ds_pipe.tokenizer)
+
+        print("DeepSparse output:")
+        _ = ds_pipe(sequences=user_input, streamer=streamer)
+
+        print("ORT output:")
+        _ = ort_pipe(sequences=user_input, streamer=streamer)
+        
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
```base
python app.py zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base_quant-none
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0.20230824 COMMUNITY | (9bc2d6e5) (release) (optimized) (system=avx512_vnni, binary=avx512)
Welcome to the interactive text generation interface!
Type 'exit' to end the session.
> def fib():

<DeepSparse output>

def fib():
    a, b = 0, 1
    while True:
        yield a
        a, b = b, a + b

def fib2(n):
    a, b = 0, 1
    while a < n:
        yield a
        a, b = b, a + b
        
<ORT output>

def fib():
    a, b = 0, 1
    while True:
        yield a
        a, b = b, a + b

def fib2(n):
    a, b = 0, 1
    while a < n:
        yield a
        a, b = b, a + b
```