### PR TITLE
explicitly set ORT providers on all InferenceSession creations

### DIFF
--- a/tests/utils/engine_mocking.py
+++ b/tests/utils/engine_mocking.py
@@ -103,7 +103,9 @@ class _FakeDeepsparseLibEngine:
         with override_onnx_batch_size(
             model_path, batch_size, inplace=True
         ) as batched_model_path:
-            session = ort.InferenceSession(batched_model_path)
+            session = ort.InferenceSession(
+                batched_model_path, providers=["CPUExecutionProvider"]
+            )
             self.input_descriptors = list(map(_to_descriptor, session.get_inputs()))
             self.output_descriptors = list(map(_to_descriptor, session.get_outputs()))
 


### PR DESCRIPTION
latest version of ORT has a hard requirement for providers to be set. this PR updates any inference session that does not have it set 

**test_plan:**
QA Team + GHA