### PR TITLE
[TextGeneration] Update `sampling_temperature` and `deterministic` to be part of the input

### DIFF
--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -47,8 +47,6 @@ class NLDecoderEngine:
     :param sequence_length: The maximum sequence length to run the engine for
     :param input_ids_length: The maximum input ids length to run the engine for
     :param engine_context: The context to run the engine in
-    :param sampling_temperature: The temperature to use for sampling
-    :param deterministic: Whether to use deterministic sampling
     :param tokenizer: The tokenizer to used for engine inputs
     :param engine_context: The context to run the engine in
     :param internal_kv_cache: Whether to use the deepsparse

--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -63,8 +63,6 @@ class NLDecoderEngine:
         sequence_length: int,
         input_ids_length: int,
         tokenizer: AutoTokenizer,
-        sampling_temperature: float = 1.0,
-        deterministic: bool = True,
         engine_context: Optional[Context] = None,
         internal_kv_cache=False,
         timer_manager: TimerManager = None,
@@ -98,8 +96,6 @@ class NLDecoderEngine:
         )
         self.timer_manager = timer_manager or TimerManager()
         self.sequence_length = sequence_length
-        self.sampling_temperature = sampling_temperature
-        self.deterministic = deterministic
         self.input_ids_length = input_ids_length
         self.cache_length = sequence_length - input_ids_length
         self.kv_cache_enabled = kv_cache_enabled

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -349,8 +349,6 @@ class TextGenerationPipeline(TransformersPipeline):
                 engine_type=self.engine_type,
                 engine_args=self.engine_args,
                 engine_context=self.context,
-                sampling_temperature=self.sampling_temperature,
-                deterministic=self.deterministic,
                 sequence_length=self.sequence_length,
                 input_ids_length=input_ids_length,
                 tokenizer=self.tokenizer,
@@ -364,8 +362,6 @@ class TextGenerationPipeline(TransformersPipeline):
                 engine_type=self.engine_type,
                 engine_args=self.engine_args,
                 engine_context=self.context,
-                sampling_temperature=self.sampling_temperature,
-                deterministic=self.deterministic,
                 sequence_length=self.sequence_length,
                 input_ids_length=1,
                 tokenizer=self.tokenizer,
@@ -435,10 +431,6 @@ class TextGenerationPipeline(TransformersPipeline):
             inputs.sequences = repeat_inputs(
                 inputs.sequences, inputs.num_generated_predictions
             )
-            if self.engine:
-                self.engine.deterministic = False
-            if self.multitoken_engine:
-                self.multitoken_engine.deterministic = False
 
         if inputs.fixed_sequences_length or not self.cache_support_enabled:
             # to enforce a fixed sequence length, we need to

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -645,12 +645,13 @@ class TextGenerationPipeline(TransformersPipeline):
             finished_reason = []
             streaming = context.get("streaming")
             generation_config = context.get("generation_config")
+            deterministic = not generation_config.do_sample
 
             if not self.cache_support_enabled:
                 prompt_logits = self.multitoken_engine(engine_inputs)
                 token_generator = TokenGenerator(
                     logits_shape=prompt_logits[-1].shape[-1],
-                    deterministic=generation_config.do_sample,
+                    deterministic=deterministic,
                     sampling_temperature=self.sampling_temperature,
                     **context,
                 )
@@ -667,7 +668,7 @@ class TextGenerationPipeline(TransformersPipeline):
             token_generator = TokenGenerator(
                 logits_shape=prompt_logits[-1].shape[-1],
                 tokens=tokens,
-                deterministic=generation_config.do_sample,
+                deterministic=deterministic,
                 sampling_temperature=self.sampling_temperature,
                 **context,
             )

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -582,6 +582,7 @@ class TextGenerationPipeline(TransformersPipeline):
                 token_generator = TokenGenerator(
                     logits_shape=prompt_logits[-1].shape[-1],
                     deterministic=self.deterministic,
+                    sampling_temperature=self.sampling_temperature,
                     **context,
                 )
                 for prompt_logit in prompt_logits:
@@ -598,6 +599,7 @@ class TextGenerationPipeline(TransformersPipeline):
                 logits_shape=prompt_logits[-1].shape[-1],
                 tokens=tokens,
                 deterministic=self.deterministic,
+                sampling_temperature=self.sampling_temperature,
                 **context,
             )
             token_generator.generate(prompt_logits[-1][0, -1, :])

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -436,6 +436,7 @@ class TextGenerationPipeline(TransformersPipeline):
             inputs.sequences = repeat_inputs(
                 inputs.sequences, generation_config.num_return_sequences
             )
+            self.deterministic = True
 
         if inputs.fixed_sequences_length or not self.cache_support_enabled:
             # to enforce a fixed sequence length, we need to

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -436,7 +436,7 @@ class TextGenerationPipeline(TransformersPipeline):
             inputs.sequences = repeat_inputs(
                 inputs.sequences, generation_config.num_return_sequences
             )
-            self.deterministic = True
+            self.deterministic = False
 
         if inputs.fixed_sequences_length or not self.cache_support_enabled:
             # to enforce a fixed sequence length, we need to

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -426,7 +426,7 @@ class TestTextGenerationPipeline:
             assert len(generation) == 2
 
     def test_token_generation__deterministic(self, setup):
-        """Output tokens should be unique"""
+        """Should generate the same tokens"""
         pipeline_kwargs = {
             "task": "text_generation",
             "model_path": self.model_stub,
@@ -437,11 +437,11 @@ class TestTextGenerationPipeline:
             sequences=["hello?"], num_generated_predictions=3, max_tokens=100
         )
         sequences = inference.sequences[0]
