### PR TITLE
[bugfix] enforce that all transformer deployement files are downloaded by pipeline

### DIFF
--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -74,6 +74,9 @@ def get_deployment_path(model_path: str) -> Tuple[str, str]:
     elif model_path.startswith("zoo:"):
         zoo_model = Model(model_path)
         deployment_path = zoo_model.deployment.path
+        for deployment_file in zoo_model.deployment.files:
+            # force download of any missing files in deployment directory
+            deployment_file.path
         return deployment_path, os.path.join(deployment_path, _MODEL_DIR_ONNX_NAME)
     elif model_path.startswith("hf:"):
         from huggingface_hub import snapshot_download


### PR DESCRIPTION
recent changes simplify downloading transformers deployment files by just running `zoo_model.depoyment.path` while this works in the base case, @dbarbuzzi found that if some files are already downloaded (ie just onnx files for benchmarking) the additional configs will not be downloaded by this command.

this pr simply loops over the deployment directory's contents to makes sure that all files get downloaded before any pipelines run

**test_plan:**
manually verified