### PR TITLE
[TextGeneration] Update pipeline inputs to support GenerationConfig

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -282,7 +282,14 @@ class Pipeline(BasePipeline):
             # ------ POSTPROCESSING ------
             timer.start(InferenceStages.POST_PROCESS)
             pipeline_outputs = self.process_engine_outputs(engine_outputs, **context)
+<<<<<<< HEAD
             if not isinstance(pipeline_outputs, (self.output_schema, Generator)):
+=======
+            if not (
+                isinstance(pipeline_outputs, self.output_schema)
+                or isinstance(pipeline_outputs, Generator)
+            ):
+>>>>>>> update pipeline.py
                 raise ValueError(
                     f"Outputs of {self.__class__} must be instances of "
                     f"{self.output_schema} found output of type "

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -282,14 +282,7 @@ class Pipeline(BasePipeline):
             # ------ POSTPROCESSING ------
             timer.start(InferenceStages.POST_PROCESS)
             pipeline_outputs = self.process_engine_outputs(engine_outputs, **context)
-<<<<<<< HEAD
             if not isinstance(pipeline_outputs, (self.output_schema, Generator)):
-=======
-            if not (
-                isinstance(pipeline_outputs, self.output_schema)
-                or isinstance(pipeline_outputs, Generator)
-            ):
->>>>>>> update pipeline.py
                 raise ValueError(
                     f"Outputs of {self.__class__} must be instances of "
                     f"{self.output_schema} found output of type "

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -78,7 +78,7 @@ class TextGenerationInput(BaseModel):
         "the sequence is repeated.",
     )
     max_tokens: int = Field(
-        default=1024,
+        default=100,
         description="Maximum number of tokens to generate per output sequence. If no "
         "value is provided, will default to 1024.",
     )

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -128,8 +128,6 @@ class TextGenerationInput(BaseModel):
         " Default set to 0.0",
     )
 
-    # TODO: what about the other parameters? Such as special tokens, which are just
-    # taken from the tokenizer?
     generation_config: Union[None, str, pathlib.Path, Dict, GenerationConfig] = Field(
         default=None,
         description="GenerationConfig file consisting of parameters used to control "

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -78,7 +78,7 @@ class TextGenerationInput(BaseModel):
         "the sequence is repeated.",
     )
     max_tokens: int = Field(
-        default=1024,
+        default=100,
         description="Maximum number of tokens to generate per output sequence. If no "
         "value is provided, will default to 1024.",
     )
@@ -268,6 +268,7 @@ class TextGenerationPipeline(TransformersPipeline):
             self.tokenizer.pad_token = self.tokenizer.eos_token
 
         self.engine, self.multitoken_engine = self.initialize_engines()
+        self.streaming = False
 
         # auxiliary flag for devs to enable debug mode for the pipeline
         self._debug = False
@@ -410,6 +411,7 @@ class TextGenerationPipeline(TransformersPipeline):
         :param inputs: the input schema for the pipeline
         :return: the inputs for the engine
         """
+        self.streaming = inputs.streaming
         if not self.cache_support_enabled and inputs.max_tokens > 1:
             raise ValueError(
                 "The model used for inference does not support kv cache. It is "

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -680,6 +680,7 @@ class TextGenerationPipeline(TransformersPipeline):
                         finished_reason.append(FinishReason.STOP)
                         break
 
+                    # TODO: Add any generic callback reason?
                     if callback is not None and callback(token) is False:
                         _LOGGER.debug(
                             "callback %s returned False, stopping generation."

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -78,7 +78,7 @@ class TextGenerationInput(BaseModel):
         "the sequence is repeated.",
     )
     max_tokens: int = Field(
-        default=100,
+        default=1024,
         description="Maximum number of tokens to generate per output sequence. If no "
         "value is provided, will default to 1024.",
     )

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -268,7 +268,6 @@ class TextGenerationPipeline(TransformersPipeline):
             self.tokenizer.pad_token = self.tokenizer.eos_token
 
         self.engine, self.multitoken_engine = self.initialize_engines()
-        self.streaming = False
 
         # auxiliary flag for devs to enable debug mode for the pipeline
         self._debug = False
@@ -411,7 +410,6 @@ class TextGenerationPipeline(TransformersPipeline):
         :param inputs: the input schema for the pipeline
         :return: the inputs for the engine
         """
