### PR TITLE
[V2 Loggers] config file

### DIFF
--- a/src/deepsparse/loggers_v2/__init__.py
+++ b/src/deepsparse/loggers_v2/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/deepsparse/loggers_v2/config.py
+++ b/src/deepsparse/loggers_v2/config.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, Extra, Field, validator
+
+
+class LoggerConfig(BaseModel):
+    class Config:
+        extra = Extra.allow
+
+    name: str = Field(
+        default="PythonLogger",
+        description=(
+            "Path (/path/to/file:FooLogger) or name of loggers in "
+            "deepsparse/loggers/registry/__init__ path"
+        ),
+    )
+    handler: Optional[Dict] = None
+
+
+class TargetConfig(BaseModel):
+    func: str = Field(
+        default="identity",
+        description=(
+            (
+                "Callable to apply to 'value' for dimensionality reduction. "
+                "func can be a path /path/to/file:func) or name of func in "
+                "deepsparse/loggers/registry/__init__ path"
+            )
+        ),
+    )
+
+    freq: int = Field(
+        default=1,
+        description="The rate to log. Log every N occurances",
+    )
+    uses: List[str] = Field(default=["default"], description="")
+
+
+class MetricTargetConfig(TargetConfig):
+    capture: List[str] = Field(
+        [".*"],
+        description=(
+            "Key of the output dict. Corresponding value will be logged. "
+            "The value can be a regex pattern"
+        ),
+    )
+
+
+class LoggingConfig(BaseModel):
+
+    version: int = Field(
+        default=2,
+        description="Pipeline logger version",
+    )
+
+    logger: Dict[str, LoggerConfig] = Field(
+        default=dict(default=LoggerConfig()),
+        description="Loggers to be Used",
+    )
+
+    system: Dict[str, List[TargetConfig]] = Field(
+        default={".*": [TargetConfig()]},
+        description="Default python logging module logger",
+    )
+
+    performance: Dict[str, List[TargetConfig]] = Field(
+        default={"cpu": [TargetConfig()]},
+        description="Performance level config",
+    )
+
+    metric: Dict[str, List[MetricTargetConfig]] = Field(
+        default={r"(?i)operator": [MetricTargetConfig()]},
+        description="Metric level config",
+    )
+
+    @validator("logger", always=True)
+    def always_include_python_logger(cls, value):
+        if "default" not in value:
+            value["default"] = LoggerConfig()
+        return value
+
+    @classmethod
+    def from_yaml(cls, yaml_path: str):
+        """Load from yaml file"""
+        with open(yaml_path, "r") as file:
+            yaml_content = yaml.safe_load(file)
+        return cls(**yaml_content)
+
+    @classmethod
+    def from_str(cls, stringified_yaml: str):
+        """Load from stringified yaml"""
+        yaml_content = yaml.safe_load(stringified_yaml)
+
+        return cls(**yaml_content)
+
+    @classmethod
+    def from_config(cls, config: Optional[str] = None):
+        # """Helper to load from file or string"""
+        if config:
+            if config.endswith(".yaml"):
+                return cls.from_yaml(config)
+            return cls.from_str(config)
+        return LoggingConfig()

