### PR TITLE
[BugFix] Remove `src.` from imports

### DIFF
--- a/src/deepsparse/evaluation/cli.py
+++ b/src/deepsparse/evaluation/cli.py
@@ -71,10 +71,10 @@ from typing import List, Union
 
 import click
 
-from src.deepsparse.evaluation.evaluator import evaluate
-from src.deepsparse.evaluation.results import Result, save_result
-from src.deepsparse.evaluation.utils import args_to_dict, get_save_path
-from src.deepsparse.operators.engine_operator import (
+from deepsparse.evaluation.evaluator import evaluate
+from deepsparse.evaluation.results import Result, save_result
+from deepsparse.evaluation.utils import args_to_dict, get_save_path
+from deepsparse.operators.engine_operator import (
     DEEPSPARSE_ENGINE,
     ORT_ENGINE,
     TORCHSCRIPT_ENGINE,

--- a/src/deepsparse/evaluation/evaluator.py
+++ b/src/deepsparse/evaluation/evaluator.py
@@ -14,10 +14,10 @@
 import logging
 from typing import Any, List, Optional, Union
 
-from src.deepsparse.evaluation.registry import EvaluationRegistry
-from src.deepsparse.evaluation.results import Result
-from src.deepsparse.evaluation.utils import create_model_from_target
-from src.deepsparse.operators.engine_operator import (
+from deepsparse.evaluation.registry import EvaluationRegistry
+from deepsparse.evaluation.results import Result
+from deepsparse.evaluation.utils import create_model_from_target
+from deepsparse.operators.engine_operator import (
     DEEPSPARSE_ENGINE,
     ORT_ENGINE,
     TORCHSCRIPT_ENGINE,

--- a/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
+++ b/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
@@ -27,9 +27,9 @@ from tqdm import tqdm
 
 import torch
 from deepsparse import Pipeline
+from deepsparse.evaluation.registry import EvaluationRegistry
 from deepsparse.evaluation.results import Dataset, Evaluation, Metric, Result
 from lm_eval import base, evaluator, tasks, utils
-from src.deepsparse.evaluation.registry import EvaluationRegistry
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/deepsparse/evaluation/results.py
+++ b/src/deepsparse/evaluation/results.py
@@ -17,7 +17,7 @@ from typing import Any, List, Optional
 import yaml
 from pydantic import BaseModel, Field
 
-from src.deepsparse.utils.data import prep_for_serialization
+from deepsparse.utils.data import prep_for_serialization
 
 
 __all__ = [

--- a/src/deepsparse/evaluation/utils.py
+++ b/src/deepsparse/evaluation/utils.py
@@ -42,9 +42,7 @@ def potentially_check_dependency_import(integration_name: str) -> bool:
     """
 
     if integration_name.replace("_", "-") == LM_EVALUATION_HARNESS:
-        from src.deepsparse.evaluation.integrations import (
-            try_import_lm_evaluation_harness,
-        )
+        from deepsparse.evaluation.integrations import try_import_lm_evaluation_harness
 
         try_import_lm_evaluation_harness(raise_error=True)
 

--- a/tests/deepsparse/evaluation/integrations/__init__.py
+++ b/tests/deepsparse/evaluation/integrations/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py
+++ b/tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import pytest
-from src.deepsparse.evaluation.integrations import try_import_lm_evaluation_harness
-from src.deepsparse.evaluation.utils import create_model_from_target
+from deepsparse.evaluation.integrations import try_import_lm_evaluation_harness
+from deepsparse.evaluation.utils import create_model_from_target
 
 
 @pytest.mark.parametrize(
@@ -49,7 +49,7 @@ class TestLMEvaluationHarness:
     def test_integration_eval_onnx_matches_torch(
         self, pipeline, model_torch, datasets, batch_size
     ):
-        from src.deepsparse.evaluation.integrations.lm_evaluation_harness import (
+        from deepsparse.evaluation.integrations.lm_evaluation_harness import (
             integration_eval,
         )
 

--- a/tests/deepsparse/evaluation/test_evaluator.py
+++ b/tests/deepsparse/evaluation/test_evaluator.py
@@ -19,10 +19,10 @@ import numpy as np
 from click.testing import CliRunner
 
 import pytest
-from src.deepsparse.evaluation.evaluator import evaluate
-from src.deepsparse.evaluation.integrations import try_import_lm_evaluation_harness
-from src.deepsparse.evaluation.registry import EvaluationRegistry
-from src.deepsparse.evaluation.results import (
+from deepsparse.evaluation.evaluator import evaluate
+from deepsparse.evaluation.integrations import try_import_lm_evaluation_harness
+from deepsparse.evaluation.registry import EvaluationRegistry
+from deepsparse.evaluation.results import (
     Dataset,
     EvalSample,
     Evaluation,
@@ -111,7 +111,7 @@ def test_evaluation_llm_evaluation_harness_integration_name(
     "click option where multiple=True",
 )
 def test_cli(tmp_path, target, datasets, dummy_integration_name, type_serialization):
-    from src.deepsparse.evaluation.cli import main
+    from deepsparse.evaluation.cli import main
 
     runner = CliRunner()
     runner.invoke(

--- a/tests/deepsparse/evaluation/test_registry.py
+++ b/tests/deepsparse/evaluation/test_registry.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytest
-from src.deepsparse.evaluation.registry import EvaluationRegistry
+from deepsparse.evaluation.registry import EvaluationRegistry
 
 
 @pytest.fixture

--- a/tests/deepsparse/evaluation/test_results.py
+++ b/tests/deepsparse/evaluation/test_results.py
@@ -18,7 +18,7 @@ import numpy as np
 import yaml
 
 import pytest
-from src.deepsparse.evaluation.results import (
+from deepsparse.evaluation.results import (
     Dataset,
     EvalSample,
     Evaluation,

--- a/tests/deepsparse/evaluation/test_utils.py
+++ b/tests/deepsparse/evaluation/test_utils.py
@@ -22,7 +22,7 @@ from transformers import (
 
 import pytest
 from deepsparse import Pipeline
-from src.deepsparse.evaluation.utils import (
+from deepsparse.evaluation.utils import (
     create_model_from_target,
     get_save_path,
     if_generative_language_model,


### PR DESCRIPTION
This PR fixes a bug where `src.` was included in front of imports; this is faulty because once the package is built `src.deepsparse` becomes invalid

Ran the affected tests locally
```
$ pytest -vv tests/deepsparse/evaluation                                                                                                                                 (main|✚10…1)
================================================================================ test session starts =================================================================================
platform linux -- Python 3.11.5, pytest-7.4.4, pluggy-1.3.0 -- /home/rahul/venvs/.base_venv/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/rahul/projects/deepsparse
configfile: pyproject.toml
plugins: flaky-3.7.0
collected 28 items                                                                                                                                                                   

tests/deepsparse/evaluation/test_evaluator.py::test_evaluate_unknown_integration PASSED                                                                                        [  3%]
tests/deepsparse/evaluation/test_evaluator.py::test_evaluate PASSED                                                                                                            [  7%]
tests/deepsparse/evaluation/test_evaluator.py::test_evaluation_llm_evaluation_harness_integration_name SKIPPED (lm_evaluation_harness not installed)                           [ 10%]
tests/deepsparse/evaluation/test_evaluator.py::test_cli[json] PASSED                                                                                                           [ 14%]
tests/deepsparse/evaluation/test_evaluator.py::test_cli[yaml] PASSED                                                                                                           [ 17%]
tests/deepsparse/evaluation/test_registry.py::test_get_foo_from_registry PASSED                                                                                                [ 21%]
tests/deepsparse/evaluation/test_registry.py::test_get_multiple_buzz_from_registry PASSED                                                                                      [ 25%]
tests/deepsparse/evaluation/test_results.py::test_serialize_result_json PASSED                                                                                                 [ 28%]
tests/deepsparse/evaluation/test_results.py::test_serialize_result_yaml PASSED                                                                                                 [ 32%]
tests/deepsparse/evaluation/test_utils.py::test_resolve_known_llm_model PASSED                                                                                                 [ 35%]
tests/deepsparse/evaluation/test_utils.py::test_resolve_unknown_model PASSED                                                                                                   [ 39%]
tests/deepsparse/evaluation/test_utils.py::test_if_generative_language_model_true PASSED                                                                                       [ 42%]
tests/deepsparse/evaluation/test_utils.py::test_if_generative_language_model_false PASSED                                                                                      [ 46%]
tests/deepsparse/evaluation/test_utils.py::test_if_generative_language_pipeline_true PASSED                                                                                    [ 50%]
tests/deepsparse/evaluation/test_utils.py::test_get_save_path_path_provided PASSED                                                                                             [ 53%]
tests/deepsparse/evaluation/test_utils.py::test_get_save_to_current_working_directory PASSED                                                                                   [ 57%]
tests/deepsparse/evaluation/test_utils.py::test_initialize_model_from_target_pipeline_onnx PASSED                                                                              [ 60%]
tests/deepsparse/evaluation/test_utils.py::test_initialize_model_from_target_pipeline_deepsparse PASSED                                                                        [ 64%]
tests/deepsparse/evaluation/test_utils.py::test_initialize_model_from_target_pipeline_with_kwargs PASSED                                                                       [ 67%]
tests/deepsparse/evaluation/test_utils.py::test_initialize_model_from_target_torch PASSED                                                                                      [ 71%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[1-datasets0-pipeline0-model_torch0] SKIPPED [ 75%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[1-datasets1-pipeline0-model_torch0] SKIPPED [ 78%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[1-gsm8k-pipeline0-model_torch0] SKIPPED [ 82%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[1-arc_challenge-pipeline0-model_torch0] SKIPPED [ 85%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[3-datasets0-pipeline0-model_torch0] SKIPPED [ 89%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[3-datasets1-pipeline0-model_torch0] SKIPPED [ 92%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[3-gsm8k-pipeline0-model_torch0] SKIPPED [ 96%]
tests/deepsparse/evaluation/integrations/test_lm_evaluation_harness.py::TestLMEvaluationHarness::test_integration_eval_onnx_matches_torch[3-arc_challenge-pipeline0-model_torch0] SKIPPED [100%]

================================================================================== warnings summary ==================================================================================
../../venvs/.base_venv/lib/python3.11/site-packages/sparsezoo/objects/file.py:15
  /home/rahul/venvs/.base_venv/lib/python3.11/site-packages/sparsezoo/objects/file.py:15: DeprecationWarning: 'imghdr' is deprecated and slated for removal in Python 3.13
    import imghdr

src/deepsparse/utils/onnx.py:106: 2 warnings
tests/deepsparse/evaluation/test_evaluator.py: 8 warnings
tests/deepsparse/evaluation/test_utils.py: 8 warnings
  /home/rahul/projects/deepsparse/src/deepsparse/utils/onnx.py:106: DeprecationWarning: `mapping.TENSOR_TYPE_TO_NP_TYPE` is now deprecated and will be removed in a future release.To silence this warning, please use `helper.tensor_dtype_to_np_dtype` instead.
    return TENSOR_TYPE_TO_NP_TYPE[tensor_type]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================== 19 passed, 9 skipped, 19 warnings in 52.47s =====================================================================

```