### PR TITLE
[TextGeneration] max token refactor

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -376,6 +376,14 @@ class TextGenerationPipeline(TransformersPipeline):
                 "Set `max_tokens` to 1 to support that scenario."
             )
 
+        # If the num_generated_predictions > 1, check how many times each prompt given
+        # as an input was repeated. If just once, the number of generated predictions
+        # for that particular prompt is equal to num_generated_predictions. This is done
+        # by repeating the prompt num_generated_predictions times If that
+        # prompt was given as an input multiple times, ignore the value of
+        # num_generated_predictions and produce n predictions, where n is the number of
+        # times the prompt was given as an input. Also, update the engine so that
+        # deterministic is set to False.
         if inputs.num_generated_predictions > 1:
             counter = Counter(inputs.sequences)
             repeated_seq = []

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -64,7 +64,7 @@ class TextGenerationInput(BaseModel):
         description="The number of text generations to create from a single prompt. If "
         "the same sequence is given as an input multiple times, the number of generated"
         "the number of generated predictins is equivalent to the number of times the "
-        "the sequence is repeated."
+        "the sequence is repeated.",
     )
     max_tokens: int = Field(
         default=1024,

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -385,6 +385,8 @@ class TextGenerationPipeline(TransformersPipeline):
         # times the prompt was given as an input. Also, update the engine so that
         # deterministic is set to False.
         if inputs.num_generated_predictions > 1:
+            if isinstance(inputs.sequences, str):
+                inputs.sequences = [inputs.sequences]
             counter = Counter(inputs.sequences)
             repeated_seq = []
             for seq in inputs.sequences:

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -375,14 +375,9 @@ class TextGenerationPipeline(TransformersPipeline):
                 "Set `max_tokens` to 1 to support that scenario."
             )
 
