### PR TITLE
Remove dependency on trust-remote-code

### DIFF
--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, List, Mapping, Optional, Union
 
 import numpy
 import transformers
-from transformers.models.auto import AutoConfig, AutoTokenizer
+from transformers.models.auto import AutoTokenizer
 
 from deepsparse import Bucketable, Pipeline
 from deepsparse.transformers.helpers import (
@@ -154,28 +154,16 @@ class TransformersPipeline(Pipeline, Bucketable):
             else:
                 self.config_path = os.path.join(self.config, "config.json")
 
-            old_config = AutoConfig.from_pretrained(
-                self.config,
-                trust_remote_code=self._trust_remote_code,
-                finetuning_task=self.task if hasattr(self, "task") else None,
-            )
-
-            new_config = transformers.PretrainedConfig.from_pretrained(
+            self.config = transformers.PretrainedConfig.from_pretrained(
                 self.config,
                 finetuning_task=self.task if hasattr(self, "task") else None,
             )
-
-            print(new_config)
-            print(old_config)
-            exit()
-
 
         if isinstance(self.tokenizer, (str, Path)):
             self.tokenizer_config_path = os.path.join(self.tokenizer, "tokenizer.json")
 
             self.tokenizer = AutoTokenizer.from_pretrained(
                 self.tokenizer,
-                trust_remote_code=self._trust_remote_code,
                 model_max_length=self.sequence_length,
             )
 

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -70,10 +70,6 @@ class TransformersPipeline(Pipeline, Bucketable):
         If a list of lengths is provided, then for each length, a model and
         tokenizer will be compiled capable of handling that sequence length
         (also known as a bucket). Default is 128
-    :param trust_remote_code: if True, will trust remote code. This option
-        should only be set to `True` for repositories you trust and in which
-        you have read the code, as it will execute possibly unsafe code
-        on your local machine. Default is False
     :param config: hugging face transformers model config. Can be a path to the config,
         a dictionary with the config values, a transformers.PretrainedConfig, or None.
         If a directory is provided, it is assumed that the file is named config.json.
@@ -89,14 +85,12 @@ class TransformersPipeline(Pipeline, Bucketable):
         self,
         *,
         sequence_length: Union[int, List[int]] = 128,
-        trust_remote_code: bool = False,
         config: Union[str, Path, Dict, transformers.PretrainedConfig] = None,
         tokenizer: Union[str, Path, transformers.PreTrainedTokenizerBase] = None,
         **kwargs,
     ):
 
         self._sequence_length = sequence_length
-        self._trust_remote_code = trust_remote_code
 
         self.config = config
         self.tokenizer = tokenizer

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -132,7 +132,6 @@ class TransformersPipeline(Pipeline, Bucketable):
         """
         onnx_path = get_onnx_path(self.model_path)
 
-        print(self.config)
         if not self.config or not self.tokenizer:
             config_found, tokenizer_found = get_hugging_face_configs(self.model_path)
             if config_found:
@@ -140,14 +139,12 @@ class TransformersPipeline(Pipeline, Bucketable):
             if tokenizer_found:
                 self.tokenizer = tokenizer_found
 
-        print(self.config)
         if isinstance(self.config, dict):
             local_config_path = os.path.join(self.model_path, "config.json")
             with open(local_config_path, "w") as f:
                 json.dump(self.config, f)
             self.config = local_config_path
 
-        print(self.config)
         if isinstance(self.config, (str, Path)):
             if str(self.config).endswith(".json"):
                 self.config_path = self.config

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -70,6 +70,10 @@ class TransformersPipeline(Pipeline, Bucketable):
         If a list of lengths is provided, then for each length, a model and
         tokenizer will be compiled capable of handling that sequence length
         (also known as a bucket). Default is 128
+    :param trust_remote_code: if True, will trust remote code. This option
+        should only be set to `True` for repositories you trust and in which
+        you have read the code, as it will execute possibly unsafe code
+        on your local machine. Default is False
     :param config: hugging face transformers model config. Can be a path to the config,
         a dictionary with the config values, a transformers.PretrainedConfig, or None.
         If a directory is provided, it is assumed that the file is named config.json.
@@ -85,12 +89,14 @@ class TransformersPipeline(Pipeline, Bucketable):
         self,
         *,
         sequence_length: Union[int, List[int]] = 128,
+        trust_remote_code: bool = False,
         config: Union[str, Path, Dict, transformers.PretrainedConfig] = None,
         tokenizer: Union[str, Path, transformers.PreTrainedTokenizerBase] = None,
         **kwargs,
     ):
 
         self._sequence_length = sequence_length
+        self._trust_remote_code = trust_remote_code
 
         self.config = config
         self.tokenizer = tokenizer
@@ -155,6 +161,7 @@ class TransformersPipeline(Pipeline, Bucketable):
 
             self.tokenizer = AutoTokenizer.from_pretrained(
                 self.tokenizer,
+                trust_remote_code=self._trust_remote_code,
                 model_max_length=self.sequence_length,
             )
 

--- a/src/deepsparse/transformers/pipelines/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/pipeline.py
@@ -132,6 +132,7 @@ class TransformersPipeline(Pipeline, Bucketable):
         """
         onnx_path = get_onnx_path(self.model_path)
 
+        print(self.config)
         if not self.config or not self.tokenizer:
             config_found, tokenizer_found = get_hugging_face_configs(self.model_path)
             if config_found:
@@ -139,23 +140,35 @@ class TransformersPipeline(Pipeline, Bucketable):
             if tokenizer_found:
                 self.tokenizer = tokenizer_found
 
+        print(self.config)
         if isinstance(self.config, dict):
             local_config_path = os.path.join(self.model_path, "config.json")
             with open(local_config_path, "w") as f:
                 json.dump(self.config, f)
             self.config = local_config_path
 
+        print(self.config)
         if isinstance(self.config, (str, Path)):
             if str(self.config).endswith(".json"):
                 self.config_path = self.config
             else:
                 self.config_path = os.path.join(self.config, "config.json")
 
-            self.config = AutoConfig.from_pretrained(
+            old_config = AutoConfig.from_pretrained(
                 self.config,
                 trust_remote_code=self._trust_remote_code,
                 finetuning_task=self.task if hasattr(self, "task") else None,
             )
+
+            new_config = transformers.PretrainedConfig.from_pretrained(
+                self.config,
+                finetuning_task=self.task if hasattr(self, "task") else None,
+            )
+
+            print(new_config)
+            print(old_config)
+            exit()
+
 
         if isinstance(self.tokenizer, (str, Path)):
             self.tokenizer_config_path = os.path.join(self.tokenizer, "tokenizer.json")


### PR DESCRIPTION
This PR is motivated to remove the dependency on the "trust-remote-code" argument for deepsparse transformers pipelines.

In addition to an additional flag, this argument also meant that custom scripts needed for the PyTorch definition of models needed to be carried over in the deployment folder, even though the PyTorch definition is not needed for deepsparse inference.

The dependency was introduced by using the AutoConfig class to load the model config. This PR replaces this with PretrainedConfig instead. AutoConfig is a class that wraps PretrainedConfig and does additional checks to guarantee that the loaded config matches what the model definition uses. By doing this replacement these checks are skipped and the model definitions is not needed any longer.

### Testing plan
 
 The model config at this moment is only used in the text-classification and token-classification pipelines. To validate this PR I evaluated accuracy on these pipelines and verified that it is the same as before. Here are the commands used for testing:

- `deepsparse.transformers.eval_downstream zoo:nlp/token_classification/obert-base/pytorch/huggingface/conll2003/pruned90_quant-none -d conll2003`

- `deepsparse.transformers.eval_downstream zoo:nlp/multilabel_text_classification/obert-base/pytorch/huggingface/goemotions/pruned90_quant-none -d go_emotions`

- `deepsparse.transformers.eval_downstream zoo:nlp/text_classification/obert-base/pytorch/huggingface/mnli/pruned90_quant-none -d mnli`

- `deepsparse.transformers.eval_downstream zoo:nlp/text_classification/obert-base/pytorch/huggingface/qqp/pruned90_quant-none -d qqp`

### Update

@mgoin Pointed out that some models (e.g., replit) can have custom tokenizers and thus trust_remote_code would still be needed for the tokenizer. Hence, updated the code to only remove the argument from the config loading, but still keep it around for the tokenizer.