### PR TITLE
[V2 Logger]  utils for import

### DIFF
--- a/src/deepsparse/loggers_v2/utils.py
+++ b/src/deepsparse/loggers_v2/utils.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+
+def import_from_registry(name: str):
+    registry = "src.deepsparse.loggers_v2.registry.__init__"
+    module = importlib.import_module(registry)
+    try:
+        return getattr(module, name)
+    except Exception:
+        raise ValueError(f"Cannot import class/func with name '{name}' from {registry}")
+
+
+def import_from_path(path: str):
+    path, class_name = path.split(":")
+    path = path.split(".py")[0]
+
+    _path = path
+    path = path.replace(r"/", ".")
+    try:
+        module = importlib.import_module(path)
+    except Exception:
+        raise ValueError(f"Cannot find module with path {_path}")
+
+    try:
+        return getattr(module, class_name)
+    except Exception:
+        raise ValueError(f"Cannot find {class_name} in {_path}")

--- a/tests/deepsparse/loggers_v2/test_util.py
+++ b/tests/deepsparse/loggers_v2/test_util.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from deepsparse.loggers_v2.utils import (
+    LOGGER_REGISTRY,
+    import_from_path,
+    import_from_registry,
+)
+
+
+@pytest.mark.parametrize(
+    "name, is_successful",
+    [
+        ("PythonLogger", True),
+        ("max", True),
+        ("blah", False),
+    ],
+)
+def test_import_from_registry(name, is_successful):
+    if is_successful:
+        assert import_from_registry(name) is not None
+    else:
+        with pytest.raises(AttributeError):
+            import_from_registry(name)
+
+
+@pytest.mark.parametrize(
+    "path, is_successful",
+    [
+        (f"{LOGGER_REGISTRY}.py:PythonLogger", True),
+        (f"{LOGGER_REGISTRY}:PythonLogger", True),
+        ("foo/bar:blah", False),
+        (f"{LOGGER_REGISTRY}:blah", False),
+    ],
+)
+def test_import_from_path(path, is_successful):
+    if is_successful:
+        assert import_from_path(path) is not None
+    else:
+        with pytest.raises((AttributeError, ImportError)):
+            import_from_path(path)


### PR DESCRIPTION
<img width="1127" alt="Screenshot 2024-01-17 at 1 52 53 PM" src="https://github.com/neuralmagic/deepsparse/assets/28371594/d356d08f-a737-479a-b36a-d0c686016921">

# Description
Given config.yaml, the contents may contain default function or class name (eg. max, everage, PythonLogger,...). The PR has utils to import

