### PR TITLE
[server] Update OpenAI Model Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -306,6 +306,7 @@ def _setup_entry_points() -> Dict:
             "deepsparse.benchmark_pipeline=deepsparse.benchmark.benchmark_pipeline:main",  # noqa E501
             "deepsparse.benchmark_sweep=deepsparse.benchmark.benchmark_sweep:main",
             "deepsparse.server=deepsparse.server.cli:main",
+            "deepsparse.openai=deepsparse.server.cli:openai",
             "deepsparse.object_detection.annotate=deepsparse.yolo.annotate:main",
             "deepsparse.yolov8.annotate=deepsparse.yolov8.annotate:main",
             "deepsparse.yolov8.eval=deepsparse.yolov8.validation:main",

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -261,6 +261,24 @@ def main(
         token_normalize_func=lambda x: x.replace("-", "_"), show_default=True
     ),
 )
+@click.argument("config-file", type=str)
+@HOST_OPTION
+@PORT_OPTION
+@LOG_LEVEL_OPTION
+@HOT_RELOAD_OPTION
+def openai(
+    config_file: str, host: str, port: int, log_level: str, hot_reload_config: bool
+):
+
+    server = OpenAIServer(server_config=config_file)
+    server.start_server(host, port, log_level, hot_reload_config=hot_reload_config)
+
+
+@main.command(
+    context_settings=dict(
+        token_normalize_func=lambda x: x.replace("-", "_"), show_default=True
+    ),
+)
 @click.argument("config-path", type=str)
 @HOST_OPTION
 @PORT_OPTION

--- a/src/deepsparse/server/deepsparse_server.py
+++ b/src/deepsparse/server/deepsparse_server.py
@@ -26,6 +26,15 @@ _LOGGER = logging.getLogger(__name__)
 
 class DeepsparseServer(Server):
     def _add_routes(self, app):
+        @app.get("/v2/health/ready", tags=["health"], response_model=CheckReady)
+        @app.get("/v2/health/live", tags=["health"], response_model=CheckReady)
+        def _check_health():
+            return CheckReady(status="OK")
+
+        @app.get("/v2", tags=["metadata", "server"], response_model=str)
+        def _get_server_info():
+            return "This is the deepsparse server. Hello!"
+
         @app.post("/endpoints", tags=["endpoints"], response_model=bool)
         def _add_endpoint_endpoint(cfg: EndpointConfig):
             if cfg.name is None:

--- a/src/deepsparse/server/openai_server.py
+++ b/src/deepsparse/server/openai_server.py
@@ -36,7 +36,7 @@ from deepsparse.server.protocol import (
     UsageInfo,
     random_uuid,
 )
-from deepsparse.server.server import Server, SystemLoggingMiddleware
+from deepsparse.server.server import Server
 from fastapi import BackgroundTasks, FastAPI, Request
 from fastapi.responses import StreamingResponse
 
@@ -70,7 +70,7 @@ class OpenAIServer(Server):
 
         @app.get("/v1/models", tags=["model"])
         async def show_available_models():
-            """Show available models. Right now we only have one model."""
+            """Show available models."""
             return app.model_list
 
         @app.post(
@@ -95,7 +95,7 @@ class OpenAIServer(Server):
             pipeline = app.model_to_pipeline.get(model)
             if not pipeline:
                 create_error_response(
-                    HTTPStatus.BAD_REQUEST, f"{model} is not " "available"
+                    HTTPStatus.BAD_REQUEST, f"{model} is not available"
                 )
 
             try:

--- a/src/deepsparse/server/sagemaker.py
+++ b/src/deepsparse/server/sagemaker.py
@@ -29,6 +29,10 @@ class SagemakerServer(DeepsparseServer):
         super().__init__(**kwargs)
 
     def _add_routes(self, app: FastAPI):
+        @app.get("/ping", tags=["health"], response_model=CheckReady)
+        def _check_health():
+            return CheckReady(status="OK")
+
         return super()._add_routes(app)
 
     def _add_inference_endpoints(

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -166,16 +166,6 @@ class Server:
         def _info():
             return self.server_config
 
-        @app.get("/ping", tags=["health"], response_model=CheckReady)
-        @app.get("/v2/health/ready", tags=["health"], response_model=CheckReady)
-        @app.get("/v2/health/live", tags=["health"], response_model=CheckReady)
-        def _check_health():
-            return CheckReady(status="OK")
-
-        @app.get("/v2", tags=["metadata", "server"], response_model=str)
-        def _get_server_info():
-            return "This is the deepsparse server. Hello!"
-
         return app
 
     def _set_pytorch_num_threads(self):


### PR DESCRIPTION
## Summary
- This PR is focused on updating the openai integration such that it is more independent of the deepsparse server, leveraging the server refactor
- This PR allows multiple text generation models to hosted using the single `/v1/chat/completions` endpoint, adds the `/v1/models` endpoint, updates the base routes, and also adds a separate openai specific workflow command

## Examples and testing
- On the command line, the following command can be used:
```
deepsparse.openai sample_config.yaml 
```

Here, `sample_config.yaml` has the following structure:

```
num_cores: 2
num_workers: 2
endpoints:
  - task: text_generation
    model: zoo:nlg/text_generation/opt-1.3b/pytorch/huggingface/opt_pretrain/pruned50_quantW8A8-none
```

- This launches a FASTAPI app with the following endpoints:
<img width="1477" alt="Screenshot 2023-10-06 at 12 51 05 PM" src="https://github.com/neuralmagic/deepsparse/assets/22260572/4b637d2a-08e7-4231-ab03-b0153110b928">

## Use the `openai` api to send requests:

```python
import openai


openai.api_key = "EMPTY"
openai.api_base = "http://localhost:5543/v1"

# Completion API
stream = False
completion = openai.ChatCompletion.create(
    messages="how are you?",
    stream=stream,
    max_tokens=30,
    model="zoo:nlg/text_generation/opt-1.3b/pytorch/huggingface/opt_pretrain/pruned50_quantW8A8-none",
)

print("Chat results:")
if stream:
    text = ""
    for c in completion:
        print(c)
else:
    print(completion)

```

- The user can provide the model they want to run inference on as part of the payload. If that model was not provided when launching the server, an error will be returned. We will be adding functionality to allow the user to add additional models, after the server has already been launched.