### PR TITLE
Use nullcontext in nl_decoder_engine when timer_manager.current is None

### DIFF
--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -191,17 +191,17 @@ class NLDecoderEngine:
             # to add the kv cache state to the input
             inp = self.add_kv_cache_to_input(inp, kv_cache)
 
-        with timer.time(f"EXECUTE_ENGINE_SEQ_LEN_{self.sequence_length}"):
-            out = self.run(inp, val_inp, kv_cache)
+        # with timer.time(f"EXECUTE_ENGINE_SEQ_LEN_{self.sequence_length}"):
+        out = self.run(inp, val_inp, kv_cache)
 
         if kv_cache:
-            with timer.time(TextGenerationTimings.KV_CACHE_UPDATE):
-                logits, *kv_cache_state = out
-                self.update_kv_cache(
-                    kv_cache_state=kv_cache_state,
-                    input_ids_len=self.input_ids_length,
-                    kv_cache=kv_cache,
-                )
+            # with timer.time(TextGenerationTimings.KV_CACHE_UPDATE):
+            logits, *kv_cache_state = out
+            self.update_kv_cache(
+                kv_cache_state=kv_cache_state,
+                input_ids_len=self.input_ids_length,
+                kv_cache=kv_cache,
+            )
         else:
             logits = out[0]
 

--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import copy
 import logging
-from typing import Any, Dict, List, Optional, Tuple
 from contextlib import nullcontext
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy
 


### PR DESCRIPTION
There is an error that seems to only happen when generating the second token when streaming=True, but only shows up in specific pipeline setups such as Gradio

Error:
```
  File "/home/user/.local/lib/python3.10/site-packages/deepsparse/transformers/engines/nl_decoder_engine.py", line 194, in __call__
    with timer.time(f"EXECUTE_ENGINE_SEQ_LEN_{self.sequence_length}"):
AttributeError: 'NoneType' object has no attribute 'time'
```

This PR simply uses nullcontext to replace the timer if it is None