### PR TITLE
[Pipeline Refactor][Server] Enable from files for v2

### DIFF
--- a/src/deepsparse/server/deepsparse_server.py
+++ b/src/deepsparse/server/deepsparse_server.py
@@ -18,6 +18,7 @@ from functools import partial
 from deepsparse import Pipeline
 from deepsparse.server.config import EndpointConfig
 from deepsparse.server.server import CheckReady, ModelMetaData, ProxyPipeline, Server
+from deepsparse.tasks import SupportedTasks
 from fastapi import FastAPI
 
 
@@ -147,10 +148,15 @@ class DeepsparseServer(Server):
                 ),
             )
         )
-        # NOTE: the new pipeline does not yet support from_files
-        if hasattr(pipeline.input_schema, "from_files") and not hasattr(
-            pipeline, "run_async"
-        ):
+
+        legacy_pipeline = not isinstance(pipeline, Pipeline) and hasattr(
+            pipeline.input_schema, "from_files"
+        )
+        # New pipelines do not have to have an input_schema. Just checking task
+        # names for now but can keep a list of supported from_files tasks in
+        # SupportedTasks as more pipelines are migrated as well as output schemas.
+        new_pipeline = SupportedTasks.is_image_classification(endpoint_config.task)
+        if legacy_pipeline or new_pipeline:
             routes_and_fns.append(
                 (
                     route + "/from_files",
@@ -161,11 +167,15 @@ class DeepsparseServer(Server):
                     ),
                 )
             )
+        if isinstance(pipeline, Pipeline):
+            response_model = None
+        else:
+            response_model = pipeline.output_schema
 
         self._update_routes(
             app=app,
             routes_and_fns=routes_and_fns,
-            response_model=pipeline.output_schema,
+            response_model=response_model,
             methods=["POST"],
             tags=["model", "inference"],
         )

--- a/src/deepsparse/server/deepsparse_server.py
+++ b/src/deepsparse/server/deepsparse_server.py
@@ -156,6 +156,7 @@ class DeepsparseServer(Server):
         # names for now but can keep a list of supported from_files tasks in
         # SupportedTasks as more pipelines are migrated as well as output schemas.
         new_pipeline = SupportedTasks.is_image_classification(endpoint_config.task)
+
         if legacy_pipeline or new_pipeline:
             routes_and_fns.append(
                 (

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -18,7 +18,7 @@ from abc import abstractmethod
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from typing import List, Union
+from typing import List, Optional, Union
 
 import yaml
 from pydantic import BaseModel
@@ -209,9 +209,9 @@ class Server:
         self,
         app: FastAPI,
         routes_and_fns: List,
-        response_model: BaseModel,
         methods: List[str],
         tags: List[str],
+        response_model: Optional[BaseModel] = None,
     ):
         existing = [route.path for route in app.routes]
         for route, endpoint_fn in routes_and_fns:
@@ -245,14 +245,16 @@ class Server:
         system_logging_config: SystemLoggingConfig,
         raw_request: Request,
     ):
+        # New and old pipelines are called directly
+        if isinstance(proxy_pipeline.pipeline, Pipeline):
 
-        if hasattr(proxy_pipeline.pipeline, "run_async"):
             inference_state = InferenceState()
             inference_state.create_state({})
 
             pipeline_outputs = await proxy_pipeline.pipeline.run_async(
                 **await raw_request.json(), inference_state=inference_state
             )
+
         else:
             pipeline_outputs = proxy_pipeline.pipeline(**await raw_request.json())
 
@@ -274,14 +276,24 @@ class Server:
         system_logging_config: SystemLoggingConfig,
         request: List[UploadFile],
     ):
