### PR TITLE
[server] pin anyio support to <4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ _server_deps = [
     "python-multipart>=0.0.5",
     "prometheus-client>=0.14.1",
     "psutil>=5.9.4",
+    "anyio<4.0.0",
 ]
 _onnxruntime_deps = [
     "onnxruntime>=1.7.0",


### PR DESCRIPTION
this is for compatibility with the maximum currently allowed version of `starlette`. `anyio` just pushed a 4.0.0 that is incompatible with earlier versions of `starlette`. 

Note that this is now fixed in later versions (`deepsparse` has not yet tested against newer versions of `fastapi` and `starlette`). See: https://github.com/encode/starlette/pull/1936


from internal bug report:
```
Our Deepsparse GHA is failing with starlette error: AttributeError: module 'anyio' has no attribute 'start_blocking_portal'
```