### PR TITLE
Add support for pulling down ARM and MacOS artifacts

### DIFF
--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -59,7 +59,7 @@ def get_platform_string():
             return "manylinux_aarch64"
     elif system == "Darwin":
         if machine == "arm64":
-            return "macos_13_0_arm64"
+            return "macosx_13_0_arm64"
 
     raise ValueError(f"Unsupported or unrecognized platform: {machine}, {system}")
 

--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -14,12 +14,12 @@
 
 import argparse
 import os
+import platform
 import sys
 import tarfile
 from io import BytesIO
 from typing import Tuple
 from urllib.request import Request, urlopen
-import platform
 
 
 __all__ = [

--- a/utils/artifacts.py
+++ b/utils/artifacts.py
@@ -19,6 +19,7 @@ import tarfile
 from io import BytesIO
 from typing import Tuple
 from urllib.request import Request, urlopen
+import platform
 
 
 __all__ = [
@@ -45,6 +46,22 @@ def parse_args():
     )
 
     return parser.parse_args()
+
+
+def get_platform_string():
+    machine = platform.machine()
+    system = platform.system()
+
+    if system == "Linux":
+        if machine == "x86_64":
+            return "manylinux_x86_64"
+        elif machine == "aarch64":
+            return "manylinux_aarch64"
+    elif system == "Darwin":
+        if machine == "arm64":
+            return "macos_13_0_arm64"
+
+    raise ValueError(f"Unsupported or unrecognized platform: {machine}, {system}")
 
 
 def get_release_and_version(package_path: str) -> Tuple[bool, bool, str, str, str, str]:
@@ -99,6 +116,7 @@ def download_wand_binaries(package_path: str, full_version: str, is_release: boo
     and extract them to the right location
     """
     release_string = "release" if is_release else "nightly"
+    platform_string = get_platform_string()
 
     print(
         f"Unable to find wand binaries locally in {package_path}.\n"
@@ -111,7 +129,7 @@ def download_wand_binaries(package_path: str, full_version: str, is_release: boo
         f"-cp{sys.version_info[0]}{sys.version_info[1]}"
         f"-cp{sys.version_info[0]}{sys.version_info[1]}"
         f"{'' if sys.version_info[1] > 7 else 'm'}"  # 3.6 and 3.7 have a 'm'
-        "-manylinux_x86_64.tar.gz"
+        f"-{platform_string}.tar.gz"
     )
 
     print("Requesting", artifact_url)


### PR DESCRIPTION
Tested using `pip install -e .` on AWS m7g.2xlarge and M1 Macbook with python 3.10