### PR TITLE
[Text Gen UX] Add `prompt` as input param alias

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -83,6 +83,7 @@ class TextGenerationInput(BaseModel):
         arbitrary_types_allowed = True
 
     sequences: Union[str, List[str]] = Field(
+        alias="prompt",
         description="The input sequences to generate the text from.",
     )
     include_prompt_logits: bool = Field(


### PR DESCRIPTION
from internal specs:

```python
text_pipeline = TextGeneration(model=MODEL, **kwargs)
text_result = text_pipeline(prompt=PROMPT, **kwargs)
```

**test_plan:**
local

```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
    "text-generation",
    model_path="/home/benjamin/neuralmagic/models/codegen_mono-350m-bigpython_bigquery_thepile-pruned50/deployment",
    engine_type="onnxruntime"
)

pipeline(prompt="def hello_world():", generation_config=dict(max_new_tokens=10))
```