### PR TITLE
[text generation] fix issues with top_p

### DIFF
--- a/src/deepsparse/transformers/utils/token_generator.py
+++ b/src/deepsparse/transformers/utils/token_generator.py
@@ -19,6 +19,9 @@ import numpy
 from deepsparse.utils.data import numpy_softmax
 
 
+_MIN_FLOAT = numpy.finfo(numpy.float32).min
+
+
 class TokenGenerator:
     """
     Responsible for generating tokens, and contains functions that
@@ -115,7 +118,7 @@ class TokenGenerator:
 
     # from https://gist.github.com/thomwolf/1a5a29f6962089e871b94cbd09daf31
     def apply_top_k(
-        self, logits: numpy.ndarray, filter_value=-float("Inf")
+        self, logits: numpy.ndarray, filter_value=_MIN_FLOAT
     ) -> numpy.ndarray:
         """
         Keep top_k logits based on its value. All other values
@@ -134,7 +137,7 @@ class TokenGenerator:
     def apply_top_p(
         self,
         logits: numpy.ndarray,
-        filter_value=-float("Inf"),
+        filter_value=_MIN_FLOAT,
         min_tokens_to_keep: int = 1,
     ) -> numpy.ndarray:
         """
@@ -156,7 +159,7 @@ class TokenGenerator:
         # (token with 0 are kept)
         sorted_indices_to_remove = logit_cumulative_probs > self.top_p
         # Keep at least min_tokens_to_keep
-        sorted_indices_to_remove[..., -min_tokens_to_keep:] = 0
+        sorted_indices_to_remove[..., :min_tokens_to_keep] = 0
 
         # scatter sorted tensors to original indexing
         indices_to_remove = sorted_indices[sorted_indices_to_remove]

--- a/src/deepsparse/transformers/utils/token_generator.py
+++ b/src/deepsparse/transformers/utils/token_generator.py
@@ -151,15 +151,16 @@ class TokenGenerator:
         logits_shape = logits.shape
         logits = logits.reshape(logits.shape[-1])
 
-        sorted_indices = numpy.argsort(logits)[::-1]
+        sorted_indices = numpy.argsort(logits)
         sorted_logits = logits[sorted_indices]
         logit_cumulative_probs = numpy.cumsum(numpy_softmax(sorted_logits))
 
         # Remove tokens with cumulative top_p above the threshold
         # (token with 0 are kept)
-        sorted_indices_to_remove = logit_cumulative_probs > self.top_p
+        sorted_indices_to_remove = logit_cumulative_probs <= (1 - self.top_p)
         # Keep at least min_tokens_to_keep
-        sorted_indices_to_remove[..., :min_tokens_to_keep] = 0
+        if min_tokens_to_keep:
+            sorted_indices_to_remove[..., -min_tokens_to_keep:] = 0
 
         # scatter sorted tensors to original indexing
         indices_to_remove = sorted_indices[sorted_indices_to_remove]


### PR DESCRIPTION
fixes two issues with `top_p`:

1. setting filtered values to `-inf` is incompatible with `numpy.choice`, was causing issues with numpy.choice in certain scenarios
2. fixes top_p application to grab the true top `p` percent by weight of the logits softmax distribution (previously was sorting  descending causing the least likely tokens would have the highest density)

**minimal reproducible example:**
```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
    "text-generation",
    model_path="hf:neuralmagic/mpt-7b-chat-pruned50-quant",
    engine_type="onnxruntime",
    sequence_length=32,
    prompt_sequence_length=1,
)
generation_config = dict(top_p=0.5, max_new_tokens=5, do_sample=True)
pipeline("def hello_world:", generation_config=generation_config)
```

**test_plan:**
@horheynm to add unit tests in ongoing refactor