### PR TITLE
Add `--num-kv-cache-tokens` to benchmarking scripts

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -420,7 +420,7 @@ def benchmark_model(
 
         # This environment variable sets the KV cache to a fixed number of prefilled
         # tokens for consistent benchmarking
-        os.environ["NM_BENCHMARK_KV_TOKENS"] = num_kv_cache_tokens
+        os.environ["NM_BENCHMARK_KV_TOKENS"] = str(num_kv_cache_tokens)
 
         _LOGGER.info(
             f"Benchmarking Engine: {engine} with "
@@ -535,6 +535,7 @@ def main():
         quiet=args.quiet,
         export_path=args.export_path,
         disable_kv_cache_overrides=args.disable_kv_cache_overrides,
+        num_kv_cache_tokens=args.num_kv_cache_tokens,
     )
 
     # Results summary

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -319,7 +319,7 @@ def parse_args():
         "--num-kv-cache-tokens",
         "--num_kv_cache_tokens",
         type=int,
-        default=1,
+        default=os.environ.get("NM_BENCHMARK_KV_TOKENS") or 1,
         help=(
             "If using internal kv cache, sets the number of tokens to fill "
             "the cache with"

--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -95,7 +95,8 @@ optional arguments:
                         with kv cache overrides
   --num-kv-cache-tokens NUM_KV_CACHE_TOKENS, --num_kv_cache_tokens NUM_KV_CACHE_TOKENS
                         If using internal kv cache, sets the number of tokens to fill 
-                        the cache with
+                        the cache with. Must be between 0 and sequence_length -
+                        input_ids_length
 
 ##########
 Example on a BERT from SparseZoo:
@@ -321,8 +322,8 @@ def parse_args():
         type=int,
         default=os.environ.get("NM_BENCHMARK_KV_TOKENS") or 1,
         help=(
-            "If using internal kv cache, sets the number of tokens to fill "
-            "the cache with"
+            "If using internal kv cache, sets the number of tokens to fill the cache "
+            "with. Must be between 0 and sequence_length - input_ids_length"
         ),
     )
 

--- a/src/deepsparse/debug_analysis.py
+++ b/src/deepsparse/debug_analysis.py
@@ -249,7 +249,7 @@ def parse_args():
         "--num-kv-cache-tokens",
         "--num_kv_cache_tokens",
         type=int,
-        default=1,
+        default=int(os.environ.get("NM_BENCHMARK_KV_TOKENS") or "1"),
         help=(
             "If using internal kv cache, sets the number of tokens to fill "
             "the cache with"

--- a/src/deepsparse/debug_analysis.py
+++ b/src/deepsparse/debug_analysis.py
@@ -433,7 +433,7 @@ def main():
 
         # This environment variable sets the KV cache to a fixed number of prefilled
         # tokens for consistent benchmarking
-        os.environ["NM_BENCHMARK_KV_TOKENS"] = args.num_kv_cache_tokens
+        os.environ["NM_BENCHMARK_KV_TOKENS"] = str(args.num_kv_cache_tokens)
 
         print(
             f"Enable KVCache: prev_num_tokens = {kv_cache_params.prev_num_tokens}, "

--- a/src/deepsparse/debug_analysis.py
+++ b/src/deepsparse/debug_analysis.py
@@ -30,6 +30,7 @@ usage: deepsparse.debug_analysis [-h] [-wi NUM_WARMUP_ITERATIONS]
                                  [--kv-cache-num-frozen-tokens KV_CACHE_NUM_FROZEN_TOKENS]
                                  [-q] [-x EXPORT_PATH]
                                  [--disable-kv-cache-overrides]
+                                 [--num-kv-cache-tokens NUM_KV_CACHE_TOKENS]
                                  model_path
 
 Analyze ONNX models in the DeepSparse Engine
@@ -86,6 +87,9 @@ optional arguments:
   --disable-kv-cache-overrides, --disable_kv_cache_overrides
                         If set, it will not alter the model
                         with kv cache overrides
+  --num-kv-cache-tokens NUM_KV_CACHE_TOKENS, --num_kv_cache_tokens NUM_KV_CACHE_TOKENS
+                        If using internal kv cache, sets the number of tokens to fill 
+                        the cache with
 """  # noqa E501
 
 import argparse
@@ -240,6 +244,16 @@ def parse_args():
         ),
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--num-kv-cache-tokens",
+        "--num_kv_cache_tokens",
+        type=int,
+        default=1,
+        help=(
+            "If using internal kv cache, sets the number of tokens to fill "
+            "the cache with"
+        ),
     )
 
     return parser.parse_args()
@@ -417,9 +431,14 @@ def main():
             args.kv_cache_num_frozen_tokens,
         )
 
+        # This environment variable sets the KV cache to a fixed number of prefilled
+        # tokens for consistent benchmarking
+        os.environ["NM_BENCHMARK_KV_TOKENS"] = args.num_kv_cache_tokens
+
         print(
             f"Enable KVCache: prev_num_tokens = {kv_cache_params.prev_num_tokens}, "
-            f"num_frozen_tokens = {kv_cache_params.num_frozen_tokens}"
+            f"num_frozen_tokens = {kv_cache_params.num_frozen_tokens}, "
+            f"num_kv_cache_tokens = {args.num_kv_cache_tokens}"
         )
 
     result = model_debug_analysis(

--- a/src/deepsparse/debug_analysis.py
+++ b/src/deepsparse/debug_analysis.py
@@ -89,7 +89,8 @@ optional arguments:
                         with kv cache overrides
   --num-kv-cache-tokens NUM_KV_CACHE_TOKENS, --num_kv_cache_tokens NUM_KV_CACHE_TOKENS
                         If using internal kv cache, sets the number of tokens to fill 
-                        the cache with
+                        the cache with. Must be between 0 and sequence_length -
+                        input_ids_length
 """  # noqa E501
 
 import argparse
@@ -251,8 +252,8 @@ def parse_args():
         type=int,
         default=int(os.environ.get("NM_BENCHMARK_KV_TOKENS") or "1"),
         help=(
-            "If using internal kv cache, sets the number of tokens to fill "
-            "the cache with"
+            "If using internal kv cache, sets the number of tokens to fill the cache "
+            "with. Must be between 0 and sequence_length - input_ids_length"
         ),
     )
 


### PR DESCRIPTION
It will default to 1 or NM_BENCHMARK_KV_TOKENS, if it is set

```
> deepsparse.benchmark hf:mgoin/TinyStories-1M-ds --num-kv-cache-tokens 1 -ncores 1 -q
Fetching 11 files: 100%|██████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 15666.33it/s]
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20231210 COMMUNITY | (99472380) (release) (optimized) (system=neon, binary=neon)
Original Model Path: hf:mgoin/TinyStories-1M-ds
Batch Size: 1
Scenario: sync
Throughput (items/sec): 1158.0933
Latency Mean (ms/batch): 0.8611
Latency Median (ms/batch): 0.8375
Latency Std (ms/batch): 0.0655
Iterations: 11581

> deepsparse.benchmark hf:mgoin/TinyStories-1M-ds --num-kv-cache-tokens 1000 -ncores 1 -q
Fetching 11 files: 100%|██████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 42134.56it/s]
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20231210 COMMUNITY | (99472380) (release) (optimized) (system=neon, binary=neon)
Original Model Path: hf:mgoin/TinyStories-1M-ds
Batch Size: 1
Scenario: sync
Throughput (items/sec): 922.7386
Latency Mean (ms/batch): 1.0813
Latency Median (ms/batch): 1.0664
Latency Std (ms/batch): 0.0502
Iterations: 9228
```