### PR TITLE
download compressed deployment directory

### DIFF
--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -73,10 +73,7 @@ def get_deployment_path(model_path: str) -> Tuple[str, str]:
 
     elif model_path.startswith("zoo:"):
         zoo_model = Model(model_path)
-        deployment_path = zoo_model.deployment.path
-        for deployment_file in zoo_model.deployment.files:
-            # force download of any missing files in deployment directory
-            deployment_file.path
+        deployment_path = zoo_model.deployment_directory_path
         return deployment_path, os.path.join(deployment_path, _MODEL_DIR_ONNX_NAME)
     elif model_path.startswith("hf:"):
         from huggingface_hub import snapshot_download

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -127,11 +127,8 @@ def model_to_path(model: Union[str, Model, File]) -> str:
         model = Model(model)
 
     if Model is not object and isinstance(model, Model):
-        # download any onnx data files in deployment directory
-        for deployment_file in model.deployment.files:
-            if ".data" in deployment_file.name:
-                # forces download of data file if not cached
-                deployment_file.path
+        # trigger download and unzipping of deployment directory if not cached
+        model.deployment_directory_path
 
         # default to the main onnx file for the model
         model = model.deployment.get_file(_MODEL_DIR_ONNX_NAME).path


### PR DESCRIPTION
to land with https://github.com/neuralmagic/sparsezoo/pull/373

updates deployment directory downloads to target the compressed directory instead of loose files

**simple test:**
```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
    "text-generation",
    model_path="zoo:nlg/text_generation/mpt-7b/pytorch/huggingface/mpt_chat/base-none",
    engine_type="onnxruntime"
)

pipeline("test", generation_config=dict(max_new_tokens=10))
```