### PR TITLE
[TextGeneration] Use appropriate future within `continuous_batching_scheduler`

### DIFF
--- a/src/deepsparse/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/schedulers/continuous_batching_scheduler.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import asyncio
 from concurrent.futures import Future
 from threading import Lock
 from typing import List
@@ -113,7 +113,7 @@ class ContinuousBatchingScheduler(OperatorScheduler):
                 f"found {type(inputs)}"
             )
 
-        future = Future()
+        future = asyncio.Future() if kwargs.get("loop") else Future()
         self._queues.add_queue_item(key=operator, item=inputs, future=future)
 
         return future

--- a/src/deepsparse/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/schedulers/continuous_batching_scheduler.py
@@ -113,6 +113,9 @@ class ContinuousBatchingScheduler(OperatorScheduler):
                 f"found {type(inputs)}"
             )
 
+        # asyncio.Future() is used when we run the pipeline using async/excecute
+        # operators using asyncio. Outside of the async pathway
+        # (i.e. outside of the server), we use concurrent.Future()
         future = asyncio.Future() if kwargs.get("loop") else Future()
         self._queues.add_queue_item(key=operator, item=inputs, future=future)
 

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -241,11 +241,42 @@ class Server:
         return ModelMetaData(model_path=proxy_pipeline.pipeline.model_path)
 
     @staticmethod
-    async def predict(
+    async def run(raw_request, proxy_pipeline):
+        if hasattr(proxy_pipeline.pipeline, "run_async"):
+            inference_state = InferenceState()
+            inference_state.create_state({})
+
+            pipeline_outputs = await proxy_pipeline.pipeline.run_async(
+                **await raw_request.json(), inference_state=inference_state
+            )
+            if isinstance(pipeline_outputs, AsyncGenerator):
+                async def format_response():
+                    async for output in pipeline_outputs:
+                        # Note: If a pipeline does not return a BaseModel this will fail
+                        response = output.json(ensure_ascii=False)
+                        yield f"{response}\n\n"
+
+                return StreamingResponse(
+                    format_response(),
+                    media_type="text/event-stream",
+                )
+        else:
+            pipeline_outputs = proxy_pipeline.pipeline(**await raw_request.json())
+        return pipeline_outputs
+
+
+    @staticmethod
+    def predict(
         proxy_pipeline: ProxyPipeline,
         system_logging_config: SystemLoggingConfig,
         raw_request: Request,
     ):
+        import asyncio
+        pipeline_outputs = asyncio.run(Server.run(raw_request, proxy_pipeline))
+        if isinstance(pipeline_outputs, StreamingResponse):
+            return pipeline_outputs
+        
+        """
         if hasattr(proxy_pipeline.pipeline, "run_async"):
             inference_state = InferenceState()
             inference_state.create_state({})
@@ -255,7 +286,6 @@ class Server:
             )
 
             if isinstance(pipeline_outputs, AsyncGenerator):
-
                 async def format_response():
                     async for output in pipeline_outputs:
                         # Note: If a pipeline does not return a BaseModel this will fail
@@ -278,7 +308,7 @@ class Server:
                 )
         except Exception as e:
             _LOGGER.debug(f"Logging failed, {e}")
-
+        """
         return prep_for_serialization(pipeline_outputs)
 
     @staticmethod

--- a/tests/deepsparse/schedulers/test_continuous_batching_scheduler.py
+++ b/tests/deepsparse/schedulers/test_continuous_batching_scheduler.py
@@ -31,7 +31,7 @@ def test_continuous_batching_executor_thread():
         "zoo:mobilenet_v2-1.0-imagenet-base",
     )
 
-    scheduler.add_engine_operator(engine_operator, [1])
+    scheduler.add_engine_operator(engine_operator, [2])
 
     # submit job to scheduler and expect future to be returned
     engine_input = engine_operator.input_schema(


### PR DESCRIPTION
# Summary
- This PR addresses this ticket: https://app.asana.com/0/1205229323407165/1206269161795436/f
- We were using concurrent futures for async calls that cannot be awaited within the `continuous_batching_scheduler`. For all other operators, we were using `asyncio` Futures. Using the incorrect future seemed to block the scheduler queue from ever growing > 1.
-  This PR updates the future to check if we're running async or not (by checking if an async loop is present) and using the correct Future accordingly 


## Testing

- Tested locally, we are now getting batch_size > 1

```yaml

num_workers: 1
num_streams: 1
endpoints:
  - task: text_generation
    model: "hf:mgoin/TinyStories-1M-ds"
    kwargs:
      {"continuous_batch_sizes": [4, 8, 16], "force_max_tokens": True}

```

Using the following code, we can see batch_size > 1 being used:

```python

from openai import OpenAI
from threading import Thread
import time, argparse

import argparse

parser = argparse.ArgumentParser(description='Process some integers.')
parser.add_argument('--num-threads', type=int, default=1)
parser.add_argument('--num-tokens', type=int, default=25)

_STREAM = False
_PRINT = True

def main(num_threads=1, num_tokens=25):
    openai_api_key = "EMPTY"
    openai_api_base = "http://localhost:5543/v1"

    client = OpenAI(
        # defaults to os.environ.get("OPENAI_API_KEY")
        api_key=openai_api_key,
        base_url=openai_api_base,
    )

    models = client.models.list()
    # model = models.data[0].id
    model = models.data[0][1]

    def run(idx, prompt="Mario jumped from the balcony"):
        print(f"launching thread {idx}")
        
        start = time.perf_counter()
        completion = client.completions.create(
            model=model,
            prompt=prompt,
            n=1,
            max_tokens=num_tokens,
            stream=_STREAM,
        )

        if _STREAM:
            for c in completion:
                print(c)
        else:
            if _PRINT:
                print(completion.choices[0].text)

        end = time.perf_counter()
        print(f"finished thread {idx} : {(num_tokens * num_threads) / (end - start): 0.5f}")

    ts = [Thread(target=run, args=[idx, "Mario jumped"]) for idx in range(num_threads)]

    for t in ts:
        t.start()
    for t in ts:
        t.join()

if __name__ == "__main__":
    args = parser.parse_args()
    main(num_threads=args.num_threads, num_tokens=args.num_tokens)

```
