### PR TITLE
[BugFix] Error with streaming in Chat Pipeline

### DIFF
--- a/src/deepsparse/transformers/pipelines/chat.py
+++ b/src/deepsparse/transformers/pipelines/chat.py
@@ -179,12 +179,10 @@ class ChatPipeline(TextGenerationPipeline):
         """
 
         engine_outputs, session_ids = list(*engine_outputs)
-        
+
         kwargs["session_ids"] = session_ids
         # process the engine outputs within the context of TextGenerationPipeline
-        return super().process_engine_outputs(
-            engine_outputs, **kwargs
-        )
+        return super().process_engine_outputs(engine_outputs, **kwargs)
 
     def engine_forward(
         self, engine_inputs: List[numpy.ndarray], context: Dict

--- a/src/deepsparse/transformers/pipelines/chat.py
+++ b/src/deepsparse/transformers/pipelines/chat.py
@@ -179,12 +179,12 @@ class ChatPipeline(TextGenerationPipeline):
         """
 
         engine_outputs, session_ids = list(*engine_outputs)
+        
+        kwargs["session_ids"] = session_ids
         # process the engine outputs within the context of TextGenerationPipeline
-        text_generation_output = super().process_engine_outputs(
+        return super().process_engine_outputs(
             engine_outputs, **kwargs
         )
-        # create the ChatOutput from the data provided
-        return ChatOutput(**text_generation_output.dict(), session_ids=session_ids)
 
     def engine_forward(
         self, engine_inputs: List[numpy.ndarray], context: Dict

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -536,10 +536,18 @@ class TextGenerationPipeline(TransformersPipeline):
                 finished_reason[0],
                 logits,
             )
-            yield TextGenerationOutput(
+            # Add session_id to schema if it exists
+            #  more relevant for `ChatPipeline`
+            schema_kwargs = (
+                {"session_ids": session_ids} 
+                if (session_ids:=kwargs.get("session_ids")) 
+                else {}
+                )
+            yield self.output_schema(
                 created=datetime.datetime.now(),
                 prompts=prompts,
                 generations=[generation],
+                **schema_kwargs,
             )
 
     def process_engine_outputs(
@@ -616,7 +624,7 @@ class TextGenerationPipeline(TransformersPipeline):
             )
             outputs.update(debug_params)
 
-        return TextGenerationOutput(**outputs)
+        return self.output_schema(**outputs)
 
     def engine_forward(
         self, engine_inputs: List[numpy.ndarray], context: Dict

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -543,7 +543,9 @@ class TextGenerationPipeline(TransformersPipeline):
             finished=False,
         )
 
-    def _stream_engine_outputs(self, engine_outputs, prompts, generation_config):
+    def _stream_engine_outputs(
+        self, engine_outputs, prompts, generation_config, **kwargs
+    ):
         for output in engine_outputs:
             generated_tokens, generated_logits, finished_reason = output
             logits = generated_logits if generation_config.output_scores else None

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -539,10 +539,10 @@ class TextGenerationPipeline(TransformersPipeline):
             # Add session_id to schema if it exists
             #  more relevant for `ChatPipeline`
             schema_kwargs = (
-                {"session_ids": session_ids} 
-                if (session_ids:=kwargs.get("session_ids")) 
+                {"session_ids": session_ids}
+                if (session_ids := kwargs.get("session_ids"))
                 else {}
-                )
+            )
             yield self.output_schema(
                 created=datetime.datetime.now(),
                 prompts=prompts,


### PR DESCRIPTION
This PR fixes a bug with `ChatPipeline` where streaming code would throw a `TypeError`, now the execution is as expected


Reproduction Code:
```python
from deepsparse import Pipeline
import inspect

streaming = True
input_text = "def fib("

chat_pipeline = Pipeline.create(
    task="chat",
    model_path="/home/rahul/.cache/sparsezoo/neuralmagic/codegen_mono-350m-bigpython_bigquery_thepile-base/deployment",
)
predictions = chat_pipeline(**{"sequences": [input_text]}, streaming=streaming)

assert inspect.isgenerator(predictions), "Predictions should be a generator"

for i, prediction in enumerate(predictions):
    print(f"Prediction {i}: {prediction}")
```

Output: 

Before this PR:
```bash
File
"/home/rahul/projects/deepsparse/src/deepsparse/pipeline.py", line 284, in __call__
    pipeline_outputs = self.process_engine_outputs(engine_outputs, **context)
  File "/home/rahul/projects/deepsparse/src/deepsparse/transformers/pipelines/chat.py", line 149, in process_engine_outputs
    return ChatOutput(**text_generation_output.dict(), session_ids=session_ids)
AttributeError: 'generator' object has no attribute 'dict'
```

After this PR:
```bash
Prediction 515: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625060) prompts=['def fib('] generations=[GeneratedText(text='10', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 516: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625120) prompts=['def fib('] generations=[GeneratedText(text='(', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 517: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625180) prompts=['def fib('] generations=[GeneratedText(text='n', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 518: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625240) prompts=['def fib('] generations=[GeneratedText(text='-', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 519: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625300) prompts=['def fib('] generations=[GeneratedText(text='2', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 520: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625365) prompts=['def fib('] generations=[GeneratedText(text=')', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 521: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625425) prompts=['def fib('] generations=[GeneratedText(text='\n', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 522: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625485) prompts=['def fib('] generations=[GeneratedText(text='\n', score=None, finished=False, finished_reason=None)] session_ids=['540e329d-8f58-4875-9526-29dc1af9467b']
Prediction 523: created=datetime.datetime(2023, 9, 26, 11, 27, 50, 625546) prompts=['def fib('] generations=[GeneratedText(text='def', score=None, finished=False, finished
.
.
.
.
```

Also added an automated test!