### PR TITLE
[Text Generation][Pipeline Refactor] Add input tokens to output for perplexity

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation/process_inputs.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/process_inputs.py
@@ -105,6 +105,9 @@ class ProcessInputsTextGeneration(Operator):
             frequency_penalty=generation_config.repetition_penalty,
         )
 
+        if inp.return_input_tokens:
+            inference_state_update.update({"input_tokens": input_tokens})
+
         return {
             "input_ids": input_ids,
             "attention_mask": attention_mask,

--- a/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
@@ -92,6 +92,7 @@ class ProcessOutputs(Operator):
             created=datetime.datetime.now(),
             prompts=inference_state.current_state.get("prompts"),
             generations=generations,
+            input_tokens=inference_state.current_state.get("input_tokens"),
         )
 
         return outputs

--- a/tests/deepsparse/transformers/pipelines/test_text_generation.py
+++ b/tests/deepsparse/transformers/pipelines/test_text_generation.py
@@ -219,7 +219,6 @@ def test_token_generation_non_deterministic(pipeline, prompt):
     assert len(set(text_outputs)) == 3
 
 
-@pytest.mark.skip("input tokens not yet in v2")
 def test_pipeline_for_ppl_eval(pipeline, prompt):
     predictions = pipeline(
         prompt,


### PR DESCRIPTION
# Summary
- This PR was merged while we were working on v2. Involves adding input_tokens to the output for perplexity
- Updates to no longer skip the test for this