### PR TITLE
Let OpenAI ChatCompletionRequest accept List[Dict] messages

### DIFF
--- a/src/deepsparse/server/openai_server.py
+++ b/src/deepsparse/server/openai_server.py
@@ -96,22 +96,21 @@ class OpenAIServer(Server):
             if isinstance(request.messages, str):
                 prompt = request.messages
             else:
-                # else case assums a FastChat-compliant dictionary
+                # else case assumes a FastChat-compliant dictionary
                 # Fetch a model-specific template from FastChat
-                _LOGGER.warning(
-                    "A dictionary message was found. This dictionary must "
-                    "be fastchat compliant."
-                )
                 try:
                     from fastchat.model.model_adapter import get_conversation_template
                 except ImportError as e:
-                    return create_error_response(HTTPStatus.FAILED_DEPENDENCY, str(e))
+                    return create_error_response(
+                        HTTPStatus.FAILED_DEPENDENCY,
+                        f"{str(e)} - Please ensure `fastchat` is installed.",
+                    )
 
                 conv = get_conversation_template(request.model)
                 messages = request.messages
                 messages = messages if isinstance(messages, list) else [messages]
+                # add the model to the Conversation template, based on the given role
                 for message in messages:
-                    # add the model to the Conversation template, based on the given role
                     msg_role = message["role"]
                     if msg_role == "system":
                         conv.system_message = message["content"]

--- a/src/deepsparse/server/openai_server.py
+++ b/src/deepsparse/server/openai_server.py
@@ -108,19 +108,21 @@ class OpenAIServer(Server):
                     return create_error_response(HTTPStatus.FAILED_DEPENDENCY, str(e))
 
                 conv = get_conversation_template(request.model)
-                message = request.messages
-                # add the model to the Conversation template, based on the given role
-                msg_role = message["role"]
-                if msg_role == "system":
-                    conv.system_message = message["content"]
-                elif msg_role == "user":
-                    conv.append_message(conv.roles[0], message["content"])
-                elif msg_role == "assistant":
-                    conv.append_message(conv.roles[1], message["content"])
-                else:
-                    return create_error_response(
-                        HTTPStatus.BAD_REQUEST, "Message role not recognized"
-                    )
+                messages = request.messages
+                messages = messages if isinstance(messages, list) else [messages]
+                for message in messages:
+                    # add the model to the Conversation template, based on the given role
+                    msg_role = message["role"]
+                    if msg_role == "system":
+                        conv.system_message = message["content"]
+                    elif msg_role == "user":
+                        conv.append_message(conv.roles[0], message["content"])
+                    elif msg_role == "assistant":
+                        conv.append_message(conv.roles[1], message["content"])
+                    else:
+                        return create_error_response(
+                            HTTPStatus.BAD_REQUEST, "Message role not recognized"
+                        )
 
                 # blank message to start generation
                 conv.append_message(conv.roles[1], None)

--- a/src/deepsparse/server/protocol.py
+++ b/src/deepsparse/server/protocol.py
@@ -107,7 +107,7 @@ class ChatCompletionRequest(BaseModel):
     """
 
     model: Optional[str] = None
-    messages: Union[str, Dict[str, str]]
+    messages: Union[str, List[Dict[str, str]], Dict[str, str]]
     temperature: Optional[float] = 0.7
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1

--- a/tests/server/test_openai.py
+++ b/tests/server/test_openai.py
@@ -107,6 +107,19 @@ def test_chat_completions_fastchat(client, model_card):
     assert response.status_code == 200
 
 
+def test_chat_completions_fastchat_list(client, model_card):
+    request = ChatCompletionRequest(
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+        ],
+        max_tokens=50,
+        model=model_card.id,
+    )
+    response = client.post("/v1/chat/completions", json=request.dict())
+    assert response.status_code == 200
+
+
 def test_completions(client, model_card):
     request = CompletionRequest(
         prompt="The Boston Bruins are ...", max_tokens=50, model=model_card.id


### PR DESCRIPTION
The OpenAI `v1/chat/completions` endpoint would fail to properly parse a `request.messages` of the `List[Dict]` format

## Test

Server command:
```
deepsparse.server --integration openai --task text-generation --model_path hf:mgoin/TinyStories-1M-ds
```
Client command:
```
curl http://localhost:5543/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer dummy" \
  -d '{
    "model": "hf:mgoin/TinyStories-1M-ds",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Hello!"
      }
    ]
  }'
```

Before:
```
{"object":"error","message":"Message role not recognized","type":"invalid_request_error","param":null,"code":null}
```

After:
```
{"id":"cmpl-e3bd5431cc384dab8782254ac0a2f862","object":"chat.completion","created":1703185938,"model":"hf:mgoin/TinyStories-1M-ds","choices":[{"message":{"role":"assistant","content":" \"Welcome to the best friends! I have a special place to you. I"},"finish_reason":"length"}],"usage":{"prompt_tokens":453,"total_tokens":469,"completion_tokens":16}}
```