--- a/src/deepsparse/loggers_v2/config.py
+++ b/src/deepsparse/loggers_v2/config.py
@@ -12,71 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# class LogLevelEnum(str, Enum):
-#     DEBUG = "DEBUG"
-#     INFO = "INFO"
-#     WARNING = "WARNING"
-#     ERROR = "ERRPR"
-#     CRITICAL = "CRITICAL"
-
-
-# class StreamLoggingConfig(BaseModel):
-#     level: str = Field(default="INFO", description="Logger level")
-#     formatter: str = Field(
-#         default="%(asctime)s - %(levelname)s - %(message)s",
-#         description="Log display format",
-#     )
-
-
-# class FileLoggingConfig(StreamLoggingConfig):
-#     filename: str = Field(
-#         default="/tmp/pipeline.log", description="Path to save the logs"
-#     )
-
-
-# class RotatingLoggingConfig(StreamLoggingConfig):
-#     filename: str = Field(
-#         default="/tmp/pipeline_rotate.log", description="Path to save the logs"
-#     )
-#     max_bytes: int = Field(default=2048, description="Max size till rotation")
-#     backup_count: int = Field(default=3, description="Number of backups")
-
-
-# class PythonLoggingConfig(BaseModel):
-#     level: str = Field(default="INFO", description="Root logger level")
-#     stream: StreamLoggingConfig = Field(
-#         default=StreamLoggingConfig(), description="Stream logging config"
-#     )
-#     file: FileLoggingConfig = Field(
-#         default=FileLoggingConfig(), description="File logging config"
-#     )
-#     rotating: RotatingLoggingConfig = Field(
-#         default=RotatingLoggingConfig(), description="Rotating logging config"
-#     )
-
-
-# class CustomLoggingConfig(BaseModel):
-#     frequency: int = Field(
-#         default=1, description="The rate to log. Log every N occurances"
-#     )
-#     use: str = Field(
-#         description=(
-#             "List of loggers to use. Should be in the format",
-#             "path/to/file.py:ClassName",
-#         ),
-#     )
-
-#     class Config:
-#         extra = Extra.allow  # Allow extra kwargs
-
-
-# class PrometheusLoggingConfig(BaseModel):
-#     use: str = Field(default="path", description="Prometheus Logging path")
-#     port: int
-#     filename: str
-
-
 from typing import Dict, List, Optional
 
 import yaml
@@ -128,11 +63,6 @@ class MetricTargetConfig(TargetConfig):
 
 class LoggingConfig(BaseModel):
 
