### PR TITLE
[Text Gen UX] default pipeline input to  value

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -405,6 +405,28 @@ class TextGenerationPipeline(TransformersPipeline):
         """
         return TextGenerationOutput
 
+    def parse_inputs(self, *args, **kwargs) -> TextGenerationInput:
+        """
+
+        :param args: in line argument can only have 1, must either be
+            a complete TextGenerationInput object or `sequences` for
+            a TextGenerationInput
+        :param kwargs: if a TextGenerationInput is not provided, then
+            these kwargs will be used to instantiate one
+        :return: parsed TextGenerationInput object
+        """
+        if (
+            args
+            and not isinstance(args[0], TextGenerationInput)
+            and "prompt" not in kwargs
+            and "sequences" not in kwargs
+        ):
+            # assume first argument is "sequences" (prompt) by default
+            kwargs["sequences"] = args[0]
+            args = args[1:]
+
+        return super().parse_inputs(*args, **kwargs)
+
     def process_inputs(
         self, inputs: TextGenerationInput
     ) -> Tuple[List[numpy.ndarray], Dict[str, Any]]:


### PR DESCRIPTION
request from product (@mgoin)

support for `pipe("text")` instead of requiring `pipe(sequences="text")`


**test example:**
```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
    "text-generation",
    model_path="/home/benjamin/neuralmagic/models/codegen_mono-350m-bigpython_bigquery_thepile-pruned50/deployment",
    engine_type="onnxruntime"
)

pipeline("def hello_world:", generation_config=dict(max_new_tokens=10))
```