### PR TITLE
Remove Dead Code

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -541,24 +541,6 @@ class TextGenerationPipeline(TransformersPipeline):
         :return: the output schema for the pipeline
         """
 
-        def _create_generated_text_output(
-            sequence: str,
-            finish_reason: FinishReason = None,
-            logits: Optional[numpy.array] = None,
-        ):
-            if finish_reason:
-                return GeneratedText(
-                    text=sequence,
-                    score=logits,
-                    finished=True,
-                    finished_reason=finish_reason.value,
-                )
-            return GeneratedText(
-                text=sequence,
-                score=logits,
-                finished=False,
-            )
-
         generation_config = kwargs.get("generation_config")
         prompts = kwargs.get("prompts")
         streaming = kwargs.get("streaming")


### PR DESCRIPTION
In one of our recent changes to `TextGenerationPipeline`,  a function within a function was moved outside, but the original function wasn't deleted. This lead to a duplicate "dead" function not used anywhere.

This PR removes that dead function `_create_generated_text_output`

Note: there is already a `_create_generated_text_output` function defined at the class level