### PR TITLE
Add bucketing to DeepSparseSentenceTransformer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -274,10 +274,7 @@ def _setup_extras() -> Dict:
         "openpifpaf": _openpifpaf_integration_deps,
         "yolov8": _yolov8_integration_deps,
         "transformers": _transformers_integration_deps,
-<<<<<<< HEAD
         "llm": _transformers_integration_deps,
-=======
->>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)
         "sentence_transformers": _sentence_transformers_integration_deps,
         "torch": _torch_deps,
         "clip": _clip_deps,

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,10 @@ def _setup_extras() -> Dict:
         "openpifpaf": _openpifpaf_integration_deps,
         "yolov8": _yolov8_integration_deps,
         "transformers": _transformers_integration_deps,
+<<<<<<< HEAD
         "llm": _transformers_integration_deps,
+=======
+>>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)
         "sentence_transformers": _sentence_transformers_integration_deps,
         "torch": _torch_deps,
         "clip": _clip_deps,

--- a/src/deepsparse/sentence_transformers/README.md
+++ b/src/deepsparse/sentence_transformers/README.md
@@ -40,16 +40,13 @@ for sentence, embedding in zip(sentences, embeddings):
 
 ## Benchmarking Performance
 
-There is a `benchmarking_encoding.py` script located in this directory that compares a standard model running in both SentenceTransformers and DeepSparse, with a sparsified model in DeepSparse. Here is an example run on an 8 core SPR CPU with the base model being `BAAI/bge-small-en-v1.5`:
+There is a `benchmark_encoding.py` script located in this directory that compares a standard model running in both SentenceTransformers and DeepSparse, with a sparsified model in DeepSparse. Here is an example run on an 8 core SPR CPU with the base model being `BAAI/bge-small-en-v1.5`:
 ```bash
-python ~/benchmark_sentencetransformers.py
+python benchmark_encoding.py --base_model BAAI/bge-small-en-v1.5 --sparse_model zeroshot/bge-small-en-v1.5-quant
 
 [Standard SentenceTransformer] Encoded 100 sentences of length 700 in 10.42 seconds.
-Batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:04<00:00, 24.77it/s]
 [DeepSparse] Encoded 100 sentences of length 700 in 4.04 seconds.
-Batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 54.95it/s]
 [DeepSparse Optimized] Encoded 100 sentences of length 700 in 1.82 seconds.
-
 ```
 
 

--- a/src/deepsparse/sentence_transformers/README.md
+++ b/src/deepsparse/sentence_transformers/README.md
@@ -1,6 +1,8 @@
 
 # DeepSparse SentenceTransformers
 
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1sfN8zDK7MIyatiSIbt2xWh0i6GnaBnTR?usp=sharing)
+
 ```python
 from deepsparse.sentence_transformers import SentenceTransformer
 ```

