### PR TITLE
Use Int KV Cache as default for deepsparse.benchmark

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -349,7 +349,7 @@ def benchmark_model(
     disable_kv_cache_overrides: bool = False,
 ) -> Dict:
     """
-    Run benchamrk of a given model on a given engine
+    Benchmark a model on a given engine
 
     :param model_path: Path or stub to the model
     :param batch_size: Batch size, Defaults to 1.
@@ -362,11 +362,14 @@ def benchmark_model(
     :param sequence_length: Sequence length for text-gen. Defaults to None.
     :param input_ids_length: Length of the input ids. Defaults to 1.
     :param thread_pinning: The hardware to pin for threading. Defaults to "core".
-    :param engine: The type of engine to use. Defaults to our proprietary DEEPSPARSE_ENGINE.
-    :param internal_kv_cache: Runs the benchmark with or w/o the kv cache. Defaults to True.
+    :param engine: The type of engine to use. Defaults to our proprietary
+        DEEPSPARSE_ENGINE.
+    :param internal_kv_cache: Runs the benchmark with or w/o the kv cache.
+        Defaults to True.
     :param quiet: Verbose option if set to False. Defaults to False.
     :param export_path: Path to save the results. Defaults to None.
-    :param disable_kv_cache_overrides: Option to override the kv cache. Defaults to False.
+    :param disable_kv_cache_overrides: Option to override the kv cache.
+        Defaults to False.
     :returns: Dictionary of benchmarked metrics
 
     """

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -343,7 +343,7 @@ def benchmark_model(
     input_ids_length: Optional[int] = 1,
     thread_pinning: str = "core",
     engine: str = DEEPSPARSE_ENGINE,
-    internal_kv_cache: bool = False,
+    internal_kv_cache: bool = True,
     quiet: bool = False,
     export_path: Optional[str] = None,
     disable_kv_cache_overrides: bool = False,

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -348,6 +348,29 @@ def benchmark_model(
     export_path: Optional[str] = None,
     disable_kv_cache_overrides: bool = False,
 ) -> Dict:
+    """
+    Run benchamrk of a given model on a given engine
+
+    :param model_path: Path or stub to the model
+    :param batch_size: Batch size, Defaults to 1.
+    :param input_shapes: Shape of the input. Defaults to "".
+    :param num_cores: Number of cores to use. Defaults to None.
+    :param scenario: The "type" of scenario to use. Defaults to "sync".
+    :param time: Total run-time to run the benchmark for. Defaults to 10.
+    :param warmup_time: Time to run the engine before running benchmarks. Defaults to 2.
+    :param num_streams: Number of streams. Defaults to None.
+    :param sequence_length: Sequence length for text-gen. Defaults to None.
+    :param input_ids_length: Length of the input ids. Defaults to 1.
+    :param thread_pinning: The hardware to pin for threading. Defaults to "core".
+    :param engine: The type of engine to use. Defaults to our proprietary DEEPSPARSE_ENGINE.
+    :param internal_kv_cache: Runs the benchmark with or w/o the kv cache. Defaults to True.
+    :param quiet: Verbose option if set to False. Defaults to False.
+    :param export_path: Path to save the results. Defaults to None.
+    :param disable_kv_cache_overrides: Option to override the kv cache. Defaults to False.
+    :returns: Dictionary of benchmarked metrics
+
+    """
+
     if quiet:
         set_logging_level(logging.WARN)
 


### PR DESCRIPTION
# Description
Tested two entrypoints for deepsparse.benchmark. One used internal KV and other used external. Goal is to always use internal KV.

1. Python
```python3
from deepsparse.benchmark.benchmark_model import benchmark_model

stub = "zoo:mistral-7b-gsm8k_mistral_pretrain-pruned80"
results = benchmark_model(stub)
print(results)
```

2. CLI
```bash
deepsparse.benchmark "zoo:mistral-7b-gsm8k_mistral_pretrain-pruned80"
```

# Results

1. Python
```json
{
   "engine":"deepsparse.engine.Engine:\n\tonnx_file_path: /home/george/.cache/sparsezoo/neuralmagic/mistral-7b-gsm8k_mistral_pretrain-pruned80/deployment/model.onnx\n\tbatch_size: 1\n\tnum_cores: 32\n\tnum_streams: 1\n\tscheduler: Scheduler.default\n\tfraction_of_supported_ops: 1.0\n\tcpu_avx_type: avx2\n\tcpu_vnni: False",
   "version":"1.7.0.20240104",
   "orig_model_path":"zoo:mistral-7b-gsm8k_mistral_pretrain-pruned80",
   "model_path":"/home/george/.cache/sparsezoo/neuralmagic/mistral-7b-gsm8k_mistral_pretrain-pruned80/deployment/model.onnx",
   "batch_size":1,
   "input_shapes":"None",
   "num_cores":32,
   "scenario":"singlestream",
   "scheduler":"Scheduler.default",
   "seconds_to_run":10,
   "num_streams":1,
   "benchmark_result":{
      "scenario":"singlestream",
      "items_per_sec":0.7033625366578768,
      "seconds_ran":15.6391610680148,
      "iterations":11,
      "median":576.397096272558,
      "mean":1421.7223456044767,
      "std":2497.9850669397615,
      "25.0%":493.93453216180205,
      "50.0%":576.397096272558,
      "75.0%":676.7404270358384,
      "90.0%":1781.627886928618,
      "95.0%":5504.294607555494,
      "99.0%":8482.427984056996,
      "99.9%":9152.507993769847
   },
   "fraction_of_supported_ops":1.0,
   "sequence_length":2048,
   "input_ids_length":1
}
```
3. CLI
```json
{
   "engine":"deepsparse.engine.Engine:\n\tonnx_file_path: /home/george/.cache/sparsezoo/neuralmagic/mistral-7b-gsm8k_mistral_pretrain-pruned80/deployment/model.onnx\n\tbatch_size: 1\n\tnum_cores: 32\n\tnum_streams: 1\n\tscheduler: Scheduler.default\n\tfraction_of_supported_ops: 1.0\n\tcpu_avx_type: avx2\n\tcpu_vnni: False",
   "version":"1.7.0.20240104",
   "orig_model_path":"zoo:mistral-7b-gsm8k_mistral_pretrain-pruned80",
   "model_path":"/home/george/.cache/sparsezoo/neuralmagic/mistral-7b-gsm8k_mistral_pretrain-pruned80/deployment/model.onnx",
   "batch_size":1,
   "input_shapes":null,
   "num_cores":32,
   "scenario":"singlestream",
   "scheduler":"Scheduler.default",
   "seconds_to_run":10,
   "num_streams":1,
   "benchmark_result":{
      "scenario":"singlestream",
      "items_per_sec":1.1406279406751316,
      "seconds_ran":19.287621506955475,
      "iterations":22,
      "median":353.46097755245864,
      "mean":876.6876120670614,
      "std":2260.886819025657,
      "25.0%":286.9633190566674,
      "50.0%":353.46097755245864,
      "75.0%":506.17970793973655,
      "90.0%":652.1910438779744,
      "95.0%":800.4174952395259,
      "99.0%":9027.320535853496,
      "99.9%":10993.794929189637
   },
   "fraction_of_supported_ops":1.0,
   "sequence_length":2048,
   "input_ids_length":1
}
```
