### PR TITLE
[Continuous Batching] Executor thread for running continuous batching

### DIFF
--- a/src/deepsparse/v2/schedulers/utils/__init__.py
+++ b/src/deepsparse/v2/schedulers/utils/__init__.py
@@ -16,3 +16,4 @@
 # limitations under the License.
 
 from .continuous_batching_queues import *
+from .continuous_batching_executor import *

--- a/src/deepsparse/v2/schedulers/utils/continuous_batching_executor.py
+++ b/src/deepsparse/v2/schedulers/utils/continuous_batching_executor.py
@@ -49,25 +49,11 @@ class ContinuousBatchingExecutorThread(Thread):
         self._should_stop = False
 
         super().__init__(target=self._working_loop)
-
-    def start(self, *args, **kwargs):
-        self._should_stop = False
-        super().start(*args, **kwargs)
-
-    def stop_next(self):
-        """
-        Stops the working loop after the next execution
-        """
-        if self.is_alive():
-            self._should_stop = True
-
-    @property
-    def should_stop(self):
-        return self._should_stop
+        self.daemon = True  # worker thread should exit when main thread exits
 
     def _working_loop(self):
         # indefinitely wait for batch, run batch, split and resolve futures
-        while not self.should_stop:
+        while True:
             # wait for next batch to be available
             engine_operator, batch = self._queues.pop_batch(block=True)
 

--- a/src/deepsparse/v2/schedulers/utils/continuous_batching_executor.py
+++ b/src/deepsparse/v2/schedulers/utils/continuous_batching_executor.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from threading import Thread
+from typing import Dict
+
+from deepsparse import Engine
+from deepsparse.v2.operators import EngineOperator
+from deepsparse.v2.schedulers.utils.continuous_batching_queues import (
+    ContinuousBatchingQueues,
+)
+
+
+__all__ = [
+    "ContinuousBatchingExecutorThread",
+]
+
+
+class ContinuousBatchingExecutorThread(Thread):
+    """
+    Thread that when started runs indefinitely, grabbing a valid batch from
+    the queues when possible and running them in the correct engine
+
+    :param queues: ContinuousBatchingQueues object containing a queue for
+        each valid engine
+    :param operators_to_engines: dictionary mapping valid engine operators
+        to a dictionary of its valid batch sizes mapped to an engine compiled
+        for that batch size
+    """
+
+    def __init__(
+        self,
+        queues: ContinuousBatchingQueues,
+        operators_to_engines: Dict[EngineOperator, Dict[int, Engine]],
+    ):
+        self._queues = queues
+        self._operators_to_engines = operators_to_engines
+        self._should_stop = False
+
+        super().__init__(target=self._working_loop)
+
+    def start(self, *args, **kwargs):
+        self._should_stop = False
+        super().start(*args, **kwargs)
+
+    def stop_next(self):
+        """
+        Stops the working loop after the next execution
+        """
+        if self.is_alive():
+            self._should_stop = True
+
+    @property
+    def should_stop(self):
+        return self._should_stop
+
+    def _working_loop(self):
+        # indefinitely wait for batch, run batch, split and resolve futures
+        while not self.should_stop:
+            # wait for next batch to be available
+            engine_operator, batch = self._queues.pop_batch(block=True)
+
+            # unpack batch of QueueEntry objects
+            engine_inputs, futures, _ = list(zip(*batch))
+            batch_size = len(engine_inputs)
+
+            # type is EngineOperatorInputs
+            joined_inputs = engine_operator.input_schema.join(engine_inputs)
+
+            # get engine for this operator compiled to the popped batch size
+            # and set the inputs to execute with it
+            joined_inputs.engine = self._operators_to_engines[engine_operator][
+                batch_size
+            ]
+
+            # run the engine operator with the given engine at the joined batch size
+            joined_outputs = engine_operator(joined_inputs)
+
+            # split outputs and return the results to their respective futures
+            split_outputs = joined_outputs.split()
+            for output, future in zip(split_outputs, futures):
+                future.set_result(output)

--- a/tests/deepsparse/v2/schedulers/utils/test_continuous_batching_executor.py
+++ b/tests/deepsparse/v2/schedulers/utils/test_continuous_batching_executor.py
@@ -40,15 +40,8 @@ def test_continuous_batching_executor_thread():
     # thread not started yet
     assert not worker_thread.is_alive()
 
-    # start
+    # start and assert thread is alive
     worker_thread.start()
