### PR TITLE
[BugFixes] `deepsparse.eval`

### DIFF
--- a/src/deepsparse/evaluation/integrations/__init__.py
+++ b/src/deepsparse/evaluation/integrations/__init__.py
@@ -24,8 +24,8 @@ def try_import_lm_evaluation_harness(raise_error=False):
         if raise_error:
             raise ImportError(
                 "Unable to import lm_eval. "
-                "To install the dependency refer to the github repository: "
-                "https://github.com/EleutherAI/lm-evaluation-harness"
+                "To install run 'pip install "
+                "git+https://github.com/EleutherAI/lm-evaluation-harness@b018a7d51'"
             )
         return False
 

--- a/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
+++ b/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
@@ -207,7 +207,12 @@ class DeepSparseLM(base.BaseLM):
         self.tokenizer = tokenizer if tokenizer else self.model.tokenizer
 
         self._batch_size = batch_size
-        self._max_length = pipeline.sequence_length
+        try:
+            self._max_length = pipeline.sequence_length
+        except:
+            # workaround until the DeepSparse pipeline exposes the sequence_length
+            self._max_length = pipeline.ops["single_engine"].sequence_length
+        
         self._max_gen_toks = max_gen_toks or 256
 
         self.vocab_size = self.tokenizer.vocab_size

--- a/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
+++ b/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
@@ -209,10 +209,10 @@ class DeepSparseLM(base.BaseLM):
         self._batch_size = batch_size
         try:
             self._max_length = pipeline.sequence_length
-        except:
+        except Exception:
             # workaround until the DeepSparse pipeline exposes the sequence_length
             self._max_length = pipeline.ops["single_engine"].sequence_length
-        
+
         self._max_gen_toks = max_gen_toks or 256
 
         self.vocab_size = self.tokenizer.vocab_size


### PR DESCRIPTION
This PR fixes a few bugs found while updating the eval framework:

1) `sequence_length` is no longer exposed at the pipeline level

```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
            task="text-generation",
            model_path="zoo:mpt-7b-mpt_pretrain-base_quantized",
        )

assert hasattr(pipeline, "sequence_length")
```

```bash
Traceback (most recent call last):
  File "/home/rahul/projects/deepsparse/local.py", line 12, in <module>
    assert hasattr(pipeline, "sequence_length")
AssertionError
>>> 
```

Fix: workaround relies on `pipeline.ops["single_engine"].sequence_length`

2) `deepsparse.eval` requires a specific commit from lm-eval-harness for now, updating the install message to reflect that