-    version: int = Field(
-        default=2,
-        description="Pipeline logger version",
-    )
-
     loggers: Dict[str, LoggerConfig] = Field(
         default=dict(default=LoggerConfig()),
         description="Loggers to be Used",
@@ -175,7 +105,7 @@ class LoggingConfig(BaseModel):
 
     @classmethod
     def from_config(cls, config: Optional[str] = None):
-        # """Helper to load from file or string"""
+        """Helper to load from file or string"""
         if config:
             if config.endswith(".yaml"):
                 return cls.from_yaml(config)

--- a/src/deepsparse/loggers_v2/config.py
+++ b/src/deepsparse/loggers_v2/config.py
@@ -13,6 +13,70 @@
 # limitations under the License.
 
 
+# class LogLevelEnum(str, Enum):
+#     DEBUG = "DEBUG"
+#     INFO = "INFO"
+#     WARNING = "WARNING"
+#     ERROR = "ERRPR"
+#     CRITICAL = "CRITICAL"
+
+
+# class StreamLoggingConfig(BaseModel):
+#     level: str = Field(default="INFO", description="Logger level")
+#     formatter: str = Field(
+#         default="%(asctime)s - %(levelname)s - %(message)s",
+#         description="Log display format",
+#     )
+
+
+# class FileLoggingConfig(StreamLoggingConfig):
+#     filename: str = Field(
+#         default="/tmp/pipeline.log", description="Path to save the logs"
+#     )
+
+
+# class RotatingLoggingConfig(StreamLoggingConfig):
+#     filename: str = Field(
+#         default="/tmp/pipeline_rotate.log", description="Path to save the logs"
+#     )
+#     max_bytes: int = Field(default=2048, description="Max size till rotation")
+#     backup_count: int = Field(default=3, description="Number of backups")
+
+
+# class PythonLoggingConfig(BaseModel):
+#     level: str = Field(default="INFO", description="Root logger level")
+#     stream: StreamLoggingConfig = Field(
+#         default=StreamLoggingConfig(), description="Stream logging config"
+#     )
+#     file: FileLoggingConfig = Field(
+#         default=FileLoggingConfig(), description="File logging config"
+#     )
+#     rotating: RotatingLoggingConfig = Field(
+#         default=RotatingLoggingConfig(), description="Rotating logging config"
+#     )
+
+
+# class CustomLoggingConfig(BaseModel):
+#     frequency: int = Field(
+#         default=1, description="The rate to log. Log every N occurances"
+#     )
+#     use: str = Field(
+#         description=(
+#             "List of loggers to use. Should be in the format",
+#             "path/to/file.py:ClassName",
+#         ),
+#     )
+
+#     class Config:
+#         extra = Extra.allow  # Allow extra kwargs
+
+
+# class PrometheusLoggingConfig(BaseModel):
+#     use: str = Field(default="path", description="Prometheus Logging path")
+#     port: int
+#     filename: str
+
+
 from typing import Dict, List, Optional
 
 import yaml
@@ -53,8 +117,8 @@ class TargetConfig(BaseModel):
 
 
 class MetricTargetConfig(TargetConfig):
-    capture: List[str] = Field(
-        [".*"],
+    capture: Optional[List[str]] = Field(
+        None,
         description=(
             "Key of the output dict. Corresponding value will be logged. "
             "The value can be a regex pattern"
@@ -69,7 +133,7 @@ class LoggingConfig(BaseModel):
         description="Pipeline logger version",
     )
 
-    logger: Dict[str, LoggerConfig] = Field(
+    loggers: Dict[str, LoggerConfig] = Field(
         default=dict(default=LoggerConfig()),
         description="Loggers to be Used",
     )
@@ -89,7 +153,7 @@ class LoggingConfig(BaseModel):
         description="Metric level config",
     )
 
-    @validator("logger", always=True)
+    @validator("loggers", always=True)
     def always_include_python_logger(cls, value):
         if "default" not in value:
             value["default"] = LoggerConfig()

--- a/tests/logger_v2/config.py
+++ b/tests/logger_v2/config.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import yaml
+
+from deepsparse.loggers_v2.config import LoggerConfig, LoggingConfig
+
+
+def test_config_generates_default_json():
+    """Check the default LoggingConfig"""
+
+    expected_config = """
+    version: 2
+    logger:
+      default:
+        name: PythonLogger
+        handler: null
+    system:
+      ".*":
+        - func: identity
+          freq: 1
+          uses:
+            - default
+    performance:
+      cpu:
+        - func: identity
+          freq: 1
+          uses:
+            - default
+    metric:
+      "(?i)operator":
+        - func: identity
+          freq: 1
+          uses:
+            - default
+          capture:
+            - .*
+    """
+    expected_dict = yaml.safe_load(expected_config)
+    default_dict = LoggingConfig().dict()
+    assert expected_dict == default_dict
+
+
+def test_logger_config_accepts_kwargs():
+    expected_config = """
+    name: PythonLogger
+    foo: 1
+    bar: "2024"
+    baz: 
+      one: 1
+      two: 2
+    boston:
+      - one
+      - two
+    """
+    config = LoggerConfig(**yaml.safe_load(expected_config)).dict()
+
+    assert config["name"] == "PythonLogger"
+    assert config["handler"] is None
+    assert config["baz"] == dict(one=1, two=2)
+    assert config["foo"] == 1
+    assert config["boston"] == ["one", "two"]
+    assert config["bar"] == "2024"

--- a/tests/logger_v2/test_config.py
+++ b/tests/logger_v2/test_config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-
 import yaml
 
 from deepsparse.loggers_v2.config import LoggerConfig, LoggingConfig
@@ -24,33 +22,34 @@ def test_config_generates_default_json():
 
     expected_config = """
     version: 2
-    logger:
+    loggers:
       default:
         name: PythonLogger
-        handler: null
+        handler: null # None in python
     system:
       ".*":
-        - func: identity
-          freq: 1
-          uses:
-            - default
+      - func: identity
+        freq: 1
+        uses:
+        - default
     performance:
       cpu:
-        - func: identity
-          freq: 1
-          uses:
-            - default
+      - func: identity
+        freq: 1
+        uses:
+        - default
     metric:
       "(?i)operator":
-        - func: identity
-          freq: 1
-          uses:
-            - default
-          capture:
-            - .*
+      - func: identity
+        freq: 1
+        uses:
+        - default
+        capture: null
+
     """
     expected_dict = yaml.safe_load(expected_config)
     default_dict = LoggingConfig().dict()
+    breakpoint()
     assert expected_dict == default_dict
 
 
@@ -59,7 +58,7 @@ def test_logger_config_accepts_kwargs():
     name: PythonLogger
     foo: 1
     bar: "2024"
-    baz: 
+    baz:
       one: 1
       two: 2
     boston:

--- a/tests/logger_v2/test_config.py
+++ b/tests/logger_v2/test_config.py
@@ -21,7 +21,6 @@ def test_config_generates_default_json():
     """Check the default LoggingConfig"""
 
     expected_config = """
-    version: 2
     loggers:
       default:
         name: PythonLogger


### PR DESCRIPTION
<img width="1182" alt="Screenshot 2024-01-18 at 10 53 12 AM" src="https://github.com/neuralmagic/deepsparse/assets/28371594/6649b164-01a3-4967-9f0f-6fe341298d5c">

## Config for validation

### Description

Config yaml file has five top level properties: version,  logging, system, performance and metric. 
version is always 2, since its for v2 pipeline
logging is the name of the defined logging (class LoggingFoo: here the name is LoggingFoo) which are singletons (one instance per any Name). 
Sys, Perf and Met are the three entry points to use the Logger. 
System is for default python (import logging) logging
Performance is for logging any hardware, benchmark,..etc metric-related log (thing that are already defined).
Metric is for input related logging (output value based on inputs).

If logging has any args for instantiation, one can define as 
```yaml
loggers:
  logger_id:
    name: FooLogger
    arg1: 1
    arg2: 2
```

For the three entry points,  the top level  after the root logger (system, metric, performance) is called the tag. Tags are used to filter out and log in any matching tag by regex. 
Under tags, we have three (four in metrics) properties, 
func is the function to apply to any value of interest to log. 
freq is the rate to log once a matching entry is encountered. 
uses: is a list to specify which logger to use, selected by logger_id

capture (metric only): key of the dict, property name to extract from the output of an operator, ran in logging middleware


```yaml
system: # Python/system level logging
  ".*": # reges tag to capture
  - func: identity # func name or path/to/file.py:func_name
    freq: 1 # rate to log
    uses: # which logger to use, point to the log id above
    - default 
metric:
  ".*":
  - func: max
    freq: 1
    uses:
    - list
    capture:  # The key, property to log. Ex rtn: Operator = AddOneOperator(...), if capture is set to value, it would record rtn.capture, if tag above is set to any regex that recognizes AddOneOperator (currently set to ".*")
    - ".*" # log every key, property that the dict, class has
```

In other words, for each root logger, what tags are we logging. With respect to tags, what function are we applying if any, at what rate and with respect to what loggers are we using

Root logger is a function of tags, tags are a fucntion of frequency, func and loggers. 
Root logger(tag(freq, func, loggers, capture))


### Examples
```yaml
version: 2 # v2 uses 2

loggers:
  list: # Logger ID
    name: ListLogger # class name or path/to/file.py:ClassName
    handler: None # Handler config, default set to default logging 
  default: 
    name: PythonLogger 
    handler: None
system: # Python/system level logging
  ".*": # reges tag to capture
  - func: identity # func name or path/to/file.py:func_name
    freq: 1 # rate to log
    uses: # which logger to use, point to the log id above
    - default 
performance:
  cpu:
  - func: identity
    freq: 1
    uses:
    - default
metric:
  ".*":
  - func: max
    freq: 1
    uses:
    - list
    capture:  # The key, property to log. Ex rtn: Operator = AddOneOperator(...), if capture is set to value, it would record rtn.capture, if tag above is set to any regex that recognizes AddOneOperator (currently set to ".*")
    - ".*"

```


Default config without any inputs
```yaml
version: 2
loggers:
  list:
    name: ListLogger
    handler: None
  default:
    name: PythonLogger
    handler: None
system:
  ".*":
  - func: identity
    freq: 1
    uses:
    - default
performance:
  cpu:
  - func: identity
    freq: 1
    uses:
    - default
metric:
  ".*":
  - func: max
    freq: 1
    uses:
    - list
    capture:
    - ".*"
```


TODO: Handlers


