### PR TITLE
[TextGeneration] Add kwarg support for generation config attributes

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -427,14 +427,14 @@ class TextGenerationPipeline(TransformersPipeline):
 
             for k, v in kwargs.items():
                 try:
-                    if getattr(GenerationDefaults, k) and not generation_kwargs.get(k):
+                    if not generation_kwargs.get(k):
+                        getattr(GenerationDefaults, k)
                         generation_kwargs[k] = v
                 except AttributeError:
                     continue
 
             kwargs["generation_kwargs"] = generation_kwargs
 
-        print(args, kwargs)
         return super().parse_inputs(*args, **kwargs)
 
     def process_inputs(

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -141,11 +141,10 @@ class TextGenerationInput(BaseModel):
         "top_k, repetition_penalty, do_sample, temperature",
     )
 
-    kwargs: Optional[Dict] = Field(
+    generation_kwargs: Optional[Dict] = Field(
         default=None,
         description="Any arguments to override generation_config arguments. Refer to "
-        "the generation_config argument for a full list of supported variables. Only "
-        "valid when generation_config is not None.",
+        "the generation_config argument for a full list of supported variables."
     )
 
 
@@ -434,7 +433,7 @@ class TextGenerationPipeline(TransformersPipeline):
             self.generation_config, inputs.generation_config, GenerationDefaults()
         )
 
-        generation_config = override_config(inputs.kwargs, generation_config)
+        generation_config = override_config(inputs.generation_kwargs, generation_config)
 
         self.streaming = inputs.streaming
         if not self.cache_support_enabled and generation_config.max_length > 1:

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -138,7 +138,9 @@ class TextGenerationInput(BaseModel):
         description="GenerationConfig file consisting of parameters used to control "
         "sequences generated for each prompt. The current supported parameters are: "
         "max_length, max_new_tokens, num_return_sequences, output_scores, top_p, "
-        "top_k, repetition_penalty, do_sample, temperature",
+        "top_k, repetition_penalty, do_sample, temperature. If None is provided, "
+        "deepsparse defaults will be used. For all other input types, HuggingFace "
+        "defaults for GenerationConfig will be used. ",
     )
 
     generation_kwargs: Optional[Dict] = Field(
@@ -200,6 +202,12 @@ class TextGenerationPipeline(TransformersPipeline):
         of tokens supplied even if the stop token is reached.
     :param internal_kv_cache: if True, the pipeline will use the deepsparse kv cache
         for caching the model outputs.
+    :param generation_config: config file consisting of parameters used to control
+        sequences generated for each prompt. The current supported parameters are:
+        max_length, max_new_tokens, num_return_sequences, output_scores, top_p,
+        top_k, repetition_penalty, do_sample, temperature. If None is provided,
+        deepsparse defaults will be used. For all other input types, HuggingFace
+        defaults for GenerationConfig will be used.
     :param kwargs: kwargs to pass to the TransformersPipeline
     """
 

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -246,15 +246,14 @@ def override_config(
         return generation_config
 
     for k, v in overrides.items():
-        try:
-            getattr(generation_config, k)
+        if hasattr(generation_config, k):
             setattr(generation_config, k, v)
             _LOGGER.debug(f"Overriding attribute {k} in the generation config")
-        except AttributeError as exception:
+        else:
             raise AttributeError(
                 "Argument provided for GenerationConfig is not "
                 "valid. Refer to the TextGenerationInput for supported attributes. "
-            ) from exception
+            )
 
     return generation_config
 

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -247,9 +247,9 @@ def override_config(
 
     for k, v in overrides.items():
         try:
-            if getattr(generation_config, k):
-                setattr(generation_config, k, v)
-                _LOGGER.debug(f"Overriding attribute {k} in the generation config")
+            getattr(generation_config, k)
+            setattr(generation_config, k, v)
+            _LOGGER.debug(f"Overriding attribute {k} in the generation config")
         except AttributeError as exception:
             raise AttributeError(
                 "Argument provided for GenerationConfig is not "

--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -251,7 +251,7 @@ def override_config(
             _LOGGER.debug(f"Overriding attribute {k} in the generation config")
         else:
             raise AttributeError(
-                "Argument provided for GenerationConfig is not "
+                f"Argument {k} provided for GenerationConfig is not "
                 "valid. Refer to the TextGenerationInput for supported attributes. "
             )
 


### PR DESCRIPTION
## Summary
Update the `text_generation` pipeline to support kwargs for generation_config attributes. 

## Test Cases:

1. kwargs only

```python
pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime",
)

inference = pipeline(prompt=["how are you?"], num_return_sequences=2, do_sample=False, max_length=10)
print(inference)
```

2. Combination of GenerationConfig input and kwargs

```python
pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime",
)

generation_config = {"do_sample": True}
inference = pipeline(prompt=["how are you?"], generation_config=generation_config, num_return_sequences=2, max_length=10)
print(inference)
```

3. Combination of `generation_kwargs` input and kwargs
```python
pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime",
)

generation_kwargs = {"do_sample": True}
inference = pipeline(prompt=["how are you?"], generation_kwargs=generation_kwargs, num_return_sequences=2, max_length=10)
print(inference)
```

4. generation config, generation_kwargs, and kwargs
```python
pipeline = Pipeline.create(
   task="text_generation",
   model_path="/home/dsikka/.cache/sparsezoo/neuralmagic/opt-1.3b-opt_pretrain-quantW8A8/deployment",
   engine_type="onnxruntime",
)

x = GenerationConfig()
x.output_scores = True

generation_kwargs = {"do_sample": True}
inference = pipeline(prompt=["how are you?"], generation_config=x, generation_kwargs=generation_kwargs, num_return_sequences=2, max_length=10)
print(inference)
```