### PR TITLE
Fix typo in sentiment analysis HTTP client example

### DIFF
--- a/src/deepsparse/transformers/README.md
+++ b/src/deepsparse/transformers/README.md
@@ -215,7 +215,7 @@ Making a request:
 ```python
 import requests
 
-url = "http://localhost:5543/v2/models/setiment_analysis/infer" # Server's port default to 5543
+url = "http://localhost:5543/v2/models/sentiment_analysis/infer" # Server's port default to 5543
 
 obj = {"sequences": "Snorlax loves my Tesla!"}
 


### PR DESCRIPTION
This PR fixes a typo in the Python client example of the Sentiment Analysis > HTTP Server section. The typo was in the URL used to make the request and thus caused the request to fail due to the URL being incorrect.