### PR TITLE
Increase default text_generation sequence_length to 512

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -192,7 +192,10 @@ class TextGenerationPipeline(TransformersPipeline):
                 use_deepsparse_cache = False
 
         super().__init__(
-            **kwargs, sequence_length=sequence_length, _delay_engine_initialize=True, _delay_overwriting_inputs=True
+            **kwargs,
+            sequence_length=sequence_length,
+            _delay_engine_initialize=True,
+            _delay_overwriting_inputs=True,
         )
         self.enable_multitoken_prefill = self.causal_mask_input_present(
             model_path=self.onnx_file_path

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -156,6 +156,8 @@ class TextGenerationPipeline(TransformersPipeline):
         tokens until the end of the sequence is reached.
         Otherwise, it will generate up to the maximum number of tokens or end of
         sequence is reached.
+    :param sequence_length: sequence length to compile model and tokenizer for.
+        This controls the maximum context length of the pipeline. Default is 512
     :param prompt_processing_sequence_length: For large prompts, the prompt is
         processed in chunks of this length. This is to maximize the inference
         speed. By default, this is set to 64.
@@ -171,6 +173,7 @@ class TextGenerationPipeline(TransformersPipeline):
         deterministic: bool = True,
         sampling_temperature: float = 1.0,
         max_generated_tokens: Optional[int] = 1024,
+        sequence_length: int = 512,
         prompt_processing_sequence_length: int = 64,
         force_max_tokens: bool = False,
         use_deepsparse_cache: bool = True,
@@ -189,7 +192,7 @@ class TextGenerationPipeline(TransformersPipeline):
                 use_deepsparse_cache = False
 
         super().__init__(
-            **kwargs, _delay_engine_initialize=True, _delay_overwriting_inputs=True
+            **kwargs, sequence_length=sequence_length, _delay_engine_initialize=True, _delay_overwriting_inputs=True
         )
         self.enable_multitoken_prefill = self.causal_mask_input_present(
             model_path=self.onnx_file_path


### PR DESCRIPTION
The default sequence length of 128 for all transformers pipelines is uncommonly small for text generation. I chose 512 because it seemed like a good middle-ground that all models can support but isn't so large as to affect performance or memory, like 2048. Final value is open to discussion but making it an explicit top-level argument is needed IMO