### PR TITLE
[Chat pipeline] session context manager

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -416,6 +416,9 @@ class TextGenerationPipeline(TransformersPipeline):
             these kwargs will be used to instantiate one
         :return: parsed TextGenerationInput object
         """
+        if "sequences" in kwargs and "prompt" not in kwargs:
+            # support prompt and sequences interchangeably
+            kwargs["prompt"] = kwargs["sequences"]
         if (
             args
             and not isinstance(args[0], TextGenerationInput)
@@ -423,7 +426,7 @@ class TextGenerationPipeline(TransformersPipeline):
             and "sequences" not in kwargs
         ):
             # assume first argument is "sequences" (prompt) by default
-            kwargs["sequences"] = args[0]
+            kwargs["prompt"] = args[0]
             args = args[1:]
 
         return super().parse_inputs(*args, **kwargs)

--- a/tests/deepsparse/transformers/pipelines/test_chat.py
+++ b/tests/deepsparse/transformers/pipelines/test_chat.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from deepsparse import Pipeline
+
+
+@pytest.mark.parametrize(
+    "pipeline_kwargs",
+    [
+        dict(
+            model_path="zoo:nlg/text_generation/codegen_mono-350m/pytorch/"
+            "huggingface/bigpython_bigquery_thepile/base-none",
+            engine_type="onnxruntime",
+        ),
+    ],
+)
+@pytest.mark.skip(reason="too heavy for now to run in gha")
+def test_chat_pipeline_session_manager(pipeline_kwargs):
+    chat_pipeline = Pipeline.create(task="chat", **pipeline_kwargs)
+
+    with chat_pipeline.session():
+        output_1 = chat_pipeline(
+            prompt="first", generation_config=dict(max_new_tokens=1)
+        )
+        output_2 = chat_pipeline(
+            prompt="second", generation_config=dict(max_new_tokens=1)
+        )
+    # assert inferences in the same context share a session id
+    assert output_1.session_ids == output_2.session_ids
+
+    # test that follow-up inference has a different session id
+    output_3 = chat_pipeline(prompt="third", generation_config=dict(max_new_tokens=1))
+    assert output_3.session_ids != output_1.session_ids


### PR DESCRIPTION
updated implementation of #1239 

includes small bug fix for text gen input parsing due to behavior with pydantic aliases

requested UX:
```python
with chat_pipeline.session():
    first_result = chat_pipeline(prompt=PROMPT, *args, **kwargs)
    second_result = chat_pipeline(prompt=PROMPT, *args, **kwargs)
```

**test_plan:**
unit test included and ran locally, but disabled due to overhead in GHA

manual verification as well:
```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
    "chat",
    model_path="/home/benjamin/neuralmagic/models/codegen_mono-350m-bigpython_bigquery_thepile-pruned50/deployment",
    engine_type="onnxruntime"
)

with pipeline.session():
    output_1 = pipeline(prompt="first", generation_config=dict(max_new_tokens=1))
    output_2 = pipeline(prompt="second", generation_config=dict(max_new_tokens=1))

output_3 = pipeline(prompt="third", generation_config=dict(max_new_tokens=1))

output_2.session_ids == output_1.session_ids  # expected True
output_3.session_ids == output_1.session_ids  # expected False
```

Co-authored-by: @rahul-tuli