### PR TITLE
[Server] Use the integration field when starting a server

### DIFF
--- a/src/deepsparse/server/config.py
+++ b/src/deepsparse/server/config.py
@@ -166,7 +166,7 @@ class ServerConfig(BaseModel):
 
     integration: str = Field(
         default=None,
-        description="The kind of integration to use. local|sagemaker|openai",
+        description=f"The kind of integration to use. {INTEGRATIONS}",
     )
 
     engine_thread_pinning: str = Field(

--- a/src/deepsparse/server/config.py
+++ b/src/deepsparse/server/config.py
@@ -40,7 +40,8 @@ __all__ = [
 # execution.
 INTEGRATION_LOCAL = "local"
 INTEGRATION_SAGEMAKER = "sagemaker"
-INTEGRATIONS = [INTEGRATION_LOCAL, INTEGRATION_SAGEMAKER]
+INTEGRATION_OPENAI = "openai"
+INTEGRATIONS = [INTEGRATION_LOCAL, INTEGRATION_SAGEMAKER, INTEGRATION_OPENAI]
 
 
 class SequenceLengthsConfig(BaseModel):
@@ -164,8 +165,8 @@ class ServerConfig(BaseModel):
     )
 
     integration: str = Field(
-        default=INTEGRATION_LOCAL,
-        description="The kind of integration to use. local|sagemaker",
+        default=None,
+        description="The kind of integration to use. local|sagemaker|openai",
     )
 
     engine_thread_pinning: str = Field(

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -41,8 +41,6 @@ from fastapi.responses import StreamingResponse
 from starlette.responses import RedirectResponse
 
 
-SUPPORTED_INTEGRATIONS = ["local", "sagemaker", "openai"]
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -82,12 +80,6 @@ class Server:
         self.context = None
         self.executor = None
         self.server_logger = server_logger_from_config(self.server_config)
-
-        if self.server_config.integration not in SUPPORTED_INTEGRATIONS:
-            raise ValueError(
-                f"Unknown integration field {self.server_config.integration}. "
-                f"Expected one of {SUPPORTED_INTEGRATIONS}"
-            )
 
     def start_server(
         self,

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -18,6 +18,7 @@ from re import escape
 from unittest.mock import patch
 
 import pytest
+from deepsparse.server.cli import _fetch_server
 from deepsparse.server.config import EndpointConfig, ServerConfig
 from deepsparse.server.server import Server
 
@@ -42,20 +43,18 @@ def test_invalid_integration():
     with pytest.raises(
         ValueError,
         match=escape(
-            "Unknown integration field asdf. "
-            "Expected one of ['local', 'sagemaker', 'openai']"
+            "asdf is not a supported integration. Must be "
+            "one of ['local', 'sagemaker', 'openai']"
         ),
     ):
-        server = Server(
-            ServerConfig(
-                num_cores=1,
-                num_workers=1,
-                integration="asdf",
-                endpoints=[],
-                loggers={},
-            )
+        server = ServerConfig(
+            num_cores=1,
+            num_workers=1,
+            integration="asdf",
+            endpoints=[],
+            loggers={},
         )
-        server._build_app()
+        _fetch_server("local", server)
 
 
 def test_pytorch_num_threads():


### PR DESCRIPTION
# Summary
- The integration value defined in the server config was being ignored and the cli argument was only being considered
- Update to use both
- Also update tests and small clean-up
- For this ticket: https://app.asana.com/0/1205229323407165/1206280777419100/f

# Testing
- All server tests pass

The following config file will create an openai server:

```yaml
num_workers: 1
num_streams: 1
integration: openai
endpoints:
  - task: text_generation
    model: "hf:mgoin/TinyStories-1M-ds"
    kwargs:
      {"continuous_batch_sizes": [4, 8, 16], "force_max_tokens": True}
```