### PR TITLE
[TextGeneration] Fix max_length = 1, repeat token

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -757,7 +757,8 @@ class TextGenerationPipeline(TransformersPipeline):
                     tokens=token_generator.tokens, kv_cache=session
                 )
                 if streaming:
-                    if max_tokens == 1:
+                    # when no new tokens are generated
+                    if len(finished_reason) == 0:
                         yield (
                             numpy.array([generated_tokens]),
                             numpy.concatenate(generated_logits, axis=1),


### PR DESCRIPTION
Summary:

This fixes the issue where if the user has set max_length=1, finish reason is never populated as we never go through the loop in engine_forward. max_length=1 is needed for our perplexity calculation so this PR will unblock that from being completed.

Testing:

Tested locally