### PR TITLE
Correct token usage reporting for OpenAI server

### DIFF
--- a/src/deepsparse/server/openai_server.py
+++ b/src/deepsparse/server/openai_server.py
@@ -189,9 +189,9 @@ class OpenAIServer(Server):
                 )
                 choices.append(choice_data)
 
-            num_prompt_tokens = len(final_res.prompt_token_ids)
+            num_prompt_tokens = len(final_res.prompt_token_ids["input_ids"])
             num_generated_tokens = sum(
-                len(output.token_ids) for output in final_res.outputs
+                len(output.token_ids["input_ids"]) for output in final_res.outputs
             )
             usage = UsageInfo(
                 prompt_tokens=num_prompt_tokens,
@@ -284,9 +284,9 @@ class OpenAIServer(Server):
                 )
                 choices.append(choice_data)
 
-            num_prompt_tokens = len(final_res.prompt_token_ids)
+            num_prompt_tokens = len(final_res.prompt_token_ids["input_ids"])
             num_generated_tokens = sum(
-                len(output.token_ids) for output in final_res.outputs
+                len(output.token_ids["input_ids"]) for output in final_res.outputs
             )
             usage = UsageInfo(
                 prompt_tokens=num_prompt_tokens,


### PR DESCRIPTION
The OpenAI server was always returning `"usage":{"prompt_tokens":2,"total_tokens":4,"completion_tokens":2}` since it was taking the length of the token_ids dictionary and not one of its members

```
final_res.prompt_token_ids {'input_ids': [1639, 389, 257, 7613], 'attention_mask': [1, 1, 1, 1]}
```

## Test

Server command:
```
deepsparse.server --integration openai --task text-generation --model_path hf:mgoin/TinyStories-1M-ds
```

Client command:
```
curl http://localhost:5543/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer dummy" \
  -d '{
    "model": "hf:mgoin/TinyStories-1M-ds",
    "messages": "You are a helpful assistant."
  }'
```

Before:
```
{"id":"cmpl-10b937d72d2b4cf382da0c6e54241814","object":"chat.completion","created":1703173842,"model":"hf:mgoin/TinyStories-1M-ds","choices":[{"message":{"role":"assistant","content":" You can make a big house for the house and the house. You can make"},"finish_reason":"length"}],"usage":{"prompt_tokens":2,"total_tokens":4,"completion_tokens":2}}
```

After:
```
{"id":"cmpl-85104f94d3294b88b2aae34095cf204d","object":"chat.completion","created":1703173678,"model":"hf:mgoin/TinyStories-1M-ds","choices":[{"message":{"role":"assistant","content":" You can make a big house for the house and the house. You can make"},"finish_reason":"length"}],"usage":{"prompt_tokens":6,"total_tokens":22,"completion_tokens":16}}
```