### PR TITLE
[TextGeneration] Update defaults to always start with deepsparse defaults when using the `generation_config` arg

### DIFF
--- a/src/deepsparse/transformers/schemas/text_generation_schemas.py
+++ b/src/deepsparse/transformers/schemas/text_generation_schemas.py
@@ -14,6 +14,7 @@
 
 import datetime
 import pathlib
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
@@ -22,20 +23,21 @@ from transformers import GenerationConfig
 
 
 # Based off of https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig # noqa E501
+@dataclass
 class GenerationDefaults:
     # Parameters that control the length of the output
-    max_length = None
-    max_new_tokens = 100
+    max_length: int = field(default=None)
+    max_new_tokens: int = field(default=100)
     # Parameters that control the generation strategy used
-    do_sample = False
+    do_sample: bool = field(default=False)
     # Parameters for manipulation of the model output logits
-    temperature = 1.0
-    top_k = 50
-    top_p = 1.0
-    repetition_penalty = 1.0
+    temperature: float = field(default=1.0)
+    top_k: int = field(default=50)
+    top_p: float = field(default=1.0)
+    repetition_penalty: float = field(default=1.0)
     # Parameters that define the outputs
-    num_return_sequences = 1
-    output_scores = False
+    num_return_sequences: int = field(default=1)
+    output_scores: bool = field(default=False)
 
 
 class FinishReason(Enum):


### PR DESCRIPTION
# Summary
- Previously, if the user provided anything for the `generation_config` argument, we always returned a `GenerationConfig` object for this case
- Now if the user provides the `GenerationConfig` object, that is the only case where we return the object without using deepsparse defaults
- If the user provides a dictionary, we create a GenerationConfig object, override with deepsparse defaults, and then set any attributes provided by the user in the dictionary
- This is aided through the conversion of the defaults into a dataclass
- All other workflows remain the same (i.e providing `generation_kwargs` or cli arguments which have always used deepsparse defaults)

Also takes care of this discussion: https://app.asana.com/0/1205229323407165/1206280624568198/f