### PR TITLE
[TexgGeneration][Bug] streaming skips generated token added from last prompt token

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -704,11 +704,13 @@ class TextGenerationPipeline(TransformersPipeline):
             # last prompt token is the first generated token
             # add it to generated tokens, and the logits
             generated_tokens = [token_generator.tokens[-1]]
+
             generated_logits = (
                 prompt_logits
                 if context.get("include_prompt_logits")
                 else [prompt_logits[-1]]
             )
+
             callback = context.get("callback")
             stop = context.get("stop")
 
@@ -722,12 +724,21 @@ class TextGenerationPipeline(TransformersPipeline):
                 )
 
             with timer.time(TextGenerationTimings.TOKEN_GENERATION):
+                if len(generated_tokens) < max_tokens:
+                    if streaming:
+                        yield (
+                            numpy.array([generated_tokens[-1]]),
+                            numpy.array([generated_logits[-1]]),
+                            [None],
+                        )
+
                 while len(generated_tokens) < max_tokens:
                     with timer.time(TextGenerationTimings.TOKEN_GENERATION_SINGLE):
                         logits = self.autoregressive_inference(
                             tokens=token_generator.tokens, kv_cache=session
                         )
                         token = token_generator.generate(logits=logits[0, -1, :])
+
                     generated_tokens.append(token)
                     generated_logits.append(logits)
 


### PR DESCRIPTION
## Summary 
- Fix this bug: https://app.asana.com/0/1205229323407165/1205618236158808/f
## Tested Locally:

## Streaming:
```
from deepsparse import Pipeline
from pathlib import Path

from huggingface_hub import snapshot_download
MODEL_PATH = snapshot_download(repo_id="mgoin/TinyStories-33M-quant-deepsparse")

pipeline = Pipeline.create(
   task="text_generation",
   model_path=MODEL_PATH,
   engine_type="onnxruntime",
)
inference = pipeline(prompt="She is in", streaming=True, max_length=17)
for i in inference:
   print(i)
```

## Output: 

```
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 480701) prompts='She is in' generations=[GeneratedText(text=' the', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 490254) prompts='She is in' generations=[GeneratedText(text=' kitchen', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 498992) prompts='She is in' generations=[GeneratedText(text='.', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 507721) prompts='She is in' generations=[GeneratedText(text=' She', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 516346) prompts='She is in' generations=[GeneratedText(text=' is', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 525062) prompts='She is in' generations=[GeneratedText(text=' making', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 533793) prompts='She is in' generations=[GeneratedText(text=' a', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 542584) prompts='She is in' generations=[GeneratedText(text=' cake', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 551423) prompts='She is in' generations=[GeneratedText(text=' for', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 560387) prompts='She is in' generations=[GeneratedText(text=' Mom', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 569149) prompts='She is in' generations=[GeneratedText(text='.', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 577878) prompts='She is in' generations=[GeneratedText(text=' She', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 586582) prompts='She is in' generations=[GeneratedText(text=' is', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 595374) prompts='She is in' generations=[GeneratedText(text=' making', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 604127) prompts='She is in' generations=[GeneratedText(text=' a', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 612984) prompts='She is in' generations=[GeneratedText(text=' card', score=None, finished=False, finished_reason=None)]
created=datetime.datetime(2023, 10, 3, 10, 40, 13, 629885) prompts='She is in' generations=[GeneratedText(text=' for', score=None, finished=True, finished_reason='length')]
```

## No Streaming:
```
created=datetime.datetime(2023, 10, 3, 10, 42, 26, 636040) prompts='She is in' generations=[GeneratedText(text=' the kitchen. She is making a cake for Mom. She is making a card for', score=None, finished=True, finished_reason='length')]
```