### PR TITLE
Default Config for Benchmark Pipeline

### DIFF
--- a/src/deepsparse/benchmark/benchmark_pipeline.py
+++ b/src/deepsparse/benchmark/benchmark_pipeline.py
@@ -237,7 +237,7 @@ def create_input_schema(
 def benchmark_pipeline(
     model_path: str,
     task: str,
-    config: PipelineBenchmarkConfig,
+    config: PipelineBenchmarkConfig = None,
     batch_size: int = 1,
     num_cores: int = None,
     scenario: str = "sync",
@@ -273,6 +273,10 @@ def benchmark_pipeline(
 
     if num_cores is None:
         num_cores = cpu_architecture().num_available_physical_cores
+
+    if config is None:
+        _LOGGER.warning("No input configuration provided, falling back to default.")
+        config = PipelineBenchmarkConfig()
 
     decide_thread_pinning(thread_pinning)
     scenario = parse_scenario(scenario.lower())
@@ -364,7 +368,7 @@ def calculate_section_stats(
     "-c",
     "--input_config",
     type=str,
-    default="config.json",
+    default=None,
     help="JSON file containing schema for input data",
 )
 @click.option(

--- a/src/deepsparse/benchmark/config.py
+++ b/src/deepsparse/benchmark/config.py
@@ -34,14 +34,14 @@ class PipelineBenchmarkConfig(BaseModel):
     )
 
     gen_sequence_length: Optional[int] = Field(
-        default=None,
+        default=512,
         description=(
             "Number of characters to generate for pipelines that take text input."
         ),
     )
 
     input_image_shape: Optional[List[int]] = Field(
-        default=None,
+        default=[224, 224, 3],
         description=(
             "Image size for pipelines that take image input, 3-dim with channel as the "
             "last dimmension"

--- a/src/deepsparse/benchmark/helpers.py
+++ b/src/deepsparse/benchmark/helpers.py
@@ -123,6 +123,10 @@ def parse_num_streams(num_streams: int, num_cores: int, scenario: str):
 
 
 def parse_input_config(input_config_file: str) -> Dict[str, any]:
+    if input_config_file is None:
+        _LOGGER.warning("No input configuration file provided, using default.")
+        return PipelineBenchmarkConfig()
+
     config_file = open(input_config_file)
     config = json.load(config_file)
     config_file.close()

--- a/tests/test_pipeline_benchmark.py
+++ b/tests/test_pipeline_benchmark.py
@@ -65,6 +65,11 @@ from tests.helpers import run_command
             ],
         ),
         (
+            "image_classification",
+            "zoo:cv/classification/resnet_v1-50_2x/pytorch/sparseml/imagenet/base-none",
+            [],
+        ),
+        (
             "token_classification",
             "zoo:nlp/token_classification/distilbert-none/pytorch/huggingface/"
             "conll2003/pruned90-none",


### PR DESCRIPTION
Requested by @horheynm, allows `benchmark_pipeline` to be run without a configuration file provided. If no config is provided, the script will default to dummy input data with sequence length 512 for text and image shape [224,224,3]

### Testing 
Updated unit test to include a case where we don't provide a config