### PR TITLE
[continuous batching] singleton pattern for scheduler

### DIFF
--- a/src/deepsparse/v2/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/v2/schedulers/continuous_batching_scheduler.py
@@ -83,8 +83,10 @@ class ContinuousBatchingScheduler(OperatorScheduler):
             schedule all jobs is created and started
         """
         if _GLOBAL_SCHEDULER is not None:
-            return _GLOBAL_SCHEDULER
-        return cls(max_workers=1)
+            return _GLOBAL_SCHEDULER  # noqa: F823
+
+        _GLOBAL_SCHEDULER = cls(max_workers=1)
+        return _GLOBAL_SCHEDULER
 
     @property
     def max_workers(self) -> int:


### PR DESCRIPTION
singleton pattern for continuous batching scheduler is favorable so that engine requests coming from different pipelines are scheduled together and do not interfere with each other. 

this diff provides a simple implementation and extends the docstring with a small example