-        # Check that all outputs are the same
+        # Output should be the same from one another
         assert all(sequence == sequences[0] for sequence in sequences)
 
     def test_token_generation__non_deterministic(self, setup):
-        """Output tokens should not be unique"""
+        """Should generate non-unique tokens"""
         pipeline_kwargs = {
             "task": "text_generation",
             "model_path": self.model_stub,
@@ -455,7 +455,7 @@ class TestTextGenerationPipeline:
             max_tokens=100,
         )
         sequences = inference.sequences[0]
-        # Check all outputs are unique
+        # Outputs should be unique from one another
         assert len(set(sequences)) == num_generated_predictions
 
     def _test_output(

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -425,6 +425,37 @@ class TestTextGenerationPipeline:
         for generation in output_sequences.generations:
             assert len(generation) == 2
 
+    def test_deterministic_token_generation__non_unique(self, setup):
+        """Deterministic token output check"""
+        pipeline_kwargs = {
+            "task": "text_generation",
+            "model_path": self.model_stub,
+            "deterministic": True,
+        }
+        pipeline = self.get_pipeline(**pipeline_kwargs)
+        inference = pipeline(
+            sequences=["hello?"], num_generated_predictions=3, max_tokens=100
+        )
+        sequences = inference.sequences[0]
+        assert all(sequence == sequences[0] for sequence in sequences)
+
+    def test_deterministic_token_generation__unique(self, setup):
+        """Deterministic token output check"""
+        pipeline_kwargs = {
+            "task": "text_generation",
+            "model_path": self.model_stub,
+            "deterministic": False,
+        }
+        pipeline = self.get_pipeline(**pipeline_kwargs)
+        num_generated_predictions = 3
+        inference = pipeline(
+            sequences=["hello?"],
+            num_generated_predictions=num_generated_predictions,
+            max_tokens=100,
+        )
+        sequences = inference.sequences[0]
+        assert len(set(sequences)) == num_generated_predictions
+
     def _test_output(
         self,
         output: "TextGenerationOutput",  # noqa F821

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -425,7 +425,7 @@ class TestTextGenerationPipeline:
         for generation in output_sequences.generations:
             assert len(generation) == 2
 
-    def test_deterministic_token_generation__non_unique(self, setup):
+    def test_deterministic_token_generation__not_unique(self, setup):
         """Deterministic token output check"""
         pipeline_kwargs = {
             "task": "text_generation",
@@ -437,10 +437,11 @@ class TestTextGenerationPipeline:
             sequences=["hello?"], num_generated_predictions=3, max_tokens=100
         )
         sequences = inference.sequences[0]
+        # Check that all outputs are the same
         assert all(sequence == sequences[0] for sequence in sequences)
 
     def test_deterministic_token_generation__unique(self, setup):
-        """Deterministic token output check"""
+        """Non deterministic token output check"""
         pipeline_kwargs = {
             "task": "text_generation",
             "model_path": self.model_stub,
@@ -454,6 +455,7 @@ class TestTextGenerationPipeline:
             max_tokens=100,
         )
         sequences = inference.sequences[0]
+        # Check all outputs are unique
         assert len(set(sequences)) == num_generated_predictions
 
     def _test_output(

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -426,7 +426,7 @@ class TestTextGenerationPipeline:
             assert len(generation) == 2
 
     def test_token_generation__deterministic(self, setup):
-        """Test output tokens are unique"""
+        """Output tokens should be unique"""
         pipeline_kwargs = {
             "task": "text_generation",
             "model_path": self.model_stub,
@@ -441,7 +441,7 @@ class TestTextGenerationPipeline:
         assert all(sequence == sequences[0] for sequence in sequences)
 
     def test_token_generation__non_deterministic(self, setup):
-        """Non output tokens are not unique"""
+        """Output tokens should not be unique"""
         pipeline_kwargs = {
             "task": "text_generation",
             "model_path": self.model_stub,

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -425,8 +425,8 @@ class TestTextGenerationPipeline:
         for generation in output_sequences.generations:
             assert len(generation) == 2
 
-    def test_deterministic_token_generation__not_unique(self, setup):
-        """Deterministic token output check"""
+    def test_token_generation__deterministic(self, setup):
+        """Test output tokens are unique"""
         pipeline_kwargs = {
             "task": "text_generation",
             "model_path": self.model_stub,
@@ -440,8 +440,8 @@ class TestTextGenerationPipeline:
         # Check that all outputs are the same
         assert all(sequence == sequences[0] for sequence in sequences)
 
-    def test_deterministic_token_generation__unique(self, setup):
-        """Non deterministic token output check"""
+    def test_token_generation__non_deterministic(self, setup):
+        """Non output tokens are not unique"""
         pipeline_kwargs = {
             "task": "text_generation",
             "model_path": self.model_stub,


### PR DESCRIPTION
## Summary:
- This removes the `temperature` and `sampling_temperature` from the constructor to the inputs. Specifically, we're mapping `temperature` to the `sampling_temperature` config attribute and `deterministic` to `do_sample`
- Note: `do_sample` being True means `deterministic` is False


```
pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime",
)
config = {
   "num_return_sequences": 3,
   "do_sample": True
}
inference = pipeline(prompt=["how are you?"], generation_config=config)
print(inference)
```

## Testing:
- All tests passing locally and updated to add two new tests with the new attributes