-        # NOTE: /from_files is not yet supported in the new pipeline
-        request = proxy_pipeline.pipeline.input_schema.from_files(
-            (file.file for file in request), from_server=True
-        )
+        # TODO: New pipelines do not have to have an input_schema.
+        # enable from_files for image_classification for now; leverage SupportedTasks
+        # or additional pipeline attributes to do this in the future
+        if isinstance(proxy_pipeline.pipeline, Pipeline):
+            from_files_func = proxy_pipeline.pipeline.ops[0].input_schema.from_files
+        else:
+            from_files_func = proxy_pipeline.pipeline.input_schema.from_files
+
+        request = from_files_func((file.file for file in request), from_server=True)
         pipeline_outputs = proxy_pipeline.pipeline(request)
-        server_logger = proxy_pipeline.pipeline.logger
-        if server_logger:
-            log_system_information(
-                server_logger=server_logger, system_logging_config=system_logging_config
-            )
+
+        try:
+            server_logger = proxy_pipeline.pipeline.logger
+            if server_logger:
+                log_system_information(
+                    server_logger=server_logger,
+                    system_logging_config=system_logging_config,
+                )
+        except Exception as e:
+            _LOGGER.debug(f"Logging failed, {e}")
         return prep_for_serialization(pipeline_outputs)

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -245,7 +245,6 @@ class Server:
         system_logging_config: SystemLoggingConfig,
         raw_request: Request,
     ):
-        # New and old pipelines are called directly
         if hasattr(proxy_pipeline.pipeline, "run_async"):
             inference_state = InferenceState()
             inference_state.create_state({})

--- a/tests/server/test_endpoints.py
+++ b/tests/server/test_endpoints.py
@@ -37,10 +37,6 @@ class StrSchema(BaseModel):
     value: str
 
 
-def run_func(value: str):
-    return int(value)
-
-
 class TestStatusEndpoints:
     @pytest.fixture(scope="class")
     def server_config(self):

--- a/tests/server/test_endpoints.py
+++ b/tests/server/test_endpoints.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 from typing import List
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from pydantic import BaseModel
 
 import pytest
-from deepsparse.loggers import MultiLogger
 from deepsparse.server.config import EndpointConfig, ServerConfig, SystemLoggingConfig
 from deepsparse.server.deepsparse_server import DeepsparseServer
 from deepsparse.server.sagemaker import SagemakerServer
@@ -104,12 +103,7 @@ class TestMockEndpoints:
     def test_add_model_endpoint(
         self, server: DeepsparseServer, app: FastAPI, client: TestClient
     ):
-        mock_pipeline = Mock(
-            input_schema=str,
-            output_schema=int,
-            side_effect=run_func,
-            logger=MultiLogger([]),
-        )
+        mock_pipeline = AsyncMock(input_schema=str, output_schema=int)
 
         server._add_inference_endpoints(
             app=app,
@@ -132,13 +126,10 @@ class TestMockEndpoints:
             )
             assert response.status_code == 200
 
+    # TODO: udpate test to include check for input_schema, once v2 pipelines
+    # have a way to store/fetch compatible from_file pipelines
     def test_add_model_endpoint_with_from_files(self, server, app):
-        mock_pipeline = Mock(input_schema=FromFilesSchema, output_schema=int)
-        # new pipeline does not yet support /from_files (which we identify through
-        # the run_async function being present in the pipeline). By default, Mock
-        # hasattr() returns True for having `run_async` which is deleted so that we can
-        # run this test until the new pipeline can support from files
-        # del mock_pipeline.run_async
+        mock_pipeline = AsyncMock(output_schema=int)
 
         server._add_inference_endpoints(
             app,


### PR DESCRIPTION
# Summary
- Temporarily disabled `from_files` when migrating the server as our previous solution involved checking the schema for the pipeline. This no longer works as an operator doesn't have to have an input schema 
- Provided a temporary solution as lower priority but wanted to unblock QA. As we migrate more pipelines, we can work on a slightly more sophisticated solution but for now, only `image_classification` has been migrated which also uses v2 and supports`from_files`

# Testing
- All server tests pass

Tested locally
```
deepsparse.server \
    task image_classification \
    --model_path "zoo:cv/classification/resnet_v1-50/pytorch/sparseml/imagenet/pruned95-none" \
    --port 5543
```