### PR TITLE
[Fix][Eval Downstream] Include prompt logits in the perplexity calculation

### DIFF
--- a/src/deepsparse/transformers/metrics.py
+++ b/src/deepsparse/transformers/metrics.py
@@ -118,7 +118,10 @@ class Perplexity:
             labels = encoded_batch
 
             out = self._pipeline(
-                sequences=predictions, return_logits=True, fixed_sequences_length=True
+                sequences=predictions,
+                return_logits=True,
+                fixed_sequences_length=True,
+                include_prompt_logits=True,
             )
 
             logits = out.logits


### PR DESCRIPTION
Before: perplexity was broken
Now:

```bash
zoo:nlg/text_generation/codegen_mono-350m/pytorch/huggingface/bigpython_bigquery_thepile/base-none -d openai_humaneval

openai_humaneval eval results: {'mean_perplexity': 4.852397926896811, 'perplexities': [2.4682281017303467, 5.375603199005127, 11.334624290466309, ...
```
