### PR TITLE
[Cherry Pick] [Fix] Remove erronous LIB.kv_cache input when using external kv cache management 

### DIFF
--- a/src/deepsparse/transformers/engines/nl_decoder_engine.py
+++ b/src/deepsparse/transformers/engines/nl_decoder_engine.py
@@ -175,7 +175,7 @@ class NLDecoderEngine:
         else:
             # run the engine assuming external kv cache
             # management.
-            return self.engine.run(inputs, val_inp, kv_cache)
+            return self.engine.run(inputs, val_inp)
 
     def __call__(
         self,


### PR DESCRIPTION
https://github.com/neuralmagic/deepsparse/pull/1337 into `release/1.6`