### PR TITLE
[Text Gen UX] top level constructor aliases + code gen subclass

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -60,6 +60,9 @@ __all__ = [
     "Bucketable",
     "BucketingPipeline",
     "create_engine",
+    "TextGeneration",
+    "CodeGeneration",
+    "Chat",
 ]
 
 DEEPSPARSE_ENGINE = "deepsparse"
@@ -772,6 +775,55 @@ def _initialize_executor_and_workers(
         )
 
     return executor, num_async_workers
+
+
+def text_generation_pipeline(
+    *args, model: Optional[str] = None, **kwargs
+) -> "Pipeline":
+    """
+    :return: text generation pipeline with the given args and
+        kwargs passed to Pipeline.create
+    """
+    kwargs = _parse_model_arg(model, **kwargs)
+    return Pipeline.create("text_generation", *args, **kwargs)
+
+
+def code_generation_pipeline(
+    *args, model: Optional[str] = None, **kwargs
+) -> "Pipeline":
+    """
+    :return: text generation pipeline with the given args and
+        kwargs passed to Pipeline.create
+    """
+    kwargs = _parse_model_arg(model, **kwargs)
+    return Pipeline.create("code_generation", *args, **kwargs)
+
+
+def chat_pipeline(*args, model: Optional[str] = None, **kwargs) -> "Pipeline":
+    """
+    :return: text generation pipeline with the given args and
+        kwargs passed to Pipeline.create
+    """
+    kwargs = _parse_model_arg(model, **kwargs)
+    return Pipeline.create("chat", *args, **kwargs)
+
+
+def _parse_model_arg(model: Optional[str], **kwargs) -> dict:
+    if model is not None:
+        model_path = kwargs.get("model_path")
+        if model_path is not None:
+            raise ValueError(
+                f"Only one of model and model_path may be supplied, found {model} "
+                f"and {model_path} respectively"
+            )
+        kwargs["model_path"] = model
+    return kwargs
+
+
+# aliases for top level import
+TextGeneration = text_generation_pipeline
+CodeGeneration = code_generation_pipeline
+Chat = chat_pipeline
 
 
 def question_answering_pipeline(*args, **kwargs) -> "Pipeline":

--- a/src/deepsparse/tasks.py
+++ b/src/deepsparse/tasks.py
@@ -103,12 +103,15 @@ class SupportedTasks:
         chatbot=AliasedTask("chatbot", []), chat=AliasedTask("chat", [])
     )
     text_generation = namedtuple(
-        "text_generation", ["text_generation", "opt", "codegen", "bloom"]
+        "text_generation", ["text_generation", "opt", "bloom"]
     )(
         text_generation=AliasedTask("text_generation", []),
-        codegen=AliasedTask("codegen", []),
         opt=AliasedTask("opt", []),
         bloom=AliasedTask("bloom", []),
+    )
+    code_generation = namedtuple("code_generation", ["code_generation", "codegen"])(
+        code_generation=AliasedTask("code_generation", []),
+        codegen=AliasedTask("codegen", []),
     )
 
     image_classification = namedtuple("image_classification", ["image_classification"])(
@@ -153,6 +156,7 @@ class SupportedTasks:
         open_pif_paf,
         text_generation,
         chat,
+        code_generation,
     ]
 
     @classmethod
@@ -173,6 +177,9 @@ class SupportedTasks:
 
         elif cls.is_chat(task):
             import deepsparse.transformers.pipelines.chat  # noqa: F401
+
+        elif cls.is_code_generation(task):
+            import deepsparse.transformers.pipelines.code_generation  # noqa: F401
 
         elif cls.is_nlp(task):
             # trigger transformers pipelines to register with Pipeline.register
@@ -235,6 +242,18 @@ class SupportedTasks:
         return any(
             text_generation_task.matches(task)
             for text_generation_task in cls.text_generation
+        )
+
+    @classmethod
+    def is_code_generation(cls, task: str) -> bool:
+        """
+        :param task: the name of the task to check whether it is a text generation task
+            such as codegen
+        :return: True if it is a text generation task, False otherwise
+        """
+        return any(
+            code_generation_task.matches(task)
+            for code_generation_task in cls.code_generation
         )
 
     @classmethod

--- a/src/deepsparse/transformers/pipelines/code_generation.py
+++ b/src/deepsparse/transformers/pipelines/code_generation.py
@@ -12,15 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
-# isort: skip_file
 
-from .pipeline import *
-from .question_answering import *
-from .text_classification import *
-from .token_classification import *
-from .text_generation import *
-from .zero_shot_text_classification import *
-from .embedding_extraction import *
-from .chat import *
-from .code_generation import *
+from deepsparse import Pipeline
+from deepsparse.transformers.pipelines.text_generation import TextGenerationPipeline
+
+
+__all__ = ["CodeGenerationPipeline"]
+
+
+@Pipeline.register(
+    task="code_generation",
+    task_aliases=["codegen"],
+)
+class CodeGenerationPipeline(TextGenerationPipeline):
+    """
+    Subclass of text generation pipeline to support any defaults or
+    overrides needed for code generation
+    """
+
+    pass

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -184,7 +184,7 @@ class TextGenerationOutput(BaseModel):
 
 @Pipeline.register(
     task="text_generation",
-    task_aliases=["codegen", "opt", "bloom"],
+    task_aliases=["opt", "bloom"],
 )
 class TextGenerationPipeline(TransformersPipeline):
     """


### PR DESCRIPTION
This PR adds the requested constructor aliases for the main text generation tasks. also adds a code generation subclass to reference - idea here is that if there is ever extra processing or defaults requested for code generation, it will be easy to add in to the subclass

requested UX:
```python
from deepsparse import TextGeneration, CodeGeneration, Chat

text_pipeline = TextGeneration(model=MODEL, **kwargs)
text_result = text_pipeline(prompt=PROMPT, **kwargs)

code_pipeline = CodeGeneration(model=MODEL, **kwargs)
code_result = code_pipeline(promp=PROMPT, **kwargs)

chat_pipeline = Chat(model=MODEL, **kwargs)
chat_result = chat_pipeline(prompt=PROMPT, *args, **kwargs)
```


**test_plan:**
manually verified:
```python
from deepsparse import CodeGeneration

code_pipeline = CodeGeneration(model="/home/benjamin/neuralmagic/models/codegen_mono-350m-bigpython_bigquery_thepile-pruned50/deployment", engine_type="onnxruntime")
code_pipeline(prompt="def hello_world:", generation_config=dict(max_new_tokens=10))
```