### PR TITLE
update datasets version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ _openpifpaf_integration_deps = [
 _yolov8_integration_deps = _yolo_integration_deps + ["ultralytics==8.0.124"]
 _transformers_integration_deps = [
     "transformers<4.35",
-    "datasets<2.13",
+    "datasets<=2.14.6",
     "scikit-learn",
     "seqeval",
 ]


### PR DESCRIPTION
Asana ticket: [NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported. (from datasets)](https://app.asana.com/0/1203126676641557/1205796604651399/f)

The latest fsspec release(2023.10.0) caused a breaking change with the datasets library. Upgrading our datasets version fixes the issue. Alternatively, we can downgrade fsspec. This change was already pushed to SparseML main