### PR TITLE
[Cherry pick] #1262 explicitly set ORT providers on all InferenceSessions

### DIFF
--- a/src/deepsparse/version.py
+++ b/src/deepsparse/version.py
@@ -39,7 +39,7 @@ try:
     from deepsparse.generated_version import is_enterprise, is_release, splash, version
 except Exception:
     # otherwise, fall back to version info in this file
-    version = "1.5.3"
+    version = "1.5.4"
     is_release = False
     is_enterprise = False
     splash = (

--- a/tests/utils/engine_mocking.py
+++ b/tests/utils/engine_mocking.py
@@ -100,7 +100,9 @@ class _FakeDeepsparseLibEngine:
         # However in general we cannot assume that all outputs have
         # a batch dimension, that's why we need onnxruntime here.
         with override_onnx_batch_size(model_path, batch_size) as batched_model_path:
-            session = ort.InferenceSession(batched_model_path)
+            session = ort.InferenceSession(
+                batched_model_path, providers=["CPUExecutionProvider"]
+            )
             self.input_descriptors = list(map(_to_descriptor, session.get_inputs()))
             self.output_descriptors = list(map(_to_descriptor, session.get_outputs()))
 


### PR DESCRIPTION
This is a cherry pick of #1262 for release/1.5, additionally updates the patch version