### PR TITLE
Add hf: stub support to model_to_path

### DIFF
--- a/src/deepsparse/transformers/helpers.py
+++ b/src/deepsparse/transformers/helpers.py
@@ -76,15 +76,17 @@ def get_deployment_path(model_path: str) -> Tuple[str, str]:
         deployment_path = zoo_model.deployment_directory_path
         return deployment_path, os.path.join(deployment_path, _MODEL_DIR_ONNX_NAME)
     elif model_path.startswith("hf:"):
+        # load Hugging Face model from stub
         from huggingface_hub import snapshot_download
 
         deployment_path = snapshot_download(repo_id=model_path.replace("hf:", "", 1))
         onnx_path = os.path.join(deployment_path, _MODEL_DIR_ONNX_NAME)
         if not os.path.isfile(onnx_path):
             raise ValueError(
-                f"{_MODEL_DIR_ONNX_NAME} not found in transformers model directory "
-                f"{deployment_path}. Be sure that an export of the model is written to "
-                f"{onnx_path}"
+                f"Could not find the ONNX model file '{_MODEL_DIR_ONNX_NAME}' in the "
+                f"Hugging Face Hub repository located at {deployment_path}. Please "
+                f"ensure the model has been correctly exported to ONNX format and "
+                f"exists in the repository."
             )
         return deployment_path, onnx_path
     else:

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -138,6 +138,21 @@ def model_to_path(model: Union[str, Model, File]) -> str:
         # get the downloaded_path -- will auto download if not on local system
         model = model.path
 
+    if isinstance(model, str) and model.startswith("hf:"):
+        # load Hugging Face model from stub
+        from huggingface_hub import snapshot_download
+
+        deployment_path = snapshot_download(repo_id=model.replace("hf:", "", 1))
+        onnx_path = os.path.join(deployment_path, _MODEL_DIR_ONNX_NAME)
+        if not os.path.isfile(onnx_path):
+            raise ValueError(
+                f"Could not find the ONNX model file '{_MODEL_DIR_ONNX_NAME}' in the "
+                f"Hugging Face Hub repository located at {deployment_path}. Please "
+                f"ensure the model has been correctly exported to ONNX format and "
+                f"exists in the repository."
+            )
+        return onnx_path
+
     if not isinstance(model, str):
         raise ValueError("unsupported type for model: {}".format(type(model)))
 


### PR DESCRIPTION
Tada - just like the transformer pipeline, support HF paths in common places like Engine construction and benchmarking

```
deepsparse.benchmark hf:mgoin/TinyStories-33M-ds -q
Fetching 9 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:00<00:00, 139294.23it/s]
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.6.0 COMMUNITY | (3d596172) (optimized) (system=avx512_vnni, binary=avx512)
Original Model Path: hf:mgoin/TinyStories-33M-ds
Batch Size: 1
Scenario: sync
Throughput (items/sec): 346.2459
Latency Mean (ms/batch): 2.8814
Latency Median (ms/batch): 2.8814
Latency Std (ms/batch): 0.2968
Iterations: 3463
```