### PR TITLE
[Text Generation][V2][Fix] Properly digest `max_new_tokens` argument

### DIFF
--- a/src/deepsparse/transformers/utils/helpers.py
+++ b/src/deepsparse/transformers/utils/helpers.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import numpy
 from transformers import AutoTokenizer, GenerationConfig
 
-from deepsparse.utils.onnx import CACHE_INPUT_PREFIX, CACHE_OUTPUT_PREFIX
+from src.deepsparse.utils.onnx import CACHE_INPUT_PREFIX, CACHE_OUTPUT_PREFIX
 
 
 __all__ = [
@@ -45,9 +45,9 @@ def set_generated_length(
     prompt_tokens_length: int,
     sequence_length: int,
     prompt_sequence_length: int,
-    max_new_tokens: int,
     finish_reason_choices: "FinishReason",  # noqa
-):
+    max_new_tokens: Optional[int] = None,
+) -> Tuple[int, "FinishReason"]:  # noqa
     """
     Determine the length of the generated tokens. The hard cap on the total number
     of tokens is based on the sequence length. If max_length is provided and is less
@@ -62,18 +62,29 @@ def set_generated_length(
     :param prompt_sequence_length: the prompt sequence length used for the pipeline
     :param max_new_tokens: the max_new_tokens attribute, which may be provided
     as part of the input during inference
+    :return a tuple of the total number of tokens to generate and the reason for
+        stopping
     """
-    if max_length:
-        # if max_length provided, use that to cap total tokens generated
-        max_tokens = max_length
-        finish_reason = finish_reason_choices.LENGTH
-    else:
-        # if not provided, max tokens is based on max_new_tokens + prompt tokens
+
+    if max_new_tokens is not None:
+        # If max_new_tokens is specified, it will take
+        # priority over `max_length` parameter. As a
+        # result, total max tokens is based on
+        # max_new_tokens + prompt tokens
         max_tokens = (
             min(max_new_tokens, sequence_length - prompt_sequence_length)
             + prompt_tokens_length
         )
         finish_reason = finish_reason_choices.MAX_NEW_TOKENS
+    elif max_length is not None:
+        # if max_length provided, use that to cap total tokens generated
+        max_tokens = max_length
+        finish_reason = finish_reason_choices.LENGTH
+    else:
+        raise ValueError(
+            "Unable to compute `max_tokens` to generate. Please provide either "
+            "`max_length` or `max_new_tokens` as arguments to `generation_config`"
+        )
 
     # hard model/pipeline cap
     return (

--- a/tests/deepsparse/transformers/utils/test_helpers.py
+++ b/tests/deepsparse/transformers/utils/test_helpers.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from enum import Enum
 
 import numpy
 
@@ -19,8 +20,63 @@ from deepsparse.transformers.utils.helpers import (
     compute_engine_inputs,
     create_causal_mask,
     initialize_kv_cache_state,
+    set_generated_length,
     validate_session_ids,
 )
+
+
+class DummyFinishReason(Enum):
+    LENGTH = "length"
+    CAPACITY = "capacity"
+    MAX_NEW_TOKENS = "max_new_tokens"
+
+
+@pytest.mark.parametrize(
+    "max_length, "
+    "prompt_tokens_length, "
+    "sequence_length, "
+    "prompt_sequence_length, "
+    "finish_reason_choices, "
+    "max_new_tokens, "
+    "expected_max_tokens, "
+    "expected_finish_reason",
+    [
+        (20, 10, 30, 2, DummyFinishReason, None, 20, DummyFinishReason.LENGTH),
+        (None, 10, 30, 2, DummyFinishReason, None, None, None),
+        (20, 10, 30, 2, DummyFinishReason, 5, 15, DummyFinishReason.MAX_NEW_TOKENS),
+        (20, 10, 5, 2, DummyFinishReason, 5, 5, DummyFinishReason.CAPACITY),
+    ],
+)
+def test_set_generated_length(
+    max_length,
+    prompt_tokens_length,
+    sequence_length,
+    prompt_sequence_length,
+    finish_reason_choices,
+    max_new_tokens,
+    expected_max_tokens,
+    expected_finish_reason,
+):
+    if max_length is None and max_new_tokens is None:
+        with pytest.raises(ValueError):
+            set_generated_length(
+                max_length,
+                prompt_tokens_length,
+                sequence_length,
+                prompt_sequence_length,
+                finish_reason_choices,
+                max_new_tokens,
+            )
+            return
+    out = set_generated_length(
+        max_length,
+        prompt_tokens_length,
+        sequence_length,
+        prompt_sequence_length,
+        finish_reason_choices,
+        max_new_tokens,
+    )
+    assert out == (expected_max_tokens, expected_finish_reason)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Feature Description

Two arguments specify the number of generated tokens: `max_lenght` (includes prompt length) and `max_new_tokens` (does not include prompt length); as specified in `GenerationDefaults` in `src.deepsparse.v2.text_generation.process_inputs.py`:

```python
class GenerationDefaults:
    num_return_sequences = 1
    max_length = 100
    max_new_tokens = None
    output_scores = False
    top_k = 0
    top_p = 0.0
    repetition_penalty = 0.0
    do_sample = False
    temperature = 1.0
```

However, the logic of the pipeline was such, that it always used `max_length` argument and ignored `max_new_tokens` argument. This diff assumes that if `max_new_tokens` != None, it would take precedence over `max_length`.

This is demonstrated by this code snippet:

```python
from deepsparse.v2.text_generation.pipeline import TextGenerationPipeline
model_path = "hf:mgoin/TinyStories-1M-deepsparse"
max_new_tokens = 64
pipeline = TextGenerationPipeline(model_path,generation_config=dict(max_new_tokens=max_new_tokens), force_max_tokens=True)
out = pipeline(prompt=["Get more cheese than doritos, cheetos, or fritos"])
print(f"Number of prompt tokens: {len(pipeline.tokenizer.tokenize(out.prompts[0]))}")
print(f"Number of generated tokens: {len(pipeline.tokenizer.tokenize(out.generations[0].text))} versus {max_new_tokens}")
```

Before:
```bash
Number of prompt tokens: 17
Number of generated tokens: 19 versus 64
```

Now:
```bash
Number of prompt tokens: 17
Number of generated tokens: 64 versus 64
```

## Testing
All tests in `tests.deepsparse.v2.unit` and `tests.deepsparse.transformers` pass.