### PR TITLE
Revert #1263

### DIFF
--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -126,11 +126,7 @@ def initialize_kv_cache_state(
     #   required for the internal kv cache management
     kv_cache_tensor = numpy.zeros(
         (
-            # TODO: @tlrmchlsmth @bfineran: uncomment line below,
-            # temporarily ignoring `empty` as passing the empty
-            # kv cache array is currently causing a segfault in the
-            # internal kv-cache runtime
-            batch_size,  # if not empty else 0,
+            batch_size if not empty else 0,
             num_attention_heads,
             length if length is not None else length_,
             hidden_dims,

--- a/tests/deepsparse/transformers/utils/test_helpers.py
+++ b/tests/deepsparse/transformers/utils/test_helpers.py
@@ -113,8 +113,8 @@ def test_create_causal_mask(input_ids, attention_mask, expected_causal_mask):
             10,
             True,
             {
-                "past_key_values.1": numpy.zeros((5, 6, 10, 8), dtype=numpy.int8),
-                "past_key_values.2": numpy.zeros((5, 6, 10, 8), dtype=numpy.int8),
+                "past_key_values.1": numpy.zeros((0, 6, 10, 8), dtype=numpy.int8),
+                "past_key_values.2": numpy.zeros((0, 6, 10, 8), dtype=numpy.int8),
             },
         ),
     ],


### PR DESCRIPTION
We've resolved the segfault that was occurring in sparse quantized MPT prefill so we can reenable external input deallocation.