### PR TITLE
Set text-generation default values to match performance and UX needs

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -61,16 +61,21 @@ _LOGGER = logging.getLogger(__name__)
 __all__ = ["TextGenerationPipeline"]
 
 
+# Based off of https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig # noqa E501
 class GenerationDefaults:
-    num_return_sequences = 1
-    max_length = 1024
-    max_new_tokens = None
-    output_scores = False
-    top_k = 0
-    top_p = 0.0
-    repetition_penalty = 0.0
+    # Parameters that control the length of the output
+    max_length = 20 
+    max_new_tokens = 200
+    # Parameters that control the generation strategy used
     do_sample = False
+    # Parameters for manipulation of the model output logits
     temperature = 1.0
+    top_k = 50
+    top_p = 1.0
+    repetition_penalty = 1.0
+    # Parameters that define the outputs
+    num_return_sequences = 1
+    output_scores = False
 
 
 class FinishReason(Enum):
@@ -213,8 +218,8 @@ class TextGenerationPipeline(TransformersPipeline):
 
     def __init__(
         self,
-        prompt_sequence_length: int = 64,
         sequence_length: int = 1024,
+        prompt_sequence_length: int = 16,
         force_max_tokens: bool = False,
         internal_kv_cache: bool = True,
         generation_config: Union[str, pathlib.Path, Dict, GenerationConfig] = None,

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -64,7 +64,7 @@ __all__ = ["TextGenerationPipeline"]
 # Based off of https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig # noqa E501
 class GenerationDefaults:
     # Parameters that control the length of the output
-    max_length = 20 
+    max_length = 20
     max_new_tokens = 200
     # Parameters that control the generation strategy used
     do_sample = False

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -64,7 +64,7 @@ __all__ = ["TextGenerationPipeline"]
 # Based off of https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig # noqa E501
 class GenerationDefaults:
     # Parameters that control the length of the output
-    max_length = None 
+    max_length = None
     max_new_tokens = 200
     # Parameters that control the generation strategy used
     do_sample = False

--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -64,7 +64,7 @@ __all__ = ["TextGenerationPipeline"]
 # Based off of https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig # noqa E501
 class GenerationDefaults:
     # Parameters that control the length of the output
-    max_length = 20 
+    max_length = None 
     max_new_tokens = 200
     # Parameters that control the generation strategy used
     do_sample = False

--- a/src/deepsparse/transformers/text_generation.md
+++ b/src/deepsparse/transformers/text_generation.md
@@ -140,8 +140,8 @@ generations = text_pipeline(prompt=PROMPT, output_score=True)
 
 | Feature | Description | Deepsparse Default | HuggingFace Default | Supported |
 | :---    |      :----: |         :----:     |        :----:       |       ---:|
-| max_length | Maximum length of generated tokens. Equal to input_prompt + max_new_tokens. Overridden by max_new_tokens | 1024 | 20 | Yes|
-| max_new_tokens | Maximum number of tokens to generate, ignoring prompt tokens. | None | None | Yes |
+| max_length | Maximum length of generated tokens. Equal to input_prompt + max_new_tokens. Overridden by max_new_tokens | 20 | 20 | Yes|
+| max_new_tokens | Maximum number of tokens to generate, ignoring prompt tokens. | 200 | None | Yes |
 | min_length | Minimum length of generated tokens. Equal to input_prompt + min_new_tokens. Overridden by min_new_tokens | - | 0 | No
 | min_new_tokens | Minomum number of tokens to generate, ignoring prompt tokens. | - | None | No |
 | max_time | - | - | - | No |
@@ -151,9 +151,9 @@ generations = text_pipeline(prompt=PROMPT, output_score=True)
 
 | Feature | Description | Deepsparse Default | HuggingFace Default | Supported |
 | :---    |      :----: |         :----:     |        :----:       |       ---:|
-| top_k | The number of highest probability vocabulary tokens to keep for top-k-filtering | 0 | 50 | Yes
-| top_p | Keep the generated tokens where its cumulative probability is >= top_p | 0.0 | 1.0 | Yes
-| repetition_penalty | Penalty applied for generating new token. Existing token frequencies summed to subtraction the logit of its corresponding logit value | 0.0 | 1.0 | Yes |
+| top_k | The number of highest probability vocabulary tokens to keep for top-k-filtering | 50 | 50 | Yes
+| top_p | Keep the generated tokens where its cumulative probability is >= top_p | 1.0 | 1.0 | Yes
+| repetition_penalty | Penalty applied for generating new token. Existing token frequencies summed to subtraction the logit of its corresponding logit value | 1.0 | 1.0 | Yes |
 | temperature | The temperature to use when sampling from the probability distribution computed from the logits. Higher values will result in more random samples. Should be greater than 0.0 | 1.0 | 1.0 | Yes |
 | typical_p | - | - | - | No |
 | epsilon_cutoff | - | - | - | No |

--- a/src/deepsparse/transformers/text_generation.md
+++ b/src/deepsparse/transformers/text_generation.md
@@ -140,7 +140,7 @@ generations = text_pipeline(prompt=PROMPT, output_score=True)
 
 | Feature | Description | Deepsparse Default | HuggingFace Default | Supported |
 | :---    |      :----: |         :----:     |        :----:       |       ---:|
-| max_length | Maximum length of generated tokens. Equal to input_prompt + max_new_tokens. Overridden by max_new_tokens | 20 | 20 | Yes|
+| max_length | Maximum length of generated tokens. Equal to input_prompt + max_new_tokens. Overridden by max_new_tokens | None | 20 | Yes|
 | max_new_tokens | Maximum number of tokens to generate, ignoring prompt tokens. | 200 | None | Yes |
 | min_length | Minimum length of generated tokens. Equal to input_prompt + min_new_tokens. Overridden by min_new_tokens | - | 0 | No
 | min_new_tokens | Minomum number of tokens to generate, ignoring prompt tokens. | - | None | No |


### PR DESCRIPTION
Proposal for new defaults for the text-generation pipeline

Includes:
- Reducing `prompt_sequence_length` to 16. This is in line with benchmarking results showing the performance benefits of going larger than 16 is not great enough to offset the padding overhead. 
- Reducing the default number of generated tokens to 200 rather than 1k - we might even want to make this smaller like 50 to start with.
- Due to the above, I propose we make `max_length` None by default since it conflicts with `sequence_length`. Both of these are trying to control the maximum allowed length of `prompt + max_new_tokens` and by default we should be limited by `sequence_length` since we cannot run past that