### PR TITLE
[Pipeline Refactor][Text Generation] Add `parse_inputs` operator to TextGeneration

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation/__init__.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/__init__.py
@@ -21,6 +21,7 @@ from .join_output import *
 from .kv_cache_operator import *
 from .multi_engine_prefill_operator import *
 from .nl_engine_operator import *
+from .parse_inputs import *
 from .prep_for_prefill import *
 from .process_inputs import *
 from .process_outputs import *

--- a/src/deepsparse/transformers/pipelines/text_generation/parse_inputs.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/parse_inputs.py
@@ -21,7 +21,10 @@ from deepsparse.transformers.schemas.text_generation_schemas import (
 from deepsparse.utils import InferenceState, PipelineState
 
 
-class ParseInputs(Operator):
+__all__ = ["ParseTextGenerationInputs"]
+
+
+class ParseTextGenerationInputs(Operator):
     def run(
         self,
         *args,

--- a/src/deepsparse/transformers/pipelines/text_generation/parse_inputs.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/parse_inputs.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from deepsparse.operators import Operator
+from deepsparse.transformers.schemas.text_generation_schemas import (
+    GenerationDefaults,
+    TextGenerationInput,
+)
+from deepsparse.utils import InferenceState, PipelineState
+
+
+class ParseInputs(Operator):
+    def run(
+        self,
+        *args,
+        inference_state: InferenceState,
+        pipeline_state: PipelineState,
+        **kwargs,
+    ):
+        """
+        :param args: in line argument can only have 1, must either be
+            a complete TextGenerationInput object or `sequences` for
+            a TextGenerationInput
+        :param kwargs: if a TextGenerationInput is not provided, then
+            these kwargs will be used to instantiate one
+        :return: parsed TextGenerationInput object
+        """
+        if "sequences" in kwargs and "prompt" not in kwargs:
+            # support prompt and sequences interchangeably
+            kwargs["prompt"] = kwargs["sequences"]
+
+        if (
+            args
+            and not isinstance(args[0], TextGenerationInput)
+            and "prompt" not in kwargs
+            and "sequences" not in kwargs
+        ):
+            # assume first argument is "sequences" (prompt) by default
+            kwargs["prompt"] = args[0]
+            args = args[1:]
+
+        if kwargs:
+            generation_kwargs = kwargs.get("generation_kwargs", {})
+            for k, v in kwargs.items():
+                if not generation_kwargs.get(k) and hasattr(GenerationDefaults, k):
+                    generation_kwargs[k] = v
+
+            kwargs["generation_kwargs"] = generation_kwargs
+
+        if args and isinstance(args[0], TextGenerationInput):
+            return args[0]
+        else:
+            return kwargs

--- a/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
@@ -31,6 +31,7 @@ from deepsparse.transformers.pipelines.text_generation import (
     KVCacheCreator,
     MultiEnginePrefill,
     NLEngineOperator,
+    ParseInputs,
     PrepareforPrefill,
     PrepareGeneration,
     ProcessInputsTextGeneration,
@@ -98,6 +99,7 @@ class TextGenerationPipeline(Pipeline):
         ] = single_engine_operator.kv_cache_data_type
         pipeline_state.create_state(pipeline_state_vals)
 
+        parse_inputs = ParseInputs()
         process_inputs = ProcessInputsTextGeneration(
             generation_config=process_generation_config(generation_config),
             sequence_length=sequence_length,
@@ -154,6 +156,7 @@ class TextGenerationPipeline(Pipeline):
                 )
 
         ops = {
+            "parse_inputs": parse_inputs,
             "process_input": process_inputs,
             "single_engine": single_engine_operator,
             "multi_engine": multi_engine_operator,
@@ -171,6 +174,7 @@ class TextGenerationPipeline(Pipeline):
         }
 
         routes = {
+            "parse_inputs": "process_input",
             "process_input": "SPLIT",
             "SPLIT": "prepare_prefill",
             "prepare_prefill": ["multi_engine_prefill", "autoregressive_preprocess"],
@@ -198,9 +202,7 @@ class TextGenerationPipeline(Pipeline):
             "process_outputs": "STOP",
         }
 
-        router = GraphRouter(
-            end_route="STOP", start_route="process_input", route=routes
-        )
+        router = GraphRouter(end_route="STOP", start_route="parse_inputs", route=routes)
         scheduler = [OperatorScheduler()]
         super().__init__(
             ops=ops,

--- a/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
@@ -31,7 +31,7 @@ from deepsparse.transformers.pipelines.text_generation import (
     KVCacheCreator,
     MultiEnginePrefill,
     NLEngineOperator,
-    ParseInputs,
+    ParseTextGenerationInputs,
     PrepareforPrefill,
     PrepareGeneration,
     ProcessInputsTextGeneration,
@@ -99,7 +99,7 @@ class TextGenerationPipeline(Pipeline):
         ] = single_engine_operator.kv_cache_data_type
         pipeline_state.create_state(pipeline_state_vals)
 
-        parse_inputs = ParseInputs()
+        parse_inputs = ParseTextGenerationInputs()
         process_inputs = ProcessInputsTextGeneration(
             generation_config=process_generation_config(generation_config),
             sequence_length=sequence_length,


### PR DESCRIPTION
# Summary
- We hadn't yet added in a `parse_inputs` function to  the new `TextGenerationPipeline`. 
- The base `parse_inputs` function previously in `BasePipeline` is covered by the normal operator functionality but for TextGeneration, we do a bit of extra kwarg/arg parsing. This operator handles that additional functionality 
# Testing
- All integration and unit testing pass

Examples of cases which now work:

With the following pipeline:
```python

pipeline = Pipeline.create(
    task="text_generation",
    model_path=model_path,
    engine_type="deepsparse",
    internal_kv_cache=True,
)
```

Not explicitly listing `prompt` or `sequences`

```python
output = pipeline(
    "What is your favourite snack?", num_return_sequences=2, do_sample=True
)
```

Listing `sequences`:

```python
output = pipeline(
    sequences="What is your favourite snack?", num_return_sequences=2, do_sample=True
)
```

Listing `prompt`:

```python
output = pipeline(
    prompt="What is your favourite snack?", num_return_sequences=2, do_sample=True
)
```

Passing generation parameters as kwargs:

```python
output = pipeline(
    "What is your favourite snack?",  num_return_sequences=2, do_sample=True)
```

Passing `generation_config` and overriding with kwargs:

```python
output = pipeline(
    "What is your favourite snack?", generation_config={"max_length": 50}, output_scores=True
)
```
