### PR TITLE
Make `Pipeline` printable

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -302,6 +302,26 @@ class Pipeline(BasePipeline):
 
         return pipeline_outputs
 
+    def __repr__(self):
+        """
+        :return: Unambiguous representation of the current pipeline
+        """
+        return "{}({})".format(self.__class__, self._properties_dict())
+
+    def __str__(self):
+        """
+        :return: Human readable form of the current pipeline
+        """
+        formatted_props = [
+            "\t{}: {}".format(key, val) for key, val in self._properties_dict().items()
+        ]
+
+        return "{}.{}:\n{}".format(
+            self.__class__.__module__,
+            self.__class__.__qualname__,
+            "\n".join(formatted_props),
+        )
+
     @classmethod
     def from_config(
         cls,

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -302,26 +302,6 @@ class Pipeline(BasePipeline):
 
         return pipeline_outputs
 
-    def __repr__(self):
-        """
-        :return: Unambiguous representation of the current pipeline
-        """
-        return "{}({})".format(self.__class__, self._properties_dict())
-
-    def __str__(self):
-        """
-        :return: Human readable form of the current pipeline
-        """
-        formatted_props = [
-            "\t{}: {}".format(key, val) for key, val in self._properties_dict().items()
-        ]
-
-        return "{}.{}:\n{}".format(
-            self.__class__.__module__,
-            self.__class__.__qualname__,
-            "\n".join(formatted_props),
-        )
-
     @classmethod
     def from_config(
         cls,
@@ -483,10 +463,10 @@ class Pipeline(BasePipeline):
             task=self.task,
             model_path=self.model_path_orig,
             engine_type=self.engine_type,
-            batch_size=self.batch_size,
-            num_cores=self.num_cores,
-            scheduler=self.scheduler,
-            input_shapes=self.input_shapes,
+            batch_size=self._batch_size,
+            num_cores=self._engine_args.get("num_cores"),
+            scheduler=self._engine_args.get("scheduler"),
+            input_shapes=self._engine_args.get("input_shapes"),
             alias=self.alias,
             kwargs=kwargs,
         )
@@ -551,6 +531,32 @@ class Pipeline(BasePipeline):
             self.onnx_file_path, self.engine_type, self._engine_args, self.context
         )
 
+    def _properties_dict(self) -> Dict:
+        return {
+            "config": self.to_config(),
+            "engine": self.engine,
+        }
+
+    def __repr__(self):
+        """
+        :return: Unambiguous representation of the current pipeline
+        """
+        return "{}({})".format(self.__class__, self._properties_dict())
+
+    def __str__(self):
+        """
+        :return: Human readable form of the current pipeline
+        """
+        formatted_props = [
+            "\t{}: {}".format(key, val) for key, val in self._properties_dict().items()
+        ]
+
+        return "{}.{}:\n{}".format(
+            self.__class__.__module__,
+            self.__class__.__qualname__,
+            "\n".join(formatted_props),
+        )
+
 
 class PipelineConfig(BaseModel):
     """
@@ -586,7 +592,7 @@ class PipelineConfig(BaseModel):
             "specifies all available cores. Default is None"
         ),
     )
-    scheduler: str = Field(
+    scheduler: Optional[str] = Field(
         default="async",
         description=(
             "(deepsparse only) kind of scheduler to execute with. Defaults to async"


### PR DESCRIPTION
Implements `__str__` and `__repr__` to make Pipeline show something useful when printed.

This PR just adds the config and engine to the printable properties - this covers most information. Also a small bugfix for `Pipeline.to_config()` 
```
    def _properties_dict(self) -> Dict:
        return {
            "config": self.to_config(),
            "engine": self.engine,
        }
```

Example:
```python
import deepsparse
pipe = deepsparse.Pipeline.create(task="text-generation", model_path="hf:mgoin/TinyStories-1M-deepsparse")
print(pipe)
### deepsparse.transformers.pipelines.text_generation.TextGenerationPipeline:
###         config: task='text_generation' model_path='hf:mgoin/TinyStories-1M-deepsparse' engine_type='deepsparse' batch_size=1 num_cores=None scheduler=None input_shapes=None alias=None kwargs={'input_schema': <class 'deepsparse.transformers.pipelines.text_generation.TextGenerationInput'>, 'output_schema': <class 'deepsparse.transformers.pipelines.text_generation.TextGenerationOutput'>}
###         engine: NLDecoderEngine: deepsparse.engine.Engine:
###         onnx_file_path: /home/mgoin/.cache/huggingface/hub/models--mgoin--TinyStories-1M-deepsparse/snapshots/62256599e36d99faefb58461e0030e19e1050ea1/model.onnx
###         batch_size: 1
###         num_cores: 18
###         num_streams: 1
###         scheduler: Scheduler.default
###         fraction_of_supported_ops: 1.0
###         cpu_avx_type: avx512
###         cpu_vnni: False

pipe = deepsparse.Pipeline.create(task="yolo")
print(pipe)
### deepsparse.yolo.pipelines.YOLOPipeline:
###         config: task='yolo' model_path='zoo:cv/detection/yolov5-l/pytorch/ultralytics/coco/pruned_quant-aggressive_95' engine_type='deepsparse' batch_size=1 num_cores=None scheduler=None input_shapes=None alias=None kwargs={'model_config': None, 'class_names': None, 'image_size': (640, 640), 'input_schema': <class 'deepsparse.yolo.schemas.YOLOInput'>, 'output_schema': <class 'deepsparse.yolo.schemas.YOLOOutput'>}
###         engine: deepsparse.engine.Engine:
###         onnx_file_path: /home/mgoin/.cache/sparsezoo/neuralmagic/yolov5-l-coco-pruned.4block_quantized/deployment/model.onnx
###         batch_size: 1
###         num_cores: 18
###         num_streams: 1
###         scheduler: Scheduler.default
###         fraction_of_supported_ops: 1.0
###         cpu_avx_type: avx512
###         cpu_vnni: False
```