### PR TITLE
[Add] sequence length to text gen pipelines

### DIFF
--- a/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
+++ b/src/deepsparse/evaluation/integrations/lm_evaluation_harness.py
@@ -207,12 +207,7 @@ class DeepSparseLM(base.BaseLM):
         self.tokenizer = tokenizer if tokenizer else self.model.tokenizer
 
         self._batch_size = batch_size
-        try:
-            self._max_length = pipeline.sequence_length
-        except Exception:
-            # workaround until the DeepSparse pipeline exposes the sequence_length
-            self._max_length = pipeline.ops["single_engine"].sequence_length
-
+        self._max_length = pipeline.sequence_length
         self._max_gen_toks = max_gen_toks or 256
 
         self.vocab_size = self.tokenizer.vocab_size

--- a/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
@@ -289,6 +289,16 @@ class TextGenerationPipeline(Pipeline):
     def condense_inputs(self, *args, **kwargs):
         return args[0], kwargs
 
+    @property
+    def sequence_length(self) -> int:
+        """
+        Property to return the sequence length for the pipeline.
+        (relies on the single engine operator)
+
+        :return: the sequence length for the pipeline
+        """
+        return self.ops["single_engine"].sequence_length
+
     def _get_continuous_batching_scheduler(
         self, batch_sizes: List[int], engines: List[EngineOperator]
     ) -> ContinuousBatchingScheduler:


### PR DESCRIPTION
This PR exposes `sequence_length` as a Pipeline level property

Test Code:
```python
from deepsparse import Pipeline

pipeline = Pipeline.create(
            task="text-generation",
            model_path="zoo:mpt-7b-mpt_pretrain-base_quantized",
        )

assert hasattr(pipeline, "sequence_length")
```

Was failing before, but passes after this PR