### PR TITLE
[server][Pipeline] fix async future being used by continuous_batching

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -665,14 +665,12 @@ class Pipeline(Operator):
         :param inference_state: inference state for the operator
         :param next_step: dictionary key to fetch the operator from the pipeline ops.
         """
-        running_continuous_batching = False
         if (
             isinstance(self.ops[next_step], EngineOperator)
             and self._continuous_batching_scheduler
         ):
             func = self._continuous_batching_scheduler.submit
             inp = self.ops[next_step].input_schema(**inp)
-            running_continuous_batching = True
         else:
             func = self._scheduler_group.submit
 

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -665,14 +665,14 @@ class Pipeline(Operator):
         :param inference_state: inference state for the operator
         :param next_step: dictionary key to fetch the operator from the pipeline ops.
         """
-        run_cb = False
+        running_continuous_batching = False
         if (
             isinstance(self.ops[next_step], EngineOperator)
             and self._continuous_batching_scheduler
         ):
             func = self._continuous_batching_scheduler.submit
             inp = self.ops[next_step].input_schema(**inp)
-            run_cb = True
+            running_continuous_batching = True
         else:
             func = self._scheduler_group.submit
 
@@ -685,7 +685,7 @@ class Pipeline(Operator):
             **kwargs,
         )
 
-        if kwargs.get("loop") and run_cb:
+        if kwargs.get("loop") and running_continuous_batching:
             return asyncio.futures.wrap_future(future, loop=kwargs.get("loop"))
         return future
 

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -676,7 +676,7 @@ class Pipeline(Operator):
         else:
             func = self._scheduler_group.submit
 
-        future = self.run_func(
+        return self.run_func(
             func=func,
             operator=self.ops[next_step],
             inp=inp,
@@ -684,13 +684,6 @@ class Pipeline(Operator):
             inference_state=inference_state,
             **kwargs,
         )
-
-        # Wraps the future returned by continuous_batching to be an asyncio.Future
-        # we also only want to do this when we are in running async pathways in which
-        # case the kwargs will contain a loop from the subgraph executor
-        if kwargs.get("loop") and running_continuous_batching:
-            return asyncio.futures.wrap_future(future, loop=kwargs.get("loop"))
-        return future
 
 
 def text_generation_pipeline(*args, **kwargs) -> "Pipeline":

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -685,6 +685,9 @@ class Pipeline(Operator):
             **kwargs,
         )
 
+        # Wraps the future returned by continuous_batching to be an asyncio.Future
+        # we also only want to do this when we are in running async pathways in which
+        # case the kwargs will contain a loop from the subgraph executor
         if kwargs.get("loop") and running_continuous_batching:
             return asyncio.futures.wrap_future(future, loop=kwargs.get("loop"))
         return future

--- a/src/deepsparse/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/schedulers/continuous_batching_scheduler.py
@@ -112,9 +112,6 @@ class ContinuousBatchingScheduler(OperatorScheduler):
                 f"found {type(inputs)}"
             )
 
-        # asyncio.Future() is used when we run the pipeline using async/excecute
-        # operators using asyncio. Outside of the async pathway
-        # (i.e. outside of the server), we use concurrent.Future()
         future = Future()
         self._queues.add_queue_item(key=operator, item=inputs, future=future)
 

--- a/src/deepsparse/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/schedulers/continuous_batching_scheduler.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 from concurrent.futures import Future
 from threading import Lock
 from typing import List

--- a/src/deepsparse/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/schedulers/continuous_batching_scheduler.py
@@ -116,7 +116,7 @@ class ContinuousBatchingScheduler(OperatorScheduler):
         # asyncio.Future() is used when we run the pipeline using async/excecute
         # operators using asyncio. Outside of the async pathway
         # (i.e. outside of the server), we use concurrent.Future()
-        future = asyncio.Future() if kwargs.get("loop") else Future()
+        future = Future()
         self._queues.add_queue_item(key=operator, item=inputs, future=future)
 
         return future

--- a/src/deepsparse/schedulers/continuous_batching_scheduler.py
+++ b/src/deepsparse/schedulers/continuous_batching_scheduler.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import asyncio
 from concurrent.futures import Future
 from threading import Lock
 from typing import List
@@ -114,6 +114,11 @@ class ContinuousBatchingScheduler(OperatorScheduler):
 
         future = Future()
         self._queues.add_queue_item(key=operator, item=inputs, future=future)