-
-    # have thread exit itself cleanly after loop
-    # if not set, then on next blocking call to pop_batch pytest will hang
-    # even after test completion due to blocked lock
-    worker_thread.stop_next()
-
-    # assert worker is alive
     assert worker_thread.is_alive()
 
     # create first input and add it to queue
@@ -88,6 +81,3 @@ def test_continuous_batching_executor_thread():
     # TODO: test that the correct bs1 item is returned (can test against bs1 engine)
     assert_batch_size_one(result_1.engine_outputs)
     assert_batch_size_one(result_2.engine_outputs)
-
-    # make sure thread stopped as expected
-    assert not worker_thread.is_alive()

--- a/tests/deepsparse/v2/schedulers/utils/test_continuous_batching_executor.py
+++ b/tests/deepsparse/v2/schedulers/utils/test_continuous_batching_executor.py
@@ -17,7 +17,6 @@ from concurrent.futures import Future
 
 import numpy
 
-from deepsparse import compile_model
 from deepsparse.v2.operators import EngineOperator
 from deepsparse.v2.schedulers.utils import (
     ContinuousBatchingExecutorThread,

--- a/tests/deepsparse/v2/schedulers/utils/test_continuous_batching_executor.py
+++ b/tests/deepsparse/v2/schedulers/utils/test_continuous_batching_executor.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from concurrent.futures import Future
+
+import numpy
+
+from deepsparse import compile_model
+from deepsparse.v2.operators import EngineOperator
+from deepsparse.v2.schedulers.utils import (
+    ContinuousBatchingExecutorThread,
+    ContinuousBatchingQueues,
+)
+
+
+def test_continuous_batching_executor_thread():
+    # mobilenet model with batch_size=2
+    engine_operator = EngineOperator("zoo:mobilenet_v2-1.0-imagenet-base", batch_size=2)
+
+    # create queues object and add operator
+    queues = ContinuousBatchingQueues()
+    queues.add_queue(engine_operator, batch_sizes=[2])
+
+    # create engine map
+    operators_to_engines = {engine_operator: {2: engine_operator.engine}}
+
+    worker_thread = ContinuousBatchingExecutorThread(queues, operators_to_engines)
+
+    # thread not started yet
+    assert not worker_thread.is_alive()
+
+    # start
+    worker_thread.start()
+
+    # have thread exit itself cleanly after loop
+    # if not set, then on next blocking call to pop_batch pytest will hang
+    # even after test completion due to blocked lock
+    worker_thread.stop_next()
+
+    # assert worker is alive
+    assert worker_thread.is_alive()
+
+    # create first input and add it to queue
+    input_1 = engine_operator.input_schema(
+        engine_inputs=[numpy.random.randn(1, 3, 224, 224).astype(numpy.float32)]
+    )
+    future_1 = Future()
+    queues.add_queue_item(engine_operator, input_1, future=future_1)
+
+    # assert that future is not yet resolved
+    assert not future_1.done()
+
+    # create second input and add it to queue
+    input_2 = engine_operator.input_schema(
+        engine_inputs=[numpy.random.randn(1, 3, 224, 224).astype(numpy.float32)]
+    )
+    future_2 = Future()
+    queues.add_queue_item(engine_operator, input_2, future=future_2)
+
+    # wait 1 second to give engine time to complete
+    time.sleep(1)
+
+    assert future_1.done()
+    assert future_2.done()
+
+    result_1 = future_1.result()
+    result_2 = future_2.result()
+
+    assert isinstance(result_1, engine_operator.output_schema)
+    assert isinstance(result_2, engine_operator.output_schema)
+
+    def assert_batch_size_one(arrays):
+        for array in arrays:
+            assert array.shape[0] == 1
+
+    # make sure only a single batch item was returned to each future
+    # TODO: test that the correct bs1 item is returned (can test against bs1 engine)
+    assert_batch_size_one(result_1.engine_outputs)
+    assert_batch_size_one(result_2.engine_outputs)
+
+    # make sure thread stopped as expected
+    assert not worker_thread.is_alive()


### PR DESCRIPTION
This PR adds a helper class for executing `EngineOperators` using batches popped from `ContinuousBatchingQueues`.

The idea is that this thread can run indefinitely, waiting for a new batch from the `ContinuousBatchingQueues` and running them as available.

The `ContinuousBatchingScheduler` will spin up `num_workers` of these threads and run them indefinitely

**test_plan:**
unit test included