### PR TITLE
[feature] Add-evaluate-function

### DIFF
--- a/src/deepsparse/transformers/evaluator.py
+++ b/src/deepsparse/transformers/evaluator.py
@@ -22,6 +22,12 @@ from deepsparse.pipeline import DEEPSPARSE_ENGINE
 from deepsparse.transformers.eval_downstream import perplexity_eval
 
 
+__all__ = [
+    "Evaluator",
+    "TransformersEvaluator",
+    "evaluate",
+]
+
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
 
@@ -111,11 +117,11 @@ class TransformersEvaluator(Evaluator):
     def _calc_perplexity(self, **kwargs):
         """
         Calculate the perplexity of the model.
-        
+
         Note: Right now, this function relies on the `perplexity_eval`
         function from `deepsparse.transformers.eval_downstream` to calculate
         perplexity. This is subject to change in the future.
-        
+
 
         :param kwargs: Additional arguments to pass to the
             perplexity function.
@@ -145,3 +151,26 @@ class TransformersEvaluator(Evaluator):
         perplexity_kwargs = dict(dataset_name=self.dataset_name_)
 
         return perplexity_eval(perplexity_args, **perplexity_kwargs)
+
+
+def evaluate(model: str, dataset: str, eval: Optional[List[str]] = None, **kwargs):
+    """
+    Utility method to evaluate language models. Uses the TransformersEvaluator
+    class to run the evaluation.
+
+    :param model: The path to the model to evaluate. Must be a directory
+        containing `model.onnx` with configuration files, or a SparseZoo stub.
+    :param dataset: The name of the dataset to evaluate on. Supported datasets
+        for Language Models are `openai_humaneval`, `wikitext2` and `c4`.
+    :param eval: The list of evaluation metrics to run. Supported metrics for
+        Language Models are `perplexity`.
+    :param kwargs: Additional arguments to pass to the evaluation function.
+        see src/deepsparse/transformers/eval_downstream.py for
+        full list of arguments, the default values can be overridden
+        by passing them as keyword arguments to this function
+    :return: The results of the evaluation.
+    """
+
+    evaluator = TransformersEvaluator(model=model, dataset=dataset, eval=eval)
+    evaluator.evaluate(**kwargs)
+    return evaluator.get_results()


### PR DESCRIPTION
This PR adds an `evaluate` method to abstract Evaluator instantiation for the user. This is nice because the code get easier to invoke now:

```python
# local-run.py

from deepsparse.transformers.evaluator import evaluate


model = "/home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/deployment"
dataset = "openai_humaneval"
results = evaluate(model=model, dataset=dataset, eval=["perplexity"])
print(results)
```

Output:
```bash
rahul at office-desktop in ~/projects/deepsparse (add-evaluate-function●) (.venv) 
$ python ./local-run.py                                                                                                                   (add-evaluate-function|✚3…12⚑4)
2023-09-26 10:09:34 deepsparse.transformers WARNING  The neuralmagic fork of transformers may not be installed. It can be installed via `pip install nm_transformers`
Found cached dataset openai_humaneval (/home/rahul/.cache/huggingface/datasets/openai_humaneval/openai_humaneval/1.0.0/2955cebd73602e828fa8c0a424c594e5fab4ec863b316ca98f3d8fdb6a626e75)
Using pad_token, but it is not set yet.
2023-09-26 10:09:37 deepsparse.transformers.pipelines.text_generation INFO     Compiling an auxiliary engine to process a prompt with a larger processing length. This improves performance, but may result in additional memory consumption.
2023-09-26 10:09:39 deepsparse.utils.onnx INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/deployment/model.onnx
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0.20230910 COMMUNITY | (c66b57da) (release) (optimized) (system=avx512, binary=avx512)
2023-09-26 10:09:48 deepsparse.utils.onnx INFO     Overwriting in-place the input shapes of the transformer model at /home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/deployment/model.onnx
  0%|                                                                                                                                             | 0/164 [00:00<?, ?it/s]2023-09-26 10:09:55 deepsparse.transformers.utils.helpers INFO      No GenerationConfig detected. Using GenerationDefaults values
  0%|        
```