-        self.streaming = inputs.streaming
         if not self.cache_support_enabled and inputs.max_tokens > 1:
             raise ValueError(
                 "The model used for inference does not support kv cache. It is "

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -739,7 +739,6 @@ class TextGenerationPipeline(TransformersPipeline):
                         finished_reason.append(FinishReason.STOP)
                         break
 
-                    # TODO: Add any generic callback reason?
                     if callback is not None and callback(token) is False:
                         _LOGGER.debug(
                             "callback %s returned False, stopping generation."

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -16,7 +16,7 @@ import datetime
 import json
 import logging
 import os
-import pathlib.Path
+import pathlib
 import warnings
 from enum import Enum
 from typing import (
@@ -262,7 +262,7 @@ class TextGenerationPipeline(TransformersPipeline):
         if self.generation_config:
             _LOGGER.info(
                 "Generation config provided for pipline. This will be used "
-                "for all inputs unless and input-specific config is provided. "
+                "for all inputs unless an input-specific config is provided. "
             )
 
     def initialize_engines(
@@ -451,13 +451,13 @@ class TextGenerationPipeline(TransformersPipeline):
                 generation_config = self.generation_config
         else:
             _LOGGER.info(
-                "Input generation config detection. This will override any "
-                " config provided during pipeline creation for this input."
+                "Input generation config detected. This will override any"
+                " config provided during pipeline creation."
             )
 
         if not generation_config:
             _LOGGER.info(
-                " No GenerationConfig detected. Using default generation values"
+                " No GenerationConfig detected. Using GenerationDefaults values"
             )
             generation_config = GenerationDefaults()
 

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import logging
+import os
+import pathlib
 import uuid
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -19,6 +22,9 @@ import numpy
 from transformers import AutoTokenizer
 
 from deepsparse.utils.onnx import CACHE_INPUT_PREFIX, CACHE_OUTPUT_PREFIX
+
+import numpy
+from transformers import GenerationConfig
 
 
 __all__ = [
@@ -28,6 +34,9 @@ __all__ = [
     "repeat_inputs",
     "initialize_kv_cache_state",
     "prepends_bos_token",
+    "check_and_return_generation_config",
+    "override_config",
+    "process_generation_config",
 ]
 
 _LOGGER = logging.getLogger(__name__)
@@ -106,6 +115,120 @@ def generate_session_id() -> str:
     """
     session_id = str(uuid.uuid4())
     return session_id
+
+
+def process_generation_config(
+    generation_config: Union[None, str, pathlib.Path, Dict, GenerationConfig]
+) -> Union[GenerationConfig, None]:
+    """
+    Process and return a GenerationConfig. The function can take in a filepath
+    pointing to a json consisting of the config values, a dictionary with the config
+    values, or a loaded GenerationConfig object. If None is given, the defaults are,
+    the pipeline GenerationConfig is used, if provided. If both are None, default
+    are used for generation.
+
+    :param generation_config: either a json filepath, dictionary or loaded
+    GenerationConfig object
+
+    :return: GenerationConfig object or None
+
+    """
+    if isinstance(generation_config, GenerationConfig):
+        return generation_config
+
+    if not generation_config:
+        return None
+
+    # TODO: move to tmp folder
+    if isinstance(generation_config, dict):
+        config_dir = os.getcwd()
+        config_name = "generation_config.json"
+        local_config_path = os.path.join(config_dir, config_name)
+        _LOGGER.info(
+            "Dictionary provided for the generation config. Creating temporary "
+            " generation_config.json"
+        )
+        with open(local_config_path, "w") as f:
+            json.dump(generation_config, f)
+
+    if isinstance(generation_config, (str, pathlib.Path)):
+        generation_config = pathlib.Path(generation_config)
+        config_dir = generation_config.parent.absolute()
+        config_name = generation_config.name
+
+    generation_config = GenerationConfig.from_pretrained(config_dir, config_name)
+    return generation_config
+
+
+def check_and_return_generation_config(
+    pipeline_generation_config: [None, str, pathlib.Path, Dict, GenerationConfig],
+    input_generation_config: [None, str, pathlib.Path, Dict, GenerationConfig],
+    defaults: "GenerationDefaults",  # noqa F821
+) -> Union[GenerationConfig, None]:
+    """
+    Check if an input generation config is provided. If not, check if a pipeline
+    generation config exists. If neither exists, use the defualt generation configs,
+    either deespsparse defaults or hugging face defaults. If a pipeline config exists
+    and an input config exists, use the input config.
+
+    :param pipeline_generation_config: either a json filepath, dictionary or loaded
+    GenerationConfig object provided by the user during pipeline creation
+    :param input_generation_config: either a json filepath, dictionary or loaded
+    GenerationConfig object provided by the user during inference
+    :param defaults: defaults to use for the GenerationConfig if a config is not
+    provided during inference or pipeline creation.
+
+    :return: GenerationConfig object or None
+
+    """
+    generation_config = process_generation_config(input_generation_config)
+    if generation_config is None:
+        if pipeline_generation_config:
+            generation_config = pipeline_generation_config
+    else:
+        _LOGGER.info(
+            "Input generation config detected. This will override any"
+            " config provided during pipeline creation."
+        )
+
+    if not generation_config:
+        _LOGGER.info(" No GenerationConfig detected. Using GenerationDefaults values")
+        generation_config = defaults
+    return generation_config
+
+
+def override_config(
+    overrides: Optional[Dict], generation_config: GenerationConfig
+) -> GenerationConfig:
+    """
+    Override any generation config properties using the `kwargs` argument in
+    TextGenerationInput. If None, the generation config is returned unchanged.
+    If provided, update all attribute stored in the dictionary. An errror will be
+    raised if the dictionary contains an key which is not a GenerationConfig
+    attribute.
+
+    :param overrides: dictionary containing GenerationConfig attributes to update
+    :param generation_config: GenerationConfig to update
+
+    :return: GenerationConfig object
+
+
+    """
+    if overrides is None:
+        return generation_config
+
+    for k, v in overrides.items():
+        try:
+            if getattr(generation_config, k):
+                setattr(generation_config, k, v)
+                _LOGGER.info(f"Overriding attribute {k} in the generation config")
+        except AttributeError as exception:
+            raise AttributeError(
+                "Argument provided for GenerationConfig is not "
+                "valid. Refer to the TextGenerationInput for supported attributes. "
+            ) from exception
+
+    return generation_config
 
 
 def repeat_inputs(

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -19,12 +19,9 @@ import uuid
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, GenerationConfig
 
 from deepsparse.utils.onnx import CACHE_INPUT_PREFIX, CACHE_OUTPUT_PREFIX
-
-import numpy
-from transformers import GenerationConfig
 
 
 __all__ = [

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -411,20 +411,12 @@ class TestTextGenerationPipeline:
         output_sequences = pipeline(
             sequences=[self.prompt], num_generated_predictions=2
         )
-<<<<<<< HEAD
-=======
-
->>>>>>> fix tests
         assert len(output_sequences.generations) == 1
         assert len(output_sequences.generations[0]) == 2
 
         output_sequences = pipeline(
             sequences=[self.prompt, self.prompt], num_generated_predictions=2
         )
-<<<<<<< HEAD
-=======
-
->>>>>>> fix tests
         assert len(output_sequences.generations) == 2
 
         for generation in output_sequences.generations:

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -411,12 +411,20 @@ class TestTextGenerationPipeline:
         output_sequences = pipeline(
             sequences=[self.prompt], num_generated_predictions=2
         )
+<<<<<<< HEAD
+=======
+
+>>>>>>> fix tests
         assert len(output_sequences.generations) == 1
         assert len(output_sequences.generations[0]) == 2
 
         output_sequences = pipeline(
             sequences=[self.prompt, self.prompt], num_generated_predictions=2
         )
+<<<<<<< HEAD
+=======
+
+>>>>>>> fix tests
         assert len(output_sequences.generations) == 2
 
         for generation in output_sequences.generations:

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -411,14 +411,12 @@ class TestTextGenerationPipeline:
         output_sequences = pipeline(
             sequences=[self.prompt], num_generated_predictions=2
         )
-
         assert len(output_sequences.generations) == 1
         assert len(output_sequences.generations[0]) == 2
 
         output_sequences = pipeline(
             sequences=[self.prompt, self.prompt], num_generated_predictions=2
         )
-
         assert len(output_sequences.generations) == 2
 
         for generation in output_sequences.generations:

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -15,6 +15,7 @@
 from typing import List, Optional, Tuple
 
 import numpy
+from transformers import GenerationConfig
 
 import pytest
 from deepsparse import Pipeline
@@ -175,11 +176,13 @@ class TestTextGenerationPipeline:
             engine_type="onnxruntime",
         )
         pipeline._debug = True
+
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
+
         output = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
         assert output.total_num_processed_tokens[0] < self.sequence_length
         self._test_output(
@@ -207,11 +210,11 @@ class TestTextGenerationPipeline:
             engine_type="onnxruntime",
         )
         pipeline._debug = True
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
         output = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
 
         assert output.total_num_processed_tokens[0] < self.sequence_length
@@ -241,11 +244,12 @@ class TestTextGenerationPipeline:
             engine_type="onnxruntime",
         )
         pipeline._debug = True
+
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
         output = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
 
         assert output.total_num_processed_tokens[0] > self.sequence_length_short, (
@@ -276,11 +280,11 @@ class TestTextGenerationPipeline:
             internal_kv_cache=self.internal_kv_cache,
         )
         pipeline._debug = True
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
         output = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
 
         assert output.total_num_processed_tokens[0] < self.sequence_length
@@ -307,11 +311,11 @@ class TestTextGenerationPipeline:
         )
         pipeline._debug = True
 
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
         output = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
 
         assert output.total_num_processed_tokens[0] < self.sequence_length
@@ -337,11 +341,11 @@ class TestTextGenerationPipeline:
             internal_kv_cache=self.internal_kv_cache,
         )
         pipeline._debug = True
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
         output = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
 
         assert output.total_num_processed_tokens[0] > self.sequence_length_short, (
@@ -361,18 +365,16 @@ class TestTextGenerationPipeline:
         # Test the scenario, where the same prompt is run multiple times
         # Every run should produce the same output
         pipeline = self.get_pipeline()
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
 
         output_1 = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
+
         output_2 = pipeline(
-            sequences=self.prompt,
-            return_logits=True,
-            include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
+            sequences=self.prompt, include_prompt_logits=True, generation_config=config
         )
 
         assert output_1.generations[0].text == output_2.generations[0].text
@@ -387,11 +389,13 @@ class TestTextGenerationPipeline:
         # Same two prompts should produce the same output
         pipeline = self.get_pipeline()
 
+        config = GenerationConfig(
+            output_scores=True, max_length=self.num_tokens_generate
+        )
         output = pipeline(
             sequences=[self.prompt, self.prompt],
-            return_logits=True,
+            generation_config=config,
             include_prompt_logits=True,
-            max_tokens=self.num_tokens_generate,
         )
 
         logits_0 = output.generations[0].score
@@ -408,14 +412,16 @@ class TestTextGenerationPipeline:
         # from the same prompt
         pipeline = self.get_pipeline()
 
-        output_sequences = pipeline(
-            sequences=[self.prompt], num_generated_predictions=2
+        config = GenerationConfig(
+            num_return_sequences=2, max_length=self.num_tokens_generate
         )
+
+        output_sequences = pipeline(sequences=[self.prompt], generation_config=config)
         assert len(output_sequences.generations) == 1
         assert len(output_sequences.generations[0]) == 2
 
         output_sequences = pipeline(
-            sequences=[self.prompt, self.prompt], num_generated_predictions=2
+            sequences=[self.prompt, self.prompt], generation_config=config
         )
         assert len(output_sequences.generations) == 2
 


### PR DESCRIPTION
## Summary:

- Update the input to the pipeline to support a `transformers.GenerationConfig`. This will essentially be used in replacement of many of the inputs that we provide as separate fields (such as `num_return_sequences`, `top_k`, etc).
- Supports path to a json with the config file, dictionary, or `transformers.GenerationConfig` object
- The user can provide the config either on the pipeline level or the input level. If an input level config is provided, it will override the pipeline level config and be used for generation. Otherwise, the one provided during pipeline creation will be used. If neither are given, defaults set in the `GenerationDefaults` class will be used
- If the user provides a generation config, either on the pipeline level or on the input level but not all the values are set, then the defaults given by `GenerationConfig` will be used for the missing values, not the `GenerationDefaults` class. 

## Test Cases 

### Dictionary:

```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime"
)
generation_config = {
   "num_return_sequences": 2,
   "max_length": 100

}
inference = pipeline(sequences=["hello?", "cool"], generation_config=generation_config)
print(next(inference))
```

### string or Path

```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime"
)
generation_config_path = "/home/dsikka/llama_run/current_config.json"
inference = pipeline(sequences=["hello?", "cool"], generation_config=generation_config_path)
print(next(inference))

```

### `GenerationConfig` object

```python
from deepsparse import Pipeline
from pathlib import Path
from transformers import GenerationConfig

pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime"
)

generation_config_obj = GenerationConfig(
   num_return_sequences=3,
   max_length=100,
   output_scores=True
)
inference = pipeline(sequences=["hello?", "cool"], generation_config=generation_config_obj)
print(next(inference))

```

### `None` - no generation config is provided, will use the `GenerationDefaults` instead

```python
from deepsparse import Pipeline
from pathlib import Path
from transformers import GenerationConfig

pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime"
)

inference = pipeline(sequences=["hello?", "cool"])
for out in inference:
   print(out)
   print("\n")
```

### Set `GenerationConfig` on the pipeline level
- The config set will be used for each pipeline input used

```python
from deepsparse import Pipeline
from pathlib import Path
from transformers import GenerationConfig

generation_config_obj = GenerationConfig(
   num_return_sequences=3,
   max_length=100,
)

pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime",
   generation_config=generation_config_obj
)

inference = pipeline(sequences=["hello?"])
for out in inference:
   print(out)
   print("\n")

inference = pipeline(sequences=["cool"])
for out in inference:
   print(out)
   print("\n")

```

- Output 3 text generations per prompt, as set by the pipeline-level config

```
2023-09-19 11:31:14 deepsparse.transformers.pipelines.text_generation INFO     Generation config provided for pipline. This will be used for all inputs unless and input-specific config is provided. 
created=datetime.datetime(2023, 9, 19, 11, 32, 43, 387168) prompts=['hello?'] generations=[[GeneratedText(text='\n\nI am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am', score=None, finished=True, finished_reason='length'), GeneratedText(text='\n\nI am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am', score=None, finished=True, finished_reason='length'), GeneratedText(text='\n\nI am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am', score=None, finished=True, finished_reason='length')]] session_id=None


created=datetime.datetime(2023, 9, 19, 11, 32, 54, 414539) prompts=['cool'] generations=[[GeneratedText(text=", i'll be there.\nI'll be there too.", score=None, finished=True, finished_reason='stop'), GeneratedText(text=", i'll be there.\nI'll be there too.", score=None, finished=True, finished_reason='stop'), GeneratedText(text=", i'll be there.\nI'll be there too.", score=None, finished=True, finished_reason='stop')]] session_id=None
```


### Set `GenerationConfig` on the pipeline level, override on the input level

```python
from deepsparse import Pipeline
from pathlib import Path
from transformers import GenerationConfig

generation_config_obj = GenerationConfig(
   num_return_sequences=3,
   max_length=100,
)

pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime",
   generation_config=generation_config_obj
)

generation_config_obj_input = GenerationConfig(
   num_return_sequences=2,
   max_length=50,
)


inference = pipeline(sequences=["hello?"], generation_config=generation_config_obj_input)
for out in inference:
   print(out)
   print("\n")

inference = pipeline(sequences=["cool"])
for out in inference:
   print(out)
   print("\n")

```

- Output:
For the first prompt, the pipeline config is overwritten with the config given with the input. This results in 2 text generations for the first input. For the second input, as not config is given, the pipeline config is used, resulting in 3 text generations.

```
created=datetime.datetime(2023, 9, 19, 11, 37, 5, 159853) prompts=['hello?'] generations=[[GeneratedText(text='\n\nI am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help.', score=None, finished=True, finished_reason='length'), GeneratedText(text='\n\nI am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help. I am a new member of the forum and I am looking for some help.', score=None, finished=True, finished_reason='length')]] session_id=None


created=datetime.datetime(2023, 9, 19, 11, 37, 17, 76668) prompts=['cool'] generations=[[GeneratedText(text=", i'll be there.\nI'll be there too.", score=None, finished=True, finished_reason='stop'), GeneratedText(text=", i'll be there.\nI'll be there too.", score=None, finished=True, finished_reason='stop'), GeneratedText(text=", i'll be there.\nI'll be there too.", score=None, finished=True, finished_reason='stop')]] session_id=None
```

