### PR TITLE
[Pipeline Refactor] Add `Pipeline.create` method to initialize pipelines

### DIFF
--- a/src/deepsparse/v2/pipeline.py
+++ b/src/deepsparse/v2/pipeline.py
@@ -173,6 +173,15 @@ class Pipeline(Operator):
         )
         return self.condense_inputs(outputs)
 
+    @staticmethod
+    def create(task: str, **kwargs) -> "Pipeline":
+        """
+        :param task: Pipeline task
+        :param kwargs: extra task specific kwargs to be passed to the Pipeline
+        :return: pipeline object initialized for the given task
+        """
+        return Operator.create(task=task, **kwargs)
+
     def run(
         self,
         *args,

--- a/src/deepsparse/v2/pipeline.py
+++ b/src/deepsparse/v2/pipeline.py
@@ -180,7 +180,13 @@ class Pipeline(Operator):
         :param kwargs: extra task specific kwargs to be passed to the Pipeline
         :return: pipeline object initialized for the given task
         """
-        return Operator.create(task=task, **kwargs)
+        pipeline = Operator.create(task=task, **kwargs)
+        if not isinstance(pipeline, Pipeline):
+            raise RuntimeError(
+                "Pipeline was not created for the given task. The "
+                "provided task should be registered using the OperatorRegistry"
+            )
+        return pipeline
 
     def run(
         self,


### PR DESCRIPTION
# Summary
- Adds `create()` method such that `Pipeline.create(...)` can be used to initialize a pipeline
- Uses the Operator registry under the hood

# Testing
```python
from deepsparse.v2.pipeline import Pipeline
model_path = "hf:neuralmagic/mpt-7b-chat-pruned50-quant"

pipeline = Pipeline.create(
    task="text_generation",
    model_path=model_path,
    engine_kwargs={"engine_type": "deepsparse"},
    internal_kv_cache=True,
    continuous_batch_sizes=[2, 4],
)
```