### PR TITLE
[timer][benchmark_pipeline] Update the `benchmark_pipeline` to work with v1 and v2; clean-up middleware/timer_middleware

### DIFF
--- a/src/deepsparse/benchmark/benchmark_pipeline.py
+++ b/src/deepsparse/benchmark/benchmark_pipeline.py
@@ -124,6 +124,8 @@ _LOGGER = logging.getLogger(__name__)
 DEEPSPARSE_ENGINE = "deepsparse"
 ORT_ENGINE = "onnxruntime"
 
+from deepsparse.middlewares import MiddlewareManager, MiddlewareSpec, TimerMiddleware
+
 
 class PipelineExecutorThread(threading.Thread):
     """
@@ -289,6 +291,10 @@ def benchmark_pipeline(
     input_type = config.data_type
     kwargs = config.pipeline_kwargs
     kwargs["benchmark"] = True
+
+    middlewares = [
+        MiddlewareSpec(TimerMiddleware),  # for timer
+    ]
     pipeline = Pipeline.create(
         task=task,
         model_path=model_path,
@@ -296,6 +302,7 @@ def benchmark_pipeline(
         scheduler=scheduler,
         num_cores=num_cores,
         num_streams=num_streams,
+        middleware_manager=MiddlewareManager(middlewares),
         **kwargs,
     )
     inputs = create_input_schema(pipeline, input_type, batch_size, config)

--- a/src/deepsparse/benchmark/benchmark_pipeline.py
+++ b/src/deepsparse/benchmark/benchmark_pipeline.py
@@ -371,7 +371,7 @@ def calculate_statistics(
 
 def calculate_section_stats(
     batch_times: Dict[str, List[float]], total_run_time: float, num_streams: int
-) -> Dict[str, Dict]:
+) -> Tuple[Dict[str, Dict], Optional[Dict[str, List]]]:
     total_run_time_ms = total_run_time * 1000
 
     sections = {}

--- a/src/deepsparse/benchmark/benchmark_pipeline.py
+++ b/src/deepsparse/benchmark/benchmark_pipeline.py
@@ -302,7 +302,8 @@ def benchmark_pipeline(
 
     if scenario == "singlestream":
         singlestream_benchmark(pipeline, inputs, warmup_time)
-        pipeline.timer_manager.clear()
+        #pipeline.timer_manager.clear()
+        pipeline.timer_manager.measurements.clear()
         start_time = time.perf_counter()
         singlestream_benchmark(pipeline, inputs, seconds_to_run)
     elif scenario == "multistream":
@@ -320,7 +321,8 @@ def benchmark_pipeline(
 
     end_time = time.perf_counter()
     total_run_time = end_time - start_time
-    batch_times = pipeline.timer_manager.all_times
+    #batch_times = pipeline.timer_manager.all_times
+    batch_times = pipeline.timer_manager.measurements
     if len(batch_times) == 0:
         raise Exception(
             "Generated no batch timings, try extending benchmark time with '--time'"
@@ -355,13 +357,30 @@ def calculate_section_stats(
     total_run_time_ms = total_run_time * 1000
 
     sections = {}
+   
+    """
     for section_name in batch_times:
         times = [t * 1000 for t in batch_times[section_name]]
         sections[section_name] = calculate_statistics(
             times, total_run_time_ms, num_streams
         )
+    """
+    print(len(batch_times))
+    all_sections = {}
+    for batch in batch_times:
+        for k, v in batch.items():
+            if k in all_sections:
+                all_sections[k].extend(v)
+            else:
+                all_sections[k] = v
 
-    return sections
+    for section_name in all_sections:
+        times = [t * 1000 for t in all_sections[section_name]]
+        sections[k] = calculate_statistics(
+            times, total_run_time_ms, num_streams
+        )
+    #"""
+    return sections, all_sections
 
 
 @click.command()
@@ -505,8 +524,9 @@ def main(
         quiet=quiet,
     )
 
