### PR TITLE
[Fix] Bring back `model.deployment_directory_path`

### DIFF
--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -73,7 +73,7 @@ def get_deployment_path(model_path: str) -> Tuple[str, str]:
 
     elif model_path.startswith("zoo:"):
         zoo_model = Model(model_path)
-        deployment_path = zoo_model.deployment.path
+        deployment_path = zoo_model.deployment_directory_path
         return deployment_path, os.path.join(deployment_path, _MODEL_DIR_ONNX_NAME)
     elif model_path.startswith("hf:"):
         from huggingface_hub import snapshot_download


### PR DESCRIPTION
Reverting my change from #1324 
Back then, I was not aware that this property of the sparsezoo `Model` was an intended change (assumed it was a typo)