### PR TITLE
[Fix][Text Generation Pipeline] Fix the erroneous sampling logic

### DIFF
--- a/src/deepsparse/transformers/utils/token_generator.py
+++ b/src/deepsparse/transformers/utils/token_generator.py
@@ -77,15 +77,16 @@ class TokenGenerator:
         :param logits: the logits from the model with shape (vocab_size,)
         :return: the sampled token
         """
-        if self.top_k:
-            logits = self.apply_top_k(logits)
-        if self.top_p:
-            logits = self.apply_top_p(logits)
-
         if self.deterministic:
             token = numpy.argmax(logits)
             self.tokens.append(token)
             return token
+
+        if self.top_k:
+            logits = self.apply_top_k(logits)
+
+        if self.top_p:
+            logits = self.apply_top_p(logits)
 
         if self.sampling_temperature != 1.0:
             logits /= self.sampling_temperature


### PR DESCRIPTION
## Fix Description

Before: regardless of whether `sampling=True or False` we would do `top_k `and `top_p` sampling.
Now: if `sampling=False`, we directly "jump" to the argmax function and avoid any sampling logic.

@horheynm Could you please validate the rest of the logic in `def generate(self, logits: numpy.ndarray)`? In the most complex scenario, we can apply both `top_k`, `top_p`, and `sampling_temperature` sequentially to our logits. Let's make sure that the order in which the sampling functions are applied matches the one defined in HF (I assume this is the original implementation that we want to mimic).