+        # Wraps the future to be an asyncio.Future
+        # we also only want to do this when we are in running async pathways in which
+        # case the kwargs will contain a loop from the subgraph executor
+        if kwargs.get("loop"):
+            future = asyncio.futures.wrap_future(future, loop=kwargs.get("loop"))
 
         return future
 


### PR DESCRIPTION
# Summary
- This fixes the `Future` being used by the `continuous_batching_scheduler` in async pathways (i.e the server) 
- Last PR to update the future to be an asyncio.Future in the `continuous_batching_scheduler` had the right idea but just applied in the incorrect spot
- Provides > 3x speedup in tokens/second processed for this ticket: https://app.asana.com/0/1205229323407165/1206353069568391/f


Inspiration: https://github.com/python/cpython/blob/b331381485c1965d1c88b7aee7ae9604aca05758/Lib/asyncio/base_events.py#L871

# Testing

## Server (using async pathway)
```yaml
num_workers: 1
endpoints:
  - task: text_generation
    model: "hf:neuralmagic/MiniChat-1.5-3B-pruned50-quant-ds"
    kwargs:
      {"continuous_batch_sizes": [2,3,4,5,6,7,8,16], "force_max_tokens": True}

```
Client
```python

import requests
from threading import Thread
import time, argparse

import argparse

parser = argparse.ArgumentParser(description='Process some integers.')
parser.add_argument('--num-threads', type=int, default=1)
parser.add_argument('--num-tokens', type=int, default=25)

_STREAM = False
_PRINT = False

def main(num_threads=1, num_tokens=25):
    url = "http://localhost:5543/v2/models/text_generation-0/infer"


    def run(idx, prompt="Mario jumped"):
        print(f"launching thread {idx}")
        
        num_return_sequences = 1
        start = time.perf_counter()
        obj = {
            "prompt": prompt,
            "generation_kwargs": {
                "max_length": num_tokens
            },
            "num_return_sequences": num_return_sequences
        }

        response = requests.post(url, json=obj)

        if _STREAM:
            for c in completion:
                print(c)
        else:
            if _PRINT:
                print(response._content)

        end = time.perf_counter()
        print(f"finished thread {idx} : {(num_tokens * num_threads * num_return_sequences) / (end - start): 0.5f}")

    ts = [Thread(target=run, args=[idx, "Mario jumped"]) for idx in range(num_threads)]

    for t in ts:
        t.start()
    for t in ts:
        t.join()

if __name__ == "__main__":
    args = parser.parse_args()
    main(num_threads=args.num_threads, num_tokens=args.num_tokens)


```

Server Numbers:

Threads | max_tokens | tokens/second
|-- | -- | --|
| 4 | 500 | 100 tokens/second |
| 8 | 500 |  155 tokens/second |
| 16 | 500 |  210 tokens/second | 


## Default `pipeline.run(...)`/non-async pathway

```python
from deepsparse import Pipeline
from threading import Thread
import time, argparse

import argparse

parser = argparse.ArgumentParser(description='Process some integers.')
parser.add_argument('--num-threads', type=int, default=1)
parser.add_argument('--num-tokens', type=int, default=25)

_STREAM = False
_PRINT = False

def main(num_threads=1, num_tokens=25):

    pipeline = Pipeline.create(
        task="text_generation",
        model_path="hf:neuralmagic/MiniChat-1.5-3B-pruned50-quant-ds",
        continuous_batch_sizes=[2,3,4,5,6,7,8,16],
        force_max_tokens=True
    )

    def run(idx, prompt="Mario jumped"):
        print(f"launching thread {idx}")
        
        num_return_sequences = 1
        start = time.perf_counter()
        completion = pipeline(
            prompt=prompt,
            max_length=num_tokens,
            num_return_sequences=num_return_sequences
        )

        if _STREAM:
            for c in completion:
                print(c)
        else:
            if _PRINT:
                print(completion)

        end = time.perf_counter()
        print(f"finished thread {idx} : {(num_tokens * num_threads * num_return_sequences) / (end - start): 0.5f}")

    ts = [Thread(target=run, args=[idx, "Mario jumped"]) for idx in range(num_threads)]

    for t in ts:
        t.start()
    for t in ts:
        t.join()

if __name__ == "__main__":
    args = parser.parse_args()
    main(num_threads=args.num_threads, num_tokens=args.num_tokens)

```

Non-async Numbers:

Threads | max_tokens | tokens/second
|-- | -- | --|
| 4 | 500 | 97 tokens/second |
| 8 | 500 |  148 tokens/second |
| 16 | 500 |  207 tokens/second | 