### PR TITLE
[server] Fix tests + allow server to parse generation kwargs

### DIFF
--- a/src/deepsparse/server/sagemaker.py
+++ b/src/deepsparse/server/sagemaker.py
@@ -57,11 +57,25 @@ class SagemakerServer(DeepsparseServer):
 
         if hasattr(pipeline.input_schema, "from_files"):
             routes_and_fns.append(
-                (route, partial(Server.predict_from_files, ProxyPipeline(pipeline)))
+                (
+                    route + "/from_files",
+                    partial(
+                        Server.predict_from_files,
+                        ProxyPipeline(pipeline),
+                        self.server_config.system_logging,
+                    ),
+                )
             )
         else:
             routes_and_fns.append(
-                (route, partial(Server.predict, ProxyPipeline(pipeline)))
+                (
+                    route,
+                    partial(
+                        Server.predict,
+                        ProxyPipeline(pipeline),
+                        self.server_config.system_logging,
+                    ),
+                )
             )
 
         self._update_routes(

--- a/tests/server/test_endpoints.py
+++ b/tests/server/test_endpoints.py
@@ -38,8 +38,8 @@ class StrSchema(BaseModel):
     value: str
 
 
-def parse(v: StrSchema) -> int:
-    return int(v.value)
+def parse(value) -> int:
+    return int(value)
 
 
 class TestStatusEndpoints:
@@ -106,7 +106,7 @@ class TestMockEndpoints:
     ):
         mock_pipeline = Mock(
             side_effect=parse,
-            input_schema=StrSchema,
+            input_schema=str,
             output_schema=int,
             logger=MultiLogger([]),
         )
@@ -146,6 +146,7 @@ class TestMockEndpoints:
         assert app.routes[-1].path == "/v2/models/predict/parse_int/infer/from_files"
         assert app.routes[-1].endpoint.func.__annotations__ == {
             "proxy_pipeline": ProxyPipeline,
+            "system_logging_config": SystemLoggingConfig,
             "request": List[UploadFile],
         }
         assert app.routes[-1].response_model is int
@@ -159,9 +160,12 @@ class TestMockEndpoints:
             pipeline=Mock(input_schema=FromFilesSchema, output_schema=int),
         )
         assert len(app.routes) == num_routes + 1
-        assert app.routes[-1].path == "/invocations/predict/parse_int/infer"
+        num_routes = len(app.routes)
+
+        assert app.routes[-1].path == "/invocations/predict/parse_int/infer/from_files"
         assert app.routes[-1].endpoint.func.__annotations__ == {
             "proxy_pipeline": ProxyPipeline,
+            "system_logging_config": SystemLoggingConfig,
             "request": List[UploadFile],
         }
 
@@ -174,7 +178,8 @@ class TestMockEndpoints:
         assert app.routes[-1].path == "/invocations/predict/parse_int/infer"
         assert app.routes[-1].endpoint.func.__annotations__ == {
             "proxy_pipeline": ProxyPipeline,
-            "request": List[UploadFile],
+            "system_logging_config": SystemLoggingConfig,
+            "raw_request": Request,
         }
 
     def test_add_endpoint_with_no_route_specified(self, server, app):


### PR DESCRIPTION
Summary

- Small update such that kwargs for generation can be given as an input to the server, without having to just be defined through the `generation_config` arguments
- Small test updates + typo fix in sagemaker

Testing:

sample config:

```yaml
num_cores: 2
num_workers: 2
endpoints:
  - task: question_answering
    model: zoo:nlp/question_answering/bert-base/pytorch/huggingface/squad/12layer_pruned80_quant-none-vnni
  - task: text_generation
    model: zoo:opt-1.3b-opt_pretrain-quantW8A8
    kwargs: {"generation_config": {"max_length": 100}}
```

We can start a server with the generation config and also send requests with attributes outside of the config:

```python
import requests
url = "http://localhost:5543/v2/models/text_generation-0/infer"
obj = {"prompt": "Hey! How are you?", "max_length": 10}

response = requests.post(url, json=obj)
print(response.text)
```

- Also updated/tested all server tests which are passing