-    section_stats = calculate_section_stats(batch_times, total_run_time, num_streams)
-    items_per_sec = (len(batch_times["total_inference"]) * batch_size) / total_run_time
+    section_stats, all_sections = calculate_section_stats(batch_times, total_run_time, num_streams)
+    #items_per_sec = (len(batch_times["total_inference"]) * batch_size) / total_run_time
+    items_per_sec = (len(all_sections["total"]) * batch_size) / total_run_time
 
     benchmark_results = {
         "items_per_sec": items_per_sec,

--- a/src/deepsparse/benchmark/benchmark_pipeline.py
+++ b/src/deepsparse/benchmark/benchmark_pipeline.py
@@ -116,6 +116,7 @@ from deepsparse.cpu import cpu_architecture
 from deepsparse.log import set_logging_level
 from deepsparse.middlewares import MiddlewareManager, MiddlewareSpec, TimerMiddleware
 from deepsparse.tasks import SupportedTasks
+from deepsparse.utils.timer import InferenceStages
 
 
 __all__ = ["benchmark_pipeline"]
@@ -547,14 +548,14 @@ def main(
 
     if all_sections:
         items_per_sec = (
-            len(all_sections["total_inference"]) * batch_size
+            len(all_sections[InferenceStages.TOTAL_INFERENCE]) * batch_size
         ) / total_run_time
-        iterations = len(all_sections["total_inference"])
+        iterations = len(all_sections[InferenceStages.TOTAL_INFERENCE])
     else:
         items_per_sec = (
-            len(batch_times["total_inference"]) * batch_size
+            len(batch_times[InferenceStages.TOTAL_INFERENCE]) * batch_size
         ) / total_run_time
-        iterations = len(batch_times["total_inference"])
+        iterations = len(batch_times[InferenceStages.TOTAL_INFERENCE])
 
     benchmark_results = {
         "items_per_sec": items_per_sec,

--- a/src/deepsparse/middlewares/__init__.py
+++ b/src/deepsparse/middlewares/__init__.py
@@ -15,4 +15,4 @@
 # flake8: noqa
 
 from .middleware import MiddlewareCallable, MiddlewareManager, MiddlewareSpec
-from .timer_middleware import TimerMiddleware
+from .timer_middleware import *

--- a/src/deepsparse/middlewares/timer_middleware.py
+++ b/src/deepsparse/middlewares/timer_middleware.py
@@ -17,6 +17,12 @@ from typing import Any
 from deepsparse.middlewares.middleware import MiddlewareCallable
 
 
+__all__ = ["TimerMiddleware", "IS_NESTED_KEY", "NAME_KEY"]
+
+IS_NESTED_KEY = "is_nested"
+NAME_KEY = "name"
+
+
 class TimerMiddleware(MiddlewareCallable):
     def __init__(
         self, call_next: MiddlewareCallable, identifier: str = "TimerMiddleware"
@@ -25,8 +31,8 @@ class TimerMiddleware(MiddlewareCallable):
         self.call_next: MiddlewareCallable = call_next
 
     def __call__(self, *args, **kwargs) -> Any:
-        name = kwargs.get("name")
-        is_nested = kwargs.pop("is_nested", False)
+        name = kwargs.get(NAME_KEY)
+        is_nested = kwargs.pop(IS_NESTED_KEY, False)
 
         inference_state = kwargs.get("inference_state")
         timer = inference_state.timer

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -82,6 +82,7 @@ class Pipeline(Operator):
         pipeline_state: Optional[PipelineState] = None,
         middleware_manager: Optional[MiddlewareManager] = None,
         timer_manager: Optional[TimerManager] = None,
+        benchmark: bool = False,
     ):
 
         self.ops = ops
@@ -96,6 +97,16 @@ class Pipeline(Operator):
 
         self._scheduler_group = SchedulerGroup(self.schedulers)
         self.subgraph_executor = SubGraphExecutor()
+        self.benchmark = benchmark
+
+    
+    @property 
+    def input_schema(self):
+        raise AttributeError("No input schema has been set for this pipeline.")
+
+    @property 
+    def output_schema(self):
+        raise AttributeError("No output schema has been set for this pipeline.")
 
     @classmethod
     def create(cls, task: str, **kwargs) -> "Pipeline":
@@ -111,6 +122,9 @@ class Pipeline(Operator):
             else:
                 new_kwargs[k] = kwargs.get(k)
 
+        
+        pipeline = Operator.create(task=task, **new_kwargs)
+        """
         try:
             model_path = new_kwargs.get("model_path")
             model = new_kwargs.pop("model", None)
@@ -133,6 +147,10 @@ class Pipeline(Operator):
             from deepsparse.legacy import Pipeline
 
             pipeline = Pipeline.create(task=task, **kwargs)
+        """
+        #from deepsparse.legacy import Pipeline
+
+        #pipeline = Pipeline.create(task=task, **kwargs)
         return pipeline
 
     @classmethod

--- a/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
@@ -15,6 +15,7 @@
 import logging
 from typing import List, Optional
 
+from deepsparse.middlewares import MiddlewareManager
 from deepsparse.operators import EngineOperator
 from deepsparse.operators.registry import OperatorRegistry
 from deepsparse.pipeline import Pipeline
@@ -61,6 +62,7 @@ class TextGenerationPipeline(Pipeline):
         generation_config=None,
         continuous_batch_sizes: Optional[List[int]] = None,
         benchmark: bool = False,
+        middleware_manager: Optional[MiddlewareManager] = None,
         **engine_kwargs,
     ):
         """
@@ -119,9 +121,6 @@ class TextGenerationPipeline(Pipeline):
 
         if internal_kv_cache and engine_kwargs.get("engine_type") == "onnxruntime":
             internal_kv_cache = False
-
-        # pop middleware_manager before going into NLEngineOperator
-        middleware_manager = engine_kwargs.pop("middleware_manager", None)
 
         single_engine_operator = NLEngineOperator(
             sequence_length=sequence_length,
@@ -279,7 +278,7 @@ class TextGenerationPipeline(Pipeline):
             pipeline_state=pipeline_state,
             continuous_batching_scheduler=continuous_batching_scheduler,
             middleware_manager=middleware_manager,
-            benchmark=benchmark
+            benchmark=benchmark,
         )
 
     @property

--- a/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/pipeline.py
@@ -60,6 +60,7 @@ class TextGenerationPipeline(Pipeline):
         force_max_tokens: bool = False,
         generation_config=None,
         continuous_batch_sizes: Optional[List[int]] = None,
+        benchmark: bool = False,
         **engine_kwargs,
     ):
         """
@@ -278,7 +279,16 @@ class TextGenerationPipeline(Pipeline):
             pipeline_state=pipeline_state,
             continuous_batching_scheduler=continuous_batching_scheduler,
             middleware_manager=middleware_manager,
+            benchmark=benchmark
         )
+
+    @property
+    def input_schema(self):
+        return self.ops["process_input"].input_schema
+
+    @property
+    def output_schema(self):
+        return self.ops["process_outputs"].output_schema
 
     def expand_inputs(self, items, batch_size):
         items = [items.get(key) for key in items.keys()]

--- a/src/deepsparse/utils/time.py
+++ b/src/deepsparse/utils/time.py
@@ -17,7 +17,18 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Dict, List
+
+
+__all__ = ["Timer", "InferenceStages", "TIMER_KEY"]
+
+TIMER_KEY = "timer"
+
+
+@dataclass(frozen=True)
+class InferenceStages:
+    TOTAL_INFERENCE: str = "total_inference"
 
 
 class Timer:

--- a/tests/test_pipeline_benchmark.py
+++ b/tests/test_pipeline_benchmark.py
@@ -173,7 +173,7 @@ def test_calculations():
 
     batch_times = timer_manager.all_times
     total_run_time = 6.0
-    section_stats = calculate_section_stats(batch_times, total_run_time, 1)
+    section_stats, _ = calculate_section_stats(batch_times, total_run_time, 1)
     assert math.isclose(
         section_stats["stage_1"]["total_percentage"], 33.33, rel_tol=0.05
     )


### PR DESCRIPTION
# Summary
- Update `benchmark_pipeline` such that it can work for both v1 and v2 pipelines. v1 uses a different timer compared to v2 and the changes in this PR allow support for both. v2 also requires `middleware` to be passed to the pipeline constructor when creating it 
- Clean-up the middleware code. There are a lot of keys being passed around that were stored as strings. To have one source of truth, the middleware/timer files were updated to include the constants 
- Also, exposes the `input_schema` and `output_schema` at the pipeline level

# Testing
- The following both work for v1 and v2 when running the benchmark pipeline:

For text_generation:

```bash
deepsparse.benchmark_pipeline text_generation  "hf:mgoin/TinyStories-1M-ds"
```

Output:

```bash

2024-01-08 22:01:22 deepsparse.benchmark.helpers WARNING  No input configuration file provided, using default.
2024-01-08 22:01:22 deepsparse.benchmark.benchmark_pipeline INFO     Original Model Path: hf:mgoin/TinyStories-1M-ds
2024-01-08 22:01:22 deepsparse.benchmark.benchmark_pipeline INFO     Task: text_generation
2024-01-08 22:01:22 deepsparse.benchmark.benchmark_pipeline INFO     Batch Size: 1
2024-01-08 22:01:22 deepsparse.benchmark.benchmark_pipeline INFO     Scenario: sync
2024-01-08 22:01:22 deepsparse.benchmark.benchmark_pipeline INFO     Requested Run Time(sec): 10
2024-01-08 22:01:22 deepsparse.benchmark.helpers INFO     Thread pinning to cores enabled
Fetching 11 files: 100%|████████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 50149.29it/s]
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20240108 COMMUNITY | (9cc30393) (release) (optimized) (system=avx2, binary=avx2)
Original Model Path: hf:mgoin/TinyStories-1M-ds
Batch Size: 1
Scenario: sync
Iterations: 31
Total Runtime: 10.2388
Throughput (items/sec): 3.0277
Processing Time Breakdown: 
     ParseTextGenerationInputs: 0.00%
     ProcessInputsTextGeneration: 0.14%
     PrepareforPrefill: 0.02%
     MultiEnginePrefill: 0.54%
     NLEngineOperator: 85.58%
     CompilePromptLogits: 0.03%
     PrepareGeneration: 3.96%
     AutoRegressiveOperatorPreprocess: 0.87%
     GenerateNewTokenOperator: 1.11%
     CompileGeneratedTokens: 0.15%
     CompileGenerations: 0.42%
     JoinOutput: 1.64%
     ProcessOutputs: 0.06%
     total_inference: 99.99%
Mean Latency Breakdown (ms/batch): 
     ParseTextGenerationInputs: 0.0085
     ProcessInputsTextGeneration: 0.4521
     PrepareforPrefill: 0.0555
     MultiEnginePrefill: 0.0851
     NLEngineOperator: 2.3954
     CompilePromptLogits: 0.0048
     PrepareGeneration: 13.0736
     AutoRegressiveOperatorPreprocess: 0.0298
     GenerateNewTokenOperator: 0.0378
     CompileGeneratedTokens: 0.0051
     CompileGenerations: 1.3707
     JoinOutput: 5.4254
     ProcessOutputs: 0.1875
     total_inference: 330.2510
```

For v1:

```bash

deepsparse.benchmark_pipeline text_classification zoo:nlp/sentiment_analysis/distilbert-none/pytorch/huggingface/sst2/pruned90-none

```

Output:

```bash

2024-01-08 22:11:56 deepsparse.benchmark.helpers WARNING  No input configuration file provided, using default.
2024-01-08 22:11:56 deepsparse.benchmark.benchmark_pipeline INFO     Original Model Path: zoo:nlp/sentiment_analysis/distilbert-none/pytorch/huggingface/sst2/pruned90-none
2024-01-08 22:11:56 deepsparse.benchmark.benchmark_pipeline INFO     Task: text_classification
2024-01-08 22:11:56 deepsparse.benchmark.benchmark_pipeline INFO     Batch Size: 1
2024-01-08 22:11:56 deepsparse.benchmark.benchmark_pipeline INFO     Scenario: sync
2024-01-08 22:11:56 deepsparse.benchmark.benchmark_pipeline INFO     Requested Run Time(sec): 10
2024-01-08 22:11:56 deepsparse.benchmark.helpers INFO     Thread pinning to cores enabled
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20240108 COMMUNITY | (9cc30393) (release) (optimized) (system=avx2, binary=avx2)

Original Model Path: zoo:nlp/sentiment_analysis/distilbert-none/pytorch/huggingface/sst2/pruned90-none
Batch Size: 1
Scenario: sync
Iterations: 1741
Total Runtime: 10.0039
Throughput (items/sec): 174.0316
Processing Time Breakdown: 
     engine_forward: 88.19%
     total_inference: 99.57%
     post_process: 0.88%
     pre_process: 10.33%
Mean Latency Breakdown (ms/batch): 
     engine_forward: 5.0676
     total_inference: 5.7216
     post_process: 0.0506
     pre_process: 0.5937
```