### PR TITLE
[TextGeneration] Add `model_path` alias

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -112,6 +112,17 @@ class Pipeline(Operator):
                 new_kwargs[k] = kwargs.get(k)
 
         try:
+            model_path = new_kwargs.get("model_path")
+            model = new_kwargs.pop("model", None)
+
+            if model and model_path:
+                raise ValueError(
+                    f"Only one of model and model_path may be supplied, found {model} "
+                    f"and {model_path} respectively"
+                )
+            elif model:
+                new_kwargs["model_path"] = model
+
             pipeline = Operator.create(task=task, **new_kwargs)
             if not isinstance(pipeline, cls):
                 raise RuntimeError(


### PR DESCRIPTION
- For this bug: https://app.asana.com/0/1205229323407165/1206273548252848/f

The following now work:

```python
from deepsparse import TextGeneration

model_1 = TextGeneration(model="hf:mgoin/TinyStories-1M-ds")
model_2 = TextGeneration(model_path="hf:mgoin/TinyStories-1M-ds")

from deepsparse import Pipeline

pipeline = Pipeline.create(
     task="text_generation",
     model_path=model_path,
     engine_type="deepsparse",
     internal_kv_cache=True,
     continuous_batch_sizes=[2, 4]
 )

pipeline = Pipeline.create(
     task="text_generation",
     model=model_path,
     engine_type="deepsparse",
     internal_kv_cache=True,
     continuous_batch_sizes=[2, 4]
 )


```