-        # If the num_generated_predictions > 1, check how many times each prompt given
-        # as an input was repeated. If just once, the number of generated predictions
-        # for that particular prompt is equal to num_generated_predictions. This is done
-        # by repeating the prompt num_generated_predictions times. If that
-        # prompt was given as an input multiple times, ignore the value of
-        # num_generated_predictions and produce n predictions, where n is the number of
-        # times the prompt was given as an input. Also, update the engine so that
-        # deterministic is set to False.
+        # If the num_generated_predictions > 1, repeat the prompt
+        # num_generated_predictions times. Also, update the engine so that deterministic
+        # is set to False.
         if inputs.num_generated_predictions > 1:
             if isinstance(inputs.sequences, str):
                 inputs.sequences = [inputs.sequences]

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -55,7 +55,7 @@ class TextGenerationInput(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
-    sequences: Union[str, List[str], List[List[str]]] = Field(
+    sequences: Union[str, List[str]] = Field(
         description="The input sequences to generate the text from.",
     )
     num_generated_predictions: int = Field(
@@ -123,7 +123,7 @@ class TextGenerationInput(BaseModel):
 
 
 class TextGenerationOutput(BaseModel):
-    sequences: Union[str, List[str]] = Field(
+    sequences: Union[str, List[str], List[List[str]]] = Field(
         description="The generated text sequences.",
     )
     logits: Optional[Any] = Field(  # numpy array, set to Any for FastAPI compatibility

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -61,7 +61,10 @@ class TextGenerationInput(BaseModel):
     )
     num_generated_predictions: int = Field(
         default=1,
-        description="The number of text generations to create from a single prompt",
+        description="The number of text generations to create from a single prompt. If "
+        "the same sequence is given as an input multiple times, the number of generated"
+        "the number of generated predictins is equivalent to the number of times the "
+        "the sequence is repeated."
     )
     max_tokens: int = Field(
         default=1024,

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -16,7 +16,6 @@ import logging
 import os
 import warnings
 from collections import Counter
-
 from typing import (
     Any,
     Callable,

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -173,7 +173,6 @@ class TextGenerationPipeline(TransformersPipeline):
         self,
         deterministic: bool = True,
         sampling_temperature: float = 1.0,
-        max_generated_tokens: Optional[int] = 1024,
         prompt_sequence_length: int = 64,
         sequence_length: int = 512,
         force_max_tokens: bool = False,
@@ -214,7 +213,6 @@ class TextGenerationPipeline(TransformersPipeline):
 
         self.deterministic = deterministic
         self.sampling_temperature = sampling_temperature
-        self.max_generated_tokens = max_generated_tokens
         self.prompt_sequence_length = prompt_sequence_length
         self.force_max_tokens = force_max_tokens
         self.internal_kv_cache = internal_kv_cache

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import uuid
+from collections import Counter
 from typing import List, Union
 
 import numpy
@@ -22,6 +23,7 @@ __all__ = [
     "generate_session_id",
     "pad_to_fixed_length",
     "create_causal_mask",
+    "repeat_inputs",
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,6 +36,29 @@ def generate_session_id() -> str:
     """
     session_id = str(uuid.uuid4())
     return session_id
+
+
+def repeat_inputs(
+    input_sequences: List[str], num_generated_predictions: int
+) -> List[str]:
+    """
+    :param input_sequences: List of input sequences to repeat
+    :param num_generated_predictions: number of times to repeat each sequence
+
+    :return: a list of input sequences, where sequences have been repeated
+        num_generated_predictions times if the sequence appears in input_sequences just
+        once. If the sequence appears multiple times in input_sequences, the
+        num_generated_predictions for the sequence is ignored.
+    """
+    counter = Counter(input_sequences)
+    repeated_seq = []
+
+    for seq in input_sequences:
+        if counter[seq] == 1:
+            repeated_seq.extend(numpy.repeat([seq], num_generated_predictions))
+        else:
+            repeated_seq.append(seq)
+    return repeated_seq
 
 
 def pad_to_fixed_length(

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import logging
 import uuid
-from collections import Counter
 from typing import List, Union
 
 import numpy
@@ -50,14 +49,10 @@ def repeat_inputs(
         once. If the sequence appears multiple times in input_sequences, the
         num_generated_predictions for the sequence is ignored.
     """
-    counter = Counter(input_sequences)
     repeated_seq = []
 
     for seq in input_sequences:
-        if counter[seq] == 1:
-            repeated_seq.extend(numpy.repeat([seq], num_generated_predictions))
-        else:
-            repeated_seq.append(seq)
+        repeated_seq.extend(numpy.repeat([seq], num_generated_predictions))
     return repeated_seq
 
 

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -144,7 +144,14 @@ class TestTextGenerationPipeline:
             sequences=[short_prompt], num_generated_predictions=2
         )
 
+        assert len(output_sequences.sequences[0]) == 2
+
+        output_sequences = pipeline(
+            sequences=[short_prompt, short_prompt], num_generated_predictions=2
+        )
         assert len(output_sequences.sequences) == 2
+        for sequences in output_sequences.sequences:
+            assert len(sequences) == 2
 
     def test_model_output_cache(self, setup):
         pipeline, model_name, _, short_prompt, long_prompt = setup


### PR DESCRIPTION
For this ticket: 

https://app.asana.com/0/1201735099598270/1205276886236972/f

### Summary:
- Refactors the TextGeneration Constructor to remove the `max_tokens` argument and makes it part of the pipeline input
- Adds `num_generated_predictions` to the input as well, which dictates the number of sequences that are generated for a given input. Similar to the hugging face implementation, we repeat the input based on the number provided, defaulting to 1. When `num_generated_predictions` is > 1,  the engine's `deterministic` property is togged to False
- In the case where the value is > 1, the output is a list of lists, where each list includes the generated sequences for a given prompt. This updates the sequences output to be one of `str, List[str], and List[List[str]]`

### Testing
- Tested locally using the new input arguments
- Also added new tests to evaluate the `num_generated_predictions`