### PR TITLE
Add support for tokenized prompt input for CompletionRequest

### DIFF
--- a/src/deepsparse/server/openai_server.py
+++ b/src/deepsparse/server/openai_server.py
@@ -232,7 +232,28 @@ class OpenAIServer(Server):
 
             request_id = f"cmpl-{random_uuid()}"
             created_time = int(time.time())
-            prompt = request.prompt
+
+            if isinstance(request.prompt, list):
+                if len(request.prompt) == 0:
+                    return create_error_response(
+                        HTTPStatus.BAD_REQUEST, "please provide at least one prompt"
+                    )
+                first_element = request.prompt[0]
+                if isinstance(first_element, int):
+                    # There is just a single tokenized prompt
+                    prompt = pipeline.tokenizer.decode(request.prompt)
+                elif isinstance(first_element, (str, list)):
+                    if len(request.prompt) > 1:
+                        return create_error_response(
+                            HTTPStatus.BAD_REQUEST,
+                            "multiple prompts in a batch is not currently supported",
+                        )
+                    if isinstance(first_element[0], int):
+                        prompt = pipeline.tokenizer.decode(first_element)
+                    else:
+                        prompt = first_element
+            else:
+                prompt = request.prompt
 
             try:
                 sampling_params = dict(

--- a/src/deepsparse/server/protocol.py
+++ b/src/deepsparse/server/protocol.py
@@ -134,7 +134,7 @@ class CompletionRequest(BaseModel):
     """
 
     model: str
-    prompt: str
+    prompt: Union[List[int], List[List[int]], str, List[str]]
     suffix: Optional[str] = None
     max_tokens: Optional[int] = 16
     temperature: Optional[float] = 1.0

--- a/src/deepsparse/transformers/schemas/text_generation_schemas.py
+++ b/src/deepsparse/transformers/schemas/text_generation_schemas.py
@@ -57,7 +57,7 @@ class TextGenerationInput(BaseModel):
     )
     return_input_tokens: bool = Field(
         default=False,
-        description="A flag that indicates whether to return " "the input_tokens. ",
+        description="A flag that indicates whether to return the input_tokens. ",
     )
     include_prompt_logits: bool = Field(
         default=False,
@@ -158,8 +158,7 @@ class TextGenerationOutput(BaseModel):
         default=None,
         description="The output of the tokenizer."
         "Dictionary containing token_ids and attention_mask, "
-        "both mapping to arrays of size "
-        "[batch_size, sequence_length]",
+        "both mapping to arrays of size [batch_size, sequence_length]",
     )
 
     class Config:

--- a/tests/server/test_openai.py
+++ b/tests/server/test_openai.py
@@ -22,6 +22,7 @@ from deepsparse.server.openai_server import (
     OpenAIServer,
 )
 from fastapi.testclient import TestClient
+from transformers import AutoTokenizer
 
 
 TEST_MODEL_ID = "hf:mgoin/TinyStories-1M-ds"
@@ -178,14 +179,14 @@ def test_completions(client, model_card):
 
 
 def test_completions_tokenized(client, model_card):
-    temp_pipeline = Pipeline.create(task="text_generation", model_path=TEST_MODEL_ID)
     prompt = "The Boston Bruins are "
     max_tokens = 30
 
     # Test both passing in input_ids itself as a List[int],
     # and inside of a "batch" as a List[List[int]]
     # TODO: Multiple prompts/batching isn't supported yet
-    input_ids = temp_pipeline.tokenizer(prompt).input_ids
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_ID.removeprefix("hf:"))
+    input_ids = tokenizer(prompt).input_ids
     num_prompt_tokens = len(input_ids)
 
     for prompt in [input_ids, [input_ids]]:

--- a/tests/server/test_openai.py
+++ b/tests/server/test_openai.py
@@ -207,6 +207,6 @@ def test_completions_tokenized(client, model_card):
 
         assert (
             response.json()["choices"][0]["text"]
-            == 'a was very happy and thanked the man. He said, "Thank you, Sara. You are a '
-            + 'good friend."\n\nSara smiled and'
+            == 'a was very happy and thanked the man. He said, "Thank you, Sara. '
+            + 'You are a good friend."\n\nSara smiled and'
         )

--- a/tests/server/test_openai.py
+++ b/tests/server/test_openai.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from transformers import AutoTokenizer
+
 import pytest
 from deepsparse import Pipeline
 from deepsparse.server.config import EndpointConfig, ServerConfig
@@ -22,7 +24,6 @@ from deepsparse.server.openai_server import (
     OpenAIServer,
 )
 from fastapi.testclient import TestClient
-from transformers import AutoTokenizer
 
 
 TEST_MODEL_ID = "hf:mgoin/TinyStories-1M-ds"

--- a/tests/server/test_openai.py
+++ b/tests/server/test_openai.py
@@ -186,10 +186,12 @@ def test_completions_tokenized(client, model_card):
     # Test both passing in input_ids itself as a List[int],
     # and inside of a "batch" as a List[List[int]]
     # TODO: Multiple prompts/batching isn't supported yet
-    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_ID.removeprefix("hf:"))
+    prefix = "hf:"
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_ID[len(prefix) :])
     input_ids = tokenizer(prompt).input_ids
     num_prompt_tokens = len(input_ids)
 
+    # Testing both passing in a single prompt tokenized, and it wrapped in a list
     for prompt in [input_ids, [input_ids]]:
         request = CompletionRequest(
             prompt=prompt, max_tokens=max_tokens, model=model_card.id


### PR DESCRIPTION
Found through lm-evaluation-harness since for the OpenAI Completion interface they make requests using raw token_ids

OAI docs reference: https://platform.openai.com/docs/api-reference/completions
> prompt: The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.

Example request during `gsm8k` evaluation:
```
{'model': 'hf:mgoin/llama-2-7b-gsm8k-pruned60-quant-ds', 'prompt': [[1, 894, 29901, 21828, 18577, 29871, 29929, 29900, 9814, 273, 21425, 322, 29871, 29946, 29900, 28145, 5697, 348, 3173, 393, 9814, 273, 21425, 29889, 1128, 1784, 18281, 947, 540, 8024, 3001, 29973, 13, 22550, 29901]], 'max_tokens': 256, 'stop': ['<|endoftext|>'], 'seed': 1234, 'temperature': 0.0}
```

Server command:
```
deepsparse.server --integration openai --task text-generation --model_path hf:mgoin/llama-2-7b-gsm8k-pruned60-quant-ds
```

Eval command (using this branch https://github.com/EleutherAI/lm-evaluation-harness/pull/1277):
```
lm_eval --model local-completions --model_args base_url=http://localhost:5543/v1,model=hf:mgoin/llama-2-7b-gsm8k-pruned60-quant-ds,tokenizer_backend=huggingface,tokenizer=mgoin/llama-2-7b-gsm8k-pruned60-quant-ds --tasks gsm8k --num_fewshot 0
```