### PR TITLE
Update CLI test validation

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -27,8 +27,6 @@ def test_benchmark_help():
         print(f"\n==== test_benchmark_help output ====\n{res.stdout}")
     assert res.returncode == 0
     assert "usage: deepsparse.benchmark" in res.stdout
-    assert "error" not in res.stdout.lower()
-    assert "fail" not in res.stdout.lower()
 
 
 @pytest.mark.parametrize(
@@ -90,8 +88,6 @@ def test_benchmark(
     if res.stdout is not None:
         print(f"\n==== test_benchmark output ====\n{res.stdout}")
     assert res.returncode == 0
-    assert "error" not in res.stdout.lower()
-    assert "fail" not in res.stdout.lower()
 
     # if passing -q, check that some logging is excluded
     if "-q" in cmd:
@@ -121,5 +117,3 @@ def test_benchmark_local(model_stub: str):
     if res.stdout is not None:
         print(f"\n==== test_benchmark_local output ====\n{res.stdout}")
     assert res.returncode == 0
-    assert "error" not in res.stdout.lower()
-    assert "fail" not in res.stdout.lower()

--- a/tests/test_check_hardware.py
+++ b/tests/test_check_hardware.py
@@ -26,8 +26,6 @@ def test_check_hardware():
         print(f"\n==== deepsparse.check_hardware output ====\n{res.stdout}")
 
     assert res.returncode == 0, "command exited with non-zero status"
-    assert "error" not in res.stdout.lower()
-    assert "fail" not in res.stdout.lower()
 
     # check for (static portions of) expected lines
     assert "DeepSparse FP32 model performance supported:" in res.stdout

--- a/tests/test_pipeline_benchmark.py
+++ b/tests/test_pipeline_benchmark.py
@@ -95,8 +95,6 @@ def test_pipeline_benchmark(
     if res.stdout is not None:
         print(f"\n==== test_benchmark output ====\n{res.stdout}")
     assert res.returncode == 0
-    assert "error" not in res.stdout.lower()
-    assert "fail" not in res.stdout.lower()
     assert "total_inference" in res.stdout.lower()
 
 


### PR DESCRIPTION
This PR updates the validation of CLI command tests. The checks for things like "error" or "failure" in the command output are problematic because they can simply be part of a log message/warning that ultimately does not impact the success of the command being run. For more involved validation, output messages/files should be verified. Recently, some output seemingly from `transformers` has, for example, included the word “error” which caused test failures.

Additionally, this fleshes out some validation for one of the commands that was previously commented out.