### PR TITLE
Enable preparing nested OutputSchemas for serialization

### DIFF
--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy
 from pydantic import BaseModel
@@ -75,26 +75,34 @@ def server_logger_from_config(config: ServerConfig) -> BaseLogger:
     )
 
 
-def prep_outputs_for_serialization(pipeline_outputs: Any):
+def prep_outputs_for_serialization(
+    pipeline_outputs: Union[BaseModel, numpy.ndarray, list]
+) -> Union[BaseModel, list]:
     """
     Prepares a pipeline output for JSON serialization by converting any numpy array
     field to a list. For large numpy arrays, this operation will take a while to run.
 
-    :param pipeline_outputs: output data to clean
-    :return: cleaned pipeline_outputs
+    :param pipeline_outputs: output data to that is to be processed before
+        serialisation. Nested objects are supported.
+    :return: Pipeline_outputs with potential numpy arrays
+        converted to lists
     """
     if isinstance(pipeline_outputs, BaseModel):
         for field_name in pipeline_outputs.__fields__.keys():
             field_value = getattr(pipeline_outputs, field_name)
-            if field_name == "generations":
-                if isinstance(field_value[0].score, numpy.ndarray):
-                    # numpy arrays aren't JSON serializable
-                    field_value[0].score = field_value[0].score.tolist()
-            if isinstance(field_value, numpy.ndarray):
-                # numpy arrays aren't JSON serializable
-                setattr(pipeline_outputs, field_name, field_value.tolist())
+            if isinstance(field_value, (numpy.ndarray, BaseModel, list)):
+                setattr(
+                    pipeline_outputs,
+                    field_name,
+                    prep_outputs_for_serialization(field_value),
+                )
+
     elif isinstance(pipeline_outputs, numpy.ndarray):
         pipeline_outputs = pipeline_outputs.tolist()
+
+    elif isinstance(pipeline_outputs, list):
+        for i, value in enumerate(pipeline_outputs):
+            pipeline_outputs[i] = prep_outputs_for_serialization(value)
 
     return pipeline_outputs
 

--- a/src/deepsparse/server/helpers.py
+++ b/src/deepsparse/server/helpers.py
@@ -86,6 +86,10 @@ def prep_outputs_for_serialization(pipeline_outputs: Any):
     if isinstance(pipeline_outputs, BaseModel):
         for field_name in pipeline_outputs.__fields__.keys():
             field_value = getattr(pipeline_outputs, field_name)
+            if field_name == "generations":
+                if isinstance(field_value[0].score, numpy.ndarray):
+                    # numpy arrays aren't JSON serializable
+                    field_value[0].score = field_value[0].score.tolist()
             if isinstance(field_value, numpy.ndarray):
                 # numpy arrays aren't JSON serializable
                 setattr(pipeline_outputs, field_name, field_value.tolist())


### PR DESCRIPTION
Currently, the `prep_outputs_for_serialization` function assumes that `pipeline_outputs` cannot be arbitrarily nested (allows up to one level of nesting). This is why, for more complex `BaseModels` returned by the python (e.g. `TextGenerationOutput`), the function will not properly convert nested numpy arrays to lists for serialization.

My diff makes sure that any `pipeline_output: BaseModel` that contains an arbitrary number and nesting depth of any fields that are either a `BaseModel`, `list` of `numpy.ndarray` is supported.

As a result, we can now serialize logits of the LLM output, that previously was not properly converted from numpy array to a list. 

```python
import requests

model_path = "hf:mgoin/TinyStories-1M-deepsparse"
prompt =  ["name one former president of the USA"]
server_address = "http://0.0.0.0:5543/v2/models/gen/infer"

payload = {"prompt": prompt, "output_scores": True, "include_prompt_logits": True}
response = requests.post(server_address, json=payload)
response = response.json()

num_tokens_prompt_and_generated = len(response["generations"][0]["score"])

payload = {"prompt": prompt, "output_scores": True}
response = requests.post(server_address, json=payload)
response = response.json()

num_tokens_generated = len(response["generations"][0]["score"])
num_tokens_prompt = num_tokens_prompt_and_generated - num_tokens_generated
print(f"Number of prompt tokens: {num_tokens_prompt}")
print(f"Number of generated tokens: {num_tokens_generated}")
```

returns

```bash
Number of prompt tokens: 6
Number of generated tokens: 3
```