### PR TITLE
[Benchmark] Fix number of iterations reported

### DIFF
--- a/src/deepsparse/benchmark/benchmark_pipeline.py
+++ b/src/deepsparse/benchmark/benchmark_pipeline.py
@@ -511,7 +511,7 @@ def main(
     benchmark_results = {
         "items_per_sec": items_per_sec,
         "seconds_ran": total_run_time,
-        "iterations": len(batch_times),
+        "iterations": len(batch_times["total_inference"]),
         "compute_sections": section_stats,
     }
 


### PR DESCRIPTION
# Summary

- While using `benchmark_pipeline`, found a small bug in reported stats where we were incorrectly reporting the number of keys in the dictionary, not the number of iterations for which inference ran