### PR TITLE
[Text Generation] Avoid mutating the original logits in-place when mapping from logits to token.

### DIFF
--- a/src/deepsparse/transformers/utils/token_generator.py
+++ b/src/deepsparse/transformers/utils/token_generator.py
@@ -77,6 +77,10 @@ class TokenGenerator:
         :param logits: the logits from the model with shape (vocab_size,)
         :return: the sampled token
         """
+        # make a copy of logits to avoid modifying the original
+        # logits distribution in-place
+        logits = logits.copy()
+
         if self.deterministic:
             token = numpy.argmax(logits)
             self.tokens.append(token)


### PR DESCRIPTION
## Feature Description

`TokenGenerator.generate(logits: numpy.ndarray)` takes a logits array and, if `do_sample=True`, optionally mutates them to enforce the appropriate sampling strategy. 

This results in the correct generation of tokens, but an in-place modification of the logits array. Logits array is then returned to the user in the mutated form. This can be confusing for the users who are interested in logits value, specially when returned together with prompt logits:

<img width="1041" alt="image" src="https://github.com/neuralmagic/deepsparse/assets/97082108/5d979e7d-9612-43b5-a92a-eaea4cadddee">
First column "before": the generated logits returned to the user are mutated (the distribution is spikier, arguably close to Dirac distribution)
Second column "after": the generated logits are the non-mutatated, original logits, consistent with the prompt logits.