### PR TITLE
[Text Generation] Enable continuous batching when internal kv_cache is enabled

### DIFF
--- a/src/deepsparse/operators/engine_operator.py
+++ b/src/deepsparse/operators/engine_operator.py
@@ -152,10 +152,15 @@ class EngineOperator(Operator):
             constructor/compilation
         :return: inference engine
         """
-
         onnx_file_path = kwargs.pop("model_path", self.model_path)
         engine_args = deepcopy(self._engine_args)
         engine_args.update(kwargs)
+
+        # If any engine_kwargs are given, unravel them and add them back to engine_args
+        engine_kwargs = engine_args.pop("engine_kwargs")
+        if engine_kwargs:
+            engine_args.update(engine_kwargs)
+
         engine_type = self._engine_type.lower()
 
         if engine_type == DEEPSPARSE_ENGINE:

--- a/src/deepsparse/operators/engine_operator.py
+++ b/src/deepsparse/operators/engine_operator.py
@@ -156,11 +156,6 @@ class EngineOperator(Operator):
         engine_args = deepcopy(self._engine_args)
         engine_args.update(kwargs)
 
-        # If any engine_kwargs are given, unravel them and add them back to engine_args
-        engine_kwargs = engine_args.pop("engine_kwargs")
-        if engine_kwargs:
-            engine_args.update(engine_kwargs)
-
         engine_type = self._engine_type.lower()
 
         if engine_type == DEEPSPARSE_ENGINE:

--- a/src/deepsparse/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/schedulers/continuous_batching_scheduler.py
@@ -17,7 +17,7 @@ from concurrent.futures import Future
 from threading import Lock
 from typing import List
 
-from deepsparse.operators import DEEPSPARSE_ENGINE, EngineOperator, Operator
+from deepsparse.operators import EngineOperator, Operator
 from deepsparse.schedulers.scheduler import OperatorScheduler
 from deepsparse.schedulers.utils import (
     ContinuousBatchingExecutorThread,
@@ -166,31 +166,8 @@ class ContinuousBatchingScheduler(OperatorScheduler):
             if batch_size == 1:
                 continue  # already added
 
-            override_model_path = None
-            kwargs = {}
-
-            if engine_operator.__class__.__name__ == "NLEngineOperator":
-                (
-                    override_model_path,
-                    additional_outputs,
-                ) = engine_operator.override_model_inputs(
-                    model_path=engine_operator.model_path,
-                    batch_size=batch_size,
-                    return_additional_outputs=True,
-                )
-
-                if (
-                    engine_operator._engine_type == DEEPSPARSE_ENGINE
-                    and engine_operator.internal_kv_cache
-                ):
-                    output_indices_to_be_cached = additional_outputs.get(
-                        "output_indices_to_be_cached"
-                    )
-                    if any(output_indices_to_be_cached):
-                        kwargs["cached_outputs"] = output_indices_to_be_cached
-
             operator_engines[batch_size] = engine_operator.create_engine(
-                batch_size=batch_size, model_path=override_model_path, **kwargs
+                batch_size=batch_size
             )
 
         self._operators_to_engines[engine_operator] = operator_engines

--- a/src/deepsparse/transformers/pipelines/text_generation/nl_engine_operator.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/nl_engine_operator.py
@@ -158,11 +158,10 @@ class NLEngineOperator(EngineOperator):
         # Create the engine with an overwritten model/new batch size and any additional
         # engine_kwargs
         kwargs = {}
-        kwargs["engine_kwargs"] = engine_kwargs
         kwargs["model_path"] = onnx_file_path
         kwargs["batch_size"] = batch_size
 
-        return super().create_engine(**kwargs)
+        return super().create_engine(**kwargs, **engine_kwargs)
 
     def override_model_inputs(
         self,

--- a/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
@@ -191,15 +191,10 @@ class TextGenerationPipeline(Pipeline):
         # TODO: do we want to support lists for different engines?
         continuous_batching_scheduler = None
         if continuous_batch_sizes:
-            if internal_kv_cache:
-                _LOGGER.warning(
-                    "continuous_batching is not supported with internal_kv_cache"
-                )
-            else:
-                continuous_batching_scheduler = self._get_continuous_batching_scheduler(
-                    batch_sizes=continuous_batch_sizes,
-                    engines=[single_engine_operator, multi_engine_operator],
-                )
+            continuous_batching_scheduler = self._get_continuous_batching_scheduler(
+                batch_sizes=continuous_batch_sizes,
+                engines=[single_engine_operator, multi_engine_operator],
+            )
 
         ops = {
             "parse_inputs": parse_inputs,


### PR DESCRIPTION
# Summary
- Remove the check in `text_generation/pipeline.py` which  disables continuous batching when internal kv cache is enabled
- Update `NLEngineOperator` to use the engine provided as an input, if available, when using internal kv cache. This engine will have the model with the updated batch size, when continuous batching is being used (this is true in general for continuous batching)
- Update step when engines are created within the `continuous_batching_scheduler` specific for the `NLEngineOperator`