### PR TITLE
[Test][Text Generation Pipeline] Add a lightweight integration tests (uses `TinyStories-1M`)

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation.py
@@ -1106,10 +1106,10 @@ class TextGenerationPipeline(TransformersPipeline):
             if debug:
                 sessions = debug[0]
                 kv_cache_state = numpy.stack(
-                    session.cached_inputs for session in sessions
+                    [session.cached_inputs for session in sessions]
                 )
                 num_processed_tokens = numpy.stack(
-                    session.total_num_processed_tokens for session in sessions
+                    [session.total_num_processed_tokens for session in sessions]
                 )
 
                 yield [

--- a/src/deepsparse/yolov8/README.md
+++ b/src/deepsparse/yolov8/README.md
@@ -42,7 +42,7 @@ After training your model with `SparseML`, locate the `.pt` file for the model y
 
 ```bash
 sparseml.ultralytics.export_onnx \
-    --weights path/to/your/model \
+    --model path/to/your/model \
     --dynamic #Allows for dynamic input shape
 ```
 This creates a `model.onnx` file, in the directory of your `weights` (e.g. `runs/train/weights/model.onnx`).
@@ -83,7 +83,7 @@ deepsparse.yolov8.annotate --source basilica.jpg --model_filepath "yolov8n.onnx"
 
 Running the above command will create an `annotation-results` folder and save the annotated image inside.
 
-#### Annotate CLI
+#### Eval CLI
 You can also use the `eval` command to have the engine run inference on a dataset (in the same fashion as it is being done in `ultralytics` module)
 ```bash
 deepsparse.yolov8.eval --model_path yolov8n.onnx

--- a/tests/deepsparse/transformers/pipelines/integration_tests/configs/gpt_neo.yaml
+++ b/tests/deepsparse/transformers/pipelines/integration_tests/configs/gpt_neo.yaml
@@ -1,0 +1,8 @@
+cadence: "commit"
+model_path: "hf:mgoin/TinyStories-1M-ds"
+torch_model_name: "roneneldan/TinyStories-1M"
+task: ["text-generation"]
+prompt: "Didn't know what time it was, the lights were low\n I leaned back on my radio"
+has_bos_token: True
+precision: 0.0001
+internal_kv_cache: [True, False]

--- a/tests/deepsparse/transformers/pipelines/integration_tests/configs/gpt_neo.yaml
+++ b/tests/deepsparse/transformers/pipelines/integration_tests/configs/gpt_neo.yaml
@@ -4,5 +4,5 @@ torch_model_name: "roneneldan/TinyStories-1M"
 task: ["text-generation"]
 prompt: "Didn't know what time it was, the lights were low\n I leaned back on my radio"
 has_bos_token: True
-precision: 0.0001
+precision: 0.001
 internal_kv_cache: [True, False]


### PR DESCRIPTION
We are currently not running any integration tests in GHA. As a result, there exists a set of potential errors, that we cannot catch in our CI. This PR adds a very lightweight integration test, that will run on every commit. It hardens the coverage of the `TextGenerationPipeline`. 