--- a/src/deepsparse/sentence_transformers/README.md
+++ b/src/deepsparse/sentence_transformers/README.md
@@ -38,6 +38,21 @@ for sentence, embedding in zip(sentences, embeddings):
     print("")
 ```
 
+## Benchmarking Performance
+
+There is a `benchmarking_encoding.py` script located in this directory that compares a standard model running in both SentenceTransformers and DeepSparse, with a sparsified model in DeepSparse. Here is an example run on an 8 core SPR CPU with the base model being `BAAI/bge-small-en-v1.5`:
+```bash
+python ~/benchmark_sentencetransformers.py
+
+[Standard SentenceTransformer] Encoded 100 sentences of length 700 in 10.42 seconds.
+Batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:04<00:00, 24.77it/s]
+[DeepSparse] Encoded 100 sentences of length 700 in 4.04 seconds.
+Batches: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:01<00:00, 54.95it/s]
+[DeepSparse Optimized] Encoded 100 sentences of length 700 in 1.82 seconds.
+
+```
+
+
 ## Accuracy Validation with MTEB
 
 DeepSparse's efficiency doesn't compromise its accuracy, thanks to testing with the Multilingual Text Embedding Benchmark (MTEB). This process validates the model's performance against standard tasks, ensuring its reliability.

--- a/src/deepsparse/sentence_transformers/__init__.py
+++ b/src/deepsparse/sentence_transformers/__init__.py
@@ -33,4 +33,4 @@ except ImportError:
     )
 
 
-from .sentence_transformer import SentenceTransformer
+from .sentence_transformer import DeepSparseSentenceTransformer, SentenceTransformer

--- a/src/deepsparse/sentence_transformers/benchmark_encoding.py
+++ b/src/deepsparse/sentence_transformers/benchmark_encoding.py
@@ -18,9 +18,7 @@ import string
 import time
 
 import sentence_transformers
-from deepsparse.sentence_transformers import (
-    SentenceTransformer as DeepSparseSentenceTransformer,
-)
+from deepsparse.sentence_transformers import DeepSparseSentenceTransformer
 
 
 def generate_random_sentence(length=700):

--- a/src/deepsparse/sentence_transformers/benchmark_encoding.py
+++ b/src/deepsparse/sentence_transformers/benchmark_encoding.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import string
+import time
+
+import sentence_transformers
+from deepsparse.sentence_transformers import (
+    SentenceTransformer as DeepSparseSentenceTransformer,
+)
+
+
+def generate_random_sentence(length=700):
+    # Generate a random sentence of a given length.
+    return "".join(
+        random.choices(
+            string.ascii_letters
+            + string.digits
+            + string.punctuation
+            + string.whitespace,
+            k=length,
+        )
+    )
+
+
+def benchmark_model(model, sentences):
+    # Benchmark the encoding time for a model with a given list of sentences.
+    start_time = time.time()
+    _ = model.encode(sentences)
+    elapsed_time = time.time() - start_time
+    return elapsed_time
+
+
+# Generate a list of random sentences
+num_sentences = 100
+sentences = [generate_random_sentence() for _ in range(num_sentences)]
+
+# Model names
+model_name = "BAAI/bge-small-en-v1.5"
+sparse_model_name = "zeroshot/bge-small-en-v1.5-quant"
+
+# Load the models
+standard_model = sentence_transformers.SentenceTransformer(model_name)
+deepsparse_model = DeepSparseSentenceTransformer(model_name, export=True)
+deepsparse_opt_model = DeepSparseSentenceTransformer(sparse_model_name)
+
+# Benchmark sentence_transformers
+standard_time = benchmark_model(standard_model, sentences)
+print(
+    f"[Standard SentenceTransformer] Encoded {num_sentences} sentences "
+    f"of length {len(sentences[0])} in {standard_time:.2f} seconds."
+)
+
+# Benchmark deepsparse.sentence_transformers
+deepsparse_time = benchmark_model(deepsparse_model, sentences)
+print(
+    f"[DeepSparse] Encoded {num_sentences} sentences of length "
+    f"{len(sentences[0])} in {deepsparse_time:.2f} seconds."
+)
+
+# Benchmark deepsparse.sentence_transformers
+deepsparse_opt_time = benchmark_model(deepsparse_opt_model, sentences)
+print(
+    f"[DeepSparse Optimized] Encoded {num_sentences} sentences of length "
+    f"{len(sentences[0])} in {deepsparse_opt_time:.2f} seconds."
+)

--- a/src/deepsparse/sentence_transformers/sentence_transformer.py
+++ b/src/deepsparse/sentence_transformers/sentence_transformer.py
@@ -44,6 +44,7 @@ from optimum.deepsparse import DeepSparseModelForFeatureExtraction
 logger = logging.getLogger(__name__)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 DEFAULT_MODEL_NAME = "zeroshot/bge-small-en-v1.5-quant"
 
 
@@ -81,11 +82,17 @@ class SentenceTransformer:
         self._max_seq_length = max_seq_length
 =======
 DEFAULT_MODEL_NAME = "zeroshot/oneshot-minilm"
+=======
+DEFAULT_MODEL_NAME = "zeroshot/bge-small-en-v1.5-quant"
+>>>>>>> 7a4cc1d5 (Update)
 
 
 class SentenceTransformer:
     def __init__(
-        self, model_name_or_path: str = DEFAULT_MODEL_NAME, export: bool = False
+        self,
+        model_name_or_path: str = DEFAULT_MODEL_NAME,
+        export: bool = False,
+        max_seq_length: int = 512,
     ):
 
         self.model_name_or_path = model_name_or_path
@@ -94,7 +101,7 @@ class SentenceTransformer:
         )
         self.tokenizer = get_preprocessor(model_name_or_path)
 
-        self._max_seq_length = 512
+        self._max_seq_length = max_seq_length
         self._batch_size = 1
 >>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)
 
@@ -108,6 +115,7 @@ class SentenceTransformer:
         convert_to_tensor: bool = False,
         normalize_embeddings: bool = False,
     ) -> Union[List[torch.Tensor], np.ndarray, torch.Tensor]:
+<<<<<<< HEAD
         """
         Computes sentence embeddings
 
@@ -130,6 +138,11 @@ class SentenceTransformer:
            a stacked tensor is returned. If convert_to_numpy, a numpy matrix
            is returned.
         """
+=======
+
+        # TODO: support executing with batch size > 1
+        batch_size = 1
+>>>>>>> 7a4cc1d5 (Update)
 
         if show_progress_bar is None:
             show_progress_bar = logger.getEffectiveLevel() in (
@@ -197,13 +210,19 @@ class SentenceTransformer:
                         last_mask_id -= 1
 
                     embeddings.append(token_emb[0 : last_mask_id + 1])
-            elif output_value is None:  # Return all outputs
+            elif output_value is None:
+                # Return all outputs
                 embeddings = []
                 for sent_idx in range(len(out_features["sentence_embedding"])):
                     row = {name: out_features[name][sent_idx] for name in out_features}
                     embeddings.append(row)
+<<<<<<< HEAD
             else:  # Sentence embeddings
 >>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)
+=======
+            else:
+                # Sentence embeddings
+>>>>>>> 7a4cc1d5 (Update)
                 embeddings = out_features[output_value]
                 if normalize_embeddings:
                     embeddings = torch.nn.functional.normalize(embeddings, p=2, dim=1)
@@ -223,6 +242,7 @@ class SentenceTransformer:
         return all_embeddings
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     def get_max_seq_length(self) -> int:
         """
         Returns the maximal sequence length for input the model accepts.
@@ -233,14 +253,21 @@ class SentenceTransformer:
     def _text_length(self, text: Union[List[int], List[List[int]]]) -> int:
 =======
     def get_max_seq_length(self):
+=======
+    def get_max_seq_length(self) -> int:
+>>>>>>> 7a4cc1d5 (Update)
         """
         Returns the maximal sequence length for input the model accepts.
         Longer inputs will be truncated
         """
         return self._max_seq_length
 
+<<<<<<< HEAD
     def _text_length(self, text: Union[List[int], List[List[int]]]):
 >>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)
+=======
+    def _text_length(self, text: Union[List[int], List[List[int]]]) -> int:
+>>>>>>> 7a4cc1d5 (Update)
         """
         Help function to get the length for the input text. Text can be either
         a list of ints (which means a single text as input), or a tuple of list of ints
@@ -263,6 +290,7 @@ class SentenceTransformer:
         return self.tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 
     def mean_pooling(
         self, model_output: torch.Tensor, attention_mask: torch.Tensor
@@ -276,6 +304,12 @@ class SentenceTransformer:
 
     def mean_pooling(self, model_output: torch.Tensor, attention_mask: torch.Tensor):
 >>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)
+=======
+
+    def mean_pooling(
+        self, model_output: torch.Tensor, attention_mask: torch.Tensor
+    ) -> torch.Tensor:
+>>>>>>> 7a4cc1d5 (Update)
         """
         Compute mean pooling of token embeddings weighted by attention mask.
         Args:

--- a/src/deepsparse/sentence_transformers/sentence_transformer.py
+++ b/src/deepsparse/sentence_transformers/sentence_transformer.py
@@ -160,11 +160,13 @@ class SentenceTransformer:
         ):
             sentences_batch = sentences_sorted[start_index : start_index + batch_size]
 
+            model_inputs = self.tokenize(sentences_batch)
+
             if self.buckets and batch_size == 1:
                 # Use bucketing for batch size 1
                 # Select the model based on the bucketing logic
                 # TODO: tokenize ahead of time and simply add padding
-                seq_length = len(self.tokenize(sentences_batch)[0])
+                seq_length = len(model_inputs[0])
                 selected_bucket = self._select_bucket(seq_length)
 
                 # Tokenize using the selected bucket size
@@ -174,7 +176,6 @@ class SentenceTransformer:
                 model = self.models[selected_bucket]
             else:
                 # Use dynamic shape
-                model_inputs = self.tokenize(sentences_batch)
                 model = self.dyn_model
 
             # Run the inference

--- a/src/deepsparse/sentence_transformers/sentence_transformer.py
+++ b/src/deepsparse/sentence_transformers/sentence_transformer.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL_NAME = "zeroshot/bge-small-en-v1.5-quant"
 
 
-class SentenceTransformer:
+class DeepSparseSentenceTransformer:
     """
     Loads or creates a SentenceTransformer-compatible model that can be used to map
     text to embeddings.
@@ -289,3 +289,6 @@ class SentenceTransformer:
         return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(
             input_mask_expanded.sum(1), min=1e-9
         )
+
+# for backwards compatibility
+SentenceTransformer = DeepSparseSentenceTransformer

--- a/src/deepsparse/sentence_transformers/sentence_transformer.py
+++ b/src/deepsparse/sentence_transformers/sentence_transformer.py
@@ -14,6 +14,7 @@
 
 import logging
 <<<<<<< HEAD
+<<<<<<< HEAD
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
@@ -24,12 +25,20 @@ import torch
 from optimum.deepsparse import DeepSparseModelForFeatureExtraction
 =======
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Type, Union
+=======
+from typing import Dict, List, Tuple, Union
+>>>>>>> 4441aad0 (Format)
 
 import numpy as np
 from tqdm.autonotebook import trange
+from transformers.onnx.utils import get_preprocessor
 
 import torch
+<<<<<<< HEAD
 >>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)
+=======
+from optimum.deepsparse import DeepSparseModelForFeatureExtraction
+>>>>>>> 4441aad0 (Format)
 
 
 logger = logging.getLogger(__name__)
@@ -78,9 +87,6 @@ class SentenceTransformer:
     def __init__(
         self, model_name_or_path: str = DEFAULT_MODEL_NAME, export: bool = False
     ):
-        from transformers.onnx.utils import get_preprocessor
-
-        from optimum.deepsparse import DeepSparseModelForFeatureExtraction
 
         self.model_name_or_path = model_name_or_path
         self.model = DeepSparseModelForFeatureExtraction.from_pretrained(
@@ -228,7 +234,8 @@ class SentenceTransformer:
 =======
     def get_max_seq_length(self):
         """
-        Returns the maximal sequence length for input the model accepts. Longer inputs will be truncated
+        Returns the maximal sequence length for input the model accepts.
+        Longer inputs will be truncated
         """
         return self._max_seq_length
 
@@ -255,12 +262,17 @@ class SentenceTransformer:
         """
         return self.tokenizer(texts, padding=True, truncation=True, return_tensors="pt")
 <<<<<<< HEAD
+<<<<<<< HEAD
 
     def mean_pooling(
         self, model_output: torch.Tensor, attention_mask: torch.Tensor
     ) -> torch.Tensor:
 =======
         # return self.tokenizer(texts, padding='max_length', truncation=True, max_length=self.get_max_seq_length(), return_tensors="pt")
+=======
+        # return self.tokenizer(texts, padding='max_length', truncation=True,
+        #  max_length=self.get_max_seq_length(), return_tensors="pt")
+>>>>>>> 4441aad0 (Format)
 
     def mean_pooling(self, model_output: torch.Tensor, attention_mask: torch.Tensor):
 >>>>>>> b750add0 (Support for SentenceTransformer with `deepsparse.sentence_transformers.SentenceTransformer`)

--- a/src/deepsparse/sentence_transformers/sentence_transformer.py
+++ b/src/deepsparse/sentence_transformers/sentence_transformer.py
@@ -290,5 +290,6 @@ class DeepSparseSentenceTransformer:
             input_mask_expanded.sum(1), min=1e-9
         )
 
+
 # for backwards compatibility
 SentenceTransformer = DeepSparseSentenceTransformer

--- a/src/deepsparse/sentence_transformers/sentence_transformer.py
+++ b/src/deepsparse/sentence_transformers/sentence_transformer.py
@@ -54,7 +54,6 @@ class SentenceTransformer:
         use_auth_token: Union[bool, str, None] = None,
         buckets: Union[bool, List[int]] = True,
     ):
-
         self.model_name_or_path = model_name_or_path
         self.tokenizer = get_preprocessor(model_name_or_path)
         self._max_seq_length = max_seq_length
@@ -62,8 +61,11 @@ class SentenceTransformer:
         self._static_batch_size = 1
 
         self.dyn_model = DeepSparseModelForFeatureExtraction.from_pretrained(
-            model_name_or_path, export=export, use_auth_token=use_auth_token
+            model_name_or_path,
+            export=export,
+            use_auth_token=use_auth_token,
         )
+        self.dyn_model.reshape(input_shapes="[0,0]")
         self.dyn_model.compile(batch_size=0)
 
         if buckets:
@@ -77,7 +79,9 @@ class SentenceTransformer:
                     model_name_or_path,
                     export=export,
                     use_auth_token=use_auth_token,
-                    input_shapes=f"[{self._static_batch_size},{bucket}]",
+                )
+                self.models[bucket].reshape(
+                    input_shapes=f"[{self._static_batch_size},{bucket}]"
                 )
                 self.models[bucket].compile(batch_size=self._static_batch_size)
         else:

--- a/src/deepsparse/sentence_transformers/sentence_transformer.py
+++ b/src/deepsparse/sentence_transformers/sentence_transformer.py
@@ -88,16 +88,32 @@ DEFAULT_MODEL_NAME = "zeroshot/bge-small-en-v1.5-quant"
 
 
 class SentenceTransformer:
+    """
+    Loads or creates a SentenceTransformer-compatible model that can be used to map
+    text to embeddings.
+
+    :param model_name_or_path: If it is a filepath on disc, it loads the model from
+        that path. If it is not a path, it first tries to download and export a model
+        from a HuggingFace models repository with that name.
+    :param export: To load a PyTorch checkpoint and convert it to the DeepSparse
+        format on-the-fly, you can set `export=True` when loading your model.
+    :param max_seq_length: Sets a limit on the maxmimum sequence length allowed,
+        this should be set to 512 for most models. Any text that exceeds this
+        token length will be truncated.
+    :param use_auth_token: HuggingFace authentication token to download private models.
+    """
+
     def __init__(
         self,
         model_name_or_path: str = DEFAULT_MODEL_NAME,
         export: bool = False,
         max_seq_length: int = 512,
+        use_auth_token: Union[bool, str, None] = None,
     ):
 
         self.model_name_or_path = model_name_or_path
         self.model = DeepSparseModelForFeatureExtraction.from_pretrained(
-            model_name_or_path, export=export
+            model_name_or_path, export=export, use_auth_token=use_auth_token
         )
         self.tokenizer = get_preprocessor(model_name_or_path)
 
@@ -116,6 +132,9 @@ class SentenceTransformer:
         normalize_embeddings: bool = False,
     ) -> Union[List[torch.Tensor], np.ndarray, torch.Tensor]:
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 5936830a (Address comments)
         """
         Computes sentence embeddings
 
@@ -138,9 +157,12 @@ class SentenceTransformer:
            a stacked tensor is returned. If convert_to_numpy, a numpy matrix
            is returned.
         """
+<<<<<<< HEAD
 =======
+=======
+>>>>>>> 5936830a (Address comments)
 
-        # TODO: support executing with batch size > 1
+        # TODO: support faster execution with batch size > 1
         batch_size = 1
 >>>>>>> 7a4cc1d5 (Update)
 
@@ -182,6 +204,7 @@ class SentenceTransformer:
             )
 
 <<<<<<< HEAD
+<<<<<<< HEAD
             embeddings = []
             if output_value == "token_embeddings":
                 for token_emb, attention in zip(
@@ -200,19 +223,20 @@ class SentenceTransformer:
             else:
                 # Sentence embeddings
 =======
+=======
+            embeddings = []
+>>>>>>> 5936830a (Address comments)
             if output_value == "token_embeddings":
-                embeddings = []
                 for token_emb, attention in zip(
                     out_features[output_value], out_features["attention_mask"]
                 ):
-                    last_mask_id = len(attention) - 1
-                    while last_mask_id > 0 and attention[last_mask_id].item() == 0:
-                        last_mask_id -= 1
-
-                    embeddings.append(token_emb[0 : last_mask_id + 1])
+                    # Apply the attention mask to remove embeddings for padding tokens
+                    # Count non-zero values in the attention mask
+                    actual_tokens_count = attention.sum().item()
+                    # Slice the embeddings using this count
+                    embeddings.append(token_emb[:actual_tokens_count])
             elif output_value is None:
                 # Return all outputs
-                embeddings = []
                 for sent_idx in range(len(out_features["sentence_embedding"])):
                     row = {name: out_features[name][sent_idx] for name in out_features}
                     embeddings.append(row)


### PR DESCRIPTION
Tighten up performance for DeepSparseSentenceTransformer by implementing bucketing alongside a dynamic model for small sequence lengths and batching. This also comes with a benchmarking script that shows speedup compared against SentenceTransformers
```bash
python benchmark_encoding.py --base_model BAAI/bge-small-en-v1.5 --sparse_model zeroshot/bge-small-en-v1.5-quant

[Standard SentenceTransformer] Encoded 100 sentences of length 700 in 10.42 seconds.
[DeepSparse] Encoded 100 sentences of length 700 in 4.04 seconds.
[DeepSparse Optimized] Encoded 100 sentences of length 700 in 1.82 seconds.
```