### PR TITLE
[Fix] Adapt to the newest SparseZoo interface (and get GHA green again) 

### DIFF
--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -129,7 +129,7 @@ def model_to_path(model: Union[str, Model, File]) -> str:
 
     if Model is not object and isinstance(model, Model):
         # trigger download and unzipping of deployment directory if not cached
-        model.deployment.download()
+        model.deployment.path
 
         # default to the main onnx file for the model
         model = model.deployment.get_file(_MODEL_DIR_ONNX_NAME).path

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -129,7 +129,7 @@ def model_to_path(model: Union[str, Model, File]) -> str:
 
     if Model is not object and isinstance(model, Model):
         # trigger download and unzipping of deployment directory if not cached
-        model.deployment_directory_path
+        model.deployment.download()
 
         # default to the main onnx file for the model
         model = model.deployment.get_file(_MODEL_DIR_ONNX_NAME).path

--- a/tests/deepsparse/image_classification/test_pipelines.py
+++ b/tests/deepsparse/image_classification/test_pipelines.py
@@ -60,8 +60,6 @@ def test_image_classification_pipeline_preprocessing(
     data_originals_path = None
 
     if zoo_model.sample_inputs is not None:
-        if not zoo_model.sample_inputs.files:
-            zoo_model.sample_inputs.unzip()
         data_originals_path = zoo_model.sample_inputs.path
 
     for idx, sample in enumerate(load_numpy_list(data_originals_path)):


### PR DESCRIPTION
Due to those changes: https://github.com/neuralmagic/sparsezoo/pull/389 we need to update the relevant pathways.