### PR TITLE
[bugfix] model_to_path should also download .data files from zoo

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -127,6 +127,12 @@ def model_to_path(model: Union[str, Model, File]) -> str:
         model = Model(model)
 
     if Model is not object and isinstance(model, Model):
+        # download any onnx data files in deployment directory
+        for deployment_file in model.deployment.files:
+            if ".data" in deployment_file.name:
+                # forces download of data file if not cached
+                deployment_file.path
+
         # default to the main onnx file for the model
         model = model.deployment.get_file(_MODEL_DIR_ONNX_NAME).path
 


### PR DESCRIPTION
fixes issue in #1247 where only `model.onnx` would be downloaded by default in `model_to_path` from a deployment directory. this breaks flows such as `benchmark` and `compile_model` which rely on only the `model_to_path` for the onnx file path from zoo.  with this change the function now also searches for and downloads `.data*` files

**test_plan:**
verified locally that data file downloads now trigger with a stub such as `zoo:mpt-7b-dolly_mpt_pretrain-base` where they weren't before