### PR TITLE
[V2 Logger] root logger

### DIFF
--- a/src/deepsparse/loggers_v2/root_logger.py
+++ b/src/deepsparse/loggers_v2/root_logger.py
@@ -15,7 +15,7 @@
 
 from collections import defaultdict
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from deepsparse.loggers_v2.filters.frequency_filter import FrequencyFilter
 from deepsparse.loggers_v2.filters.pattern import (
@@ -37,7 +37,8 @@ class RootLogger(FrequencyFilter):
     Child class for SystemLogger, PerformanceLogger, MetricLogger
     All class instantitated with RootLogger will have its own FrequencyFilter
 
-    :param config: config with respect to the log_type (LoggerConfig().dict().get(log_type))
+    :param config: config with respect to the
+     log_type (LoggerConfig().dict().get(log_type))
     :param leaf_logger: leaf logger singleton shared among other RootLogger
 
     """
@@ -79,7 +80,7 @@ class RootLogger(FrequencyFilter):
                     leaf_loggers.append(self.leaf_logger[logger_id])
 
                 self.run_args[tag][func][func_arg.get("freq", 1)].append(
-                    (leaf_loggers, func_arg.get("capture"))
+                    (leaf_loggers, func_arg.get("capture", []))
                 )
 
     def log(
@@ -95,8 +96,8 @@ class RootLogger(FrequencyFilter):
         Send args to the leaf loggers if the given tag, func, freq are accpeted. Need to
          pass three filters to be accepted.
 
-         1. The provided tag must be a subset or regex match with the tags in the
-            root logger config file
+         1. Tag filter: the provided tag must be a subset or regex match with the tags
+            in theroot logger config file
          2. The number of calls to the current self.log(...) must be a multiple of
             freq from the config file wrt tag and func
          3. If capture is speficied in the config file (only for metric log), it must be
@@ -108,72 +109,159 @@ class RootLogger(FrequencyFilter):
         :param value: Any value to log, may be dimentionally reduced by func
         :param log_type: String representing the root logger level
         :param tag: Candidate id that will be used to filter out only the wanted log
-        :param capture: The property or dict key to record if match exists. If set to None
-            no capture filter will be applied even if set in config
+        :param capture: The property or dict key to record if match exists.
+            If set to None no capture filter will be applied even if set in config
 
         """
         for tag_from_config, tag_run_args in self.run_args.items():
-            if is_match_found(tag_from_config, tag):
+            self._execute_on_match_filter(
+                tag=tag,
+                value=value,
+                log_type=log_type,
+                capture=capture,
+                tag_from_config=tag_from_config,
+                tag_run_args=tag_run_args,
+                *args,
+                **kwargs,
+            )
 
-                # key: func_name, value: {freq: {...}}
-                for func_from_config, func_execute_args in tag_run_args.items():
+    def _execute_on_match_filter(
+        self, tag: str, tag_from_config: str, tag_run_args: defaultdict, *args, **kwargs
+    ):
+        if is_match_found(tag_from_config, tag):
 
-                    # key: freq, value = [ ([loggers], [capture]), ... ]
-                    for freq_from_config, execute_args in func_execute_args.items():
+            # key: func_name, value: {freq: {...}}
+            for func_from_config, func_execute_args in tag_run_args.items():
+                self._unwrap_execute_args(
+                    tag_from_config=tag_from_config,
+                    func_from_config=func_from_config,
+                    func_execute_args=func_execute_args,
+                    tag=tag,
+                    *args,
+                    **kwargs,
+                )
 
-                        # increment the counter
-                        self.inc(tag_from_config, func_from_config)
+    def _unwrap_execute_args(
+        self,
+        func_execute_args: defaultdict,
+        tag_from_config: str,
+        func_from_config: str,
+        *args,
+        **kwargs,
+    ):
+        """
+        Increment the counter with respect to the matching tag and func from the
+         config file, and then unwrap func_execute_args.
 
-                        # execute_arg = ([loggers], [capture])
-                        for execute_arg in execute_args:
+        Args:
+        :param func_execute_args: defaultdict with frequency as key and tuple of
+         list loggers and list capture. Capture is set to None for non-metric log_type
 
-                            leaf_loggers, captures_from_config = execute_arg
+        func_execute_args =
+            func: {
+                freq: [
+                    ([loggers], [capture]),
+                    ([loggers2], [capture2]),
+                    ...
+                ]
+            },
+        :param tag_from_config: Tag from the config file
+        :param func_from_config: Func from the config file
 
-                            # check if the given tag.func is a multiple of the counter
-                            if self.should_execute_on_frequency(
-                                tag_from_config, func_from_config, freq_from_config
-                            ):
-                                # Capture filter (filter by class prop or dict key)
-                                if capture is None:
-                                    self._apply_func_and_log(
-                                        value=value,
-                                        tag=tag,
-                                        log_type=log_type,
-                                        func_from_config=func_from_config,
-                                        leaf_loggers=leaf_loggers,
-                                        *args,
-                                        **kwargs,
-                                    )
+        """
 
-                                else:
-                                    for capture_from_config in captures_from_config:
-                                        if is_match_found(capture_from_config, capture):
-                                            for (
-                                                captured,
-                                                value,
-                                            ) in unravel_value_as_generator(value):
+        # increment the counter before interating over each frequency
+        self.inc(tag_from_config, func_from_config)
 
-                                                self._apply_func_and_log(
-                                                    value=value,
-                                                    tag=tag,
-                                                    log_type=log_type,
-                                                    func_from_config=func_from_config,
-                                                    leaf_loggers=leaf_loggers,
-                                                    capture=captured,
-                                                    *args,
-                                                    **kwargs,
-                                                )
+        # key: freq, value = [ ([loggers], [capture]), ... ]
+        for freq_from_config, execute_args in func_execute_args.items():
+
+            # execute_arg = ([loggers], [capture])
+            for execute_arg in execute_args:
+
+                leaf_loggers, captures_from_config = execute_arg
+                self._execute_on_frequency_fitler(
+                    tag_from_config=tag_from_config,
+                    leaf_loggers=leaf_loggers,
+                    captures_from_config=captures_from_config,
+                    freq_from_config=freq_from_config,
+                    func_from_config=func_from_config,
+                    *args,
+                    **kwargs,
+                )
+
+    def _execute_on_frequency_fitler(
+        self,
+        tag_from_config: str,
+        func_from_config: str,
+        freq_from_config: int,
+        captures_from_config: List[str],
+        capture: str,
+        value: Any,
+        *args,
+        **kwargs,
+    ):
+        """
+        Proceed if
+         1. Frequency filter is satisifed
+         2. Capture filter is satisfied, if capture was  given as
+            input arg to .log.
+
+        :param tag_from_config: Tag from the config file
+        :param func_from_config: Func from the config file
+        :param freq_from_config: Freq from the config file
+        :param captures_from_config: Capture from the config file
+        :param capture: Input arg to .log, capture any matching attr/dict key
+         based on capture_from_config
+        :param value: Any value to log
+        """
+
+        # check if the given tag.func is a multiple of the counter
+        if self.should_execute_on_frequency(
+            tag_from_config, func_from_config, freq_from_config
+        ):
+            # Capture filter (filter by class prop or dict key)
+            if capture is None:
+                self._apply_func_and_log(
+                    value=value,
+                    func_from_config=func_from_config,
+                    *args,
+                    **kwargs,
+                )
+
+            else:
+                for capture_from_config in captures_from_config:
+                    if is_match_found(capture_from_config, capture):
+                        for (
+                            captured,
+                            value,
+                        ) in unravel_value_as_generator(value):
+
+                            self._apply_func_and_log(
+                                value=value,
+                                func_from_config=func_from_config,
+                                capture=captured,
+                                *args,
+                                **kwargs,
+                            )
 
     def _apply_func_and_log(
         self,
         value: Any,
-        log_type: str,
-        tag: str,
         func_from_config: str,
         leaf_loggers: list,
         *args,
         **kwargs,
     ):
+        """
+        Call the root loggers after applying func to the
+        value
+
+        :param value: Designated value to log
+        :param func_from_config: Func to use to reduce dimensionality
+         from the config file
+        :param leaf_loggers: Loggers to use from the config gile
+        """
         if func_from_config is not None:
             func_callable = import_from_registry(func_from_config)
             value = func_callable(value)
@@ -181,9 +269,7 @@ class RootLogger(FrequencyFilter):
         for leaf_logger in leaf_loggers:
             leaf_logger.log(
                 value=value,
-                tag=tag,
                 func=func_from_config,
-                log_type=log_type,
                 *args,
                 **kwargs,
             )
@@ -219,9 +305,6 @@ class MetricLogger(RootLogger):
     """
 
     LOG_TYPE = "metric"
-
-    def __init__(self, config: Dict, leaf_logger):
-        super().__init__(config, leaf_logger)
 
     def log(self, *args, **kwargs):
         super().log(log_type=self.LOG_TYPE, *args, **kwargs)

--- a/src/deepsparse/loggers_v2/root_logger.py
+++ b/src/deepsparse/loggers_v2/root_logger.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from collections import defaultdict
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from deepsparse.loggers_v2.filters.frequency_filter import FrequencyFilter
+from deepsparse.loggers_v2.filters.pattern import is_match_found
+
+from .utils import import_from_registry
+
+
+class LogType(Enum):
+    SYSTEM = "SYSTEM"
+    PERFORMANCE = "PERFORMANCE"
+    METRIC = "METRIC"
+
+
+class RootLogger(FrequencyFilter):
+    def __init__(self, config: Dict, leaf_logger):
+        super().__init__()
+        self.config = config
+        self.leaf_logger = leaf_logger
+        self.logger = defaultdict(list)  # tag as key
+        self.func = {}  # func name: callable
+        self.tag = set()
+        self.create()
+
+    def create(self):
+        """
+        Instantiate the loggers as singleton and
+            import the class/func from registry
+        """
+        for tag, func_args in self.config.items():
+            for func_arg in func_args:
+                func = func_arg.get("func")
+                self.func[func] = import_from_registry(func)
+                super().add_template_to_frequency(
+                    tag=tag, func=func, rate=func_arg.get("freq", 1)
+                )
+                for logger_id in func_arg.get("uses", []):
+                    self.logger[tag].append(self.leaf_logger[logger_id])
+
+    def log(
+        self, value: Any, log_type: str, tag: Optional[str] = None, *args, **kwargs
+    ):
+        """
+        Send args to its appropriate logger if the given tag is valid
+        """
+        for pattern, loggers in self.logger.items():
+            if is_match_found(pattern, tag):
+                for func_name, func_callable in self.func.items():
+                    if super().should_execute_on_frequency(
+                        tag=tag, log_type=log_type, func=func_name
+                    ):
+                        value = func_callable(value)
+                        for logger in loggers:
+                            logger.log(
+                                value=value,
+                                tag=tag,
+                                func=func_name,
+                                log_type=log_type,
+                                *args,
+                                **kwargs,
+                            )
+
+
+class SystemLogger(RootLogger):
+    """
+    Create Python level logging with handles
+    """
+
+    LOG_TYPE = "system"
+
+    def log(self, *args, **kwargs):
+        super().log(log_type=self.LOG_TYPE, *args, **kwargs)
+
+
+class PerformanceLogger(RootLogger):
+    """
+    Create performance level (in-line pipeline)
+        logging with handles
+    """
+
+    LOG_TYPE = "performance"
+
+    def log(self, *args, **kwargs):
+        super().log(log_type=self.LOG_TYPE, *args, **kwargs)
+
+
+class MetricLogger(RootLogger):
+    """
+    Create metric level (logged in LoggerMiddleware)
+        logging with handles
+    """
+
+    LOG_TYPE = "metric"
+
+    def __init__(self, config: Dict, leaf_logger):
+        self.capture = set()
+        super().__init__(config, leaf_logger)
+
+    def create(self):
+        super().create()
+        for func_args in self.config.values():
+            for func_arg in func_args:
+                for capture in func_arg["capture"]:
+                    self.capture.add(capture)
+
+    def log(self, capture: str, *args, **kwargs):
+        for pattern in self.capture:
+            if is_match_found(pattern, capture):
+                super().log(log_type=self.LOG_TYPE, capture=capture, *args, **kwargs)

--- a/src/deepsparse/loggers_v2/root_logger.py
+++ b/src/deepsparse/loggers_v2/root_logger.py
@@ -34,8 +34,8 @@ class RootLogger(FrequencyFilter):
         super().__init__()
         self.config = config
         self.leaf_logger = leaf_logger
-        self.logger = defaultdict(list)  # tag as key
-        self.func = {}  # func name: callable
+        self.logger = defaultdict(list)  # tag as key, store list of loggers
+        self.func = defaultdict(list)  # tag as key, store list of func
         self.tag = set()
         self.create()
 
@@ -47,7 +47,8 @@ class RootLogger(FrequencyFilter):
         for tag, func_args in self.config.items():
             for func_arg in func_args:
                 func = func_arg.get("func")
-                self.func[func] = import_from_registry(func)
+                self.func[tag].append((func, import_from_registry(func)))
+
                 super().add_template_to_frequency(
                     tag=tag, func=func, rate=func_arg.get("freq", 1)
                 )
@@ -62,7 +63,7 @@ class RootLogger(FrequencyFilter):
         """
         for pattern, loggers in self.logger.items():
             if is_match_found(pattern, tag):
-                for func_name, func_callable in self.func.items():
+                for func_name, func_callable in self.func[pattern]:
                     if super().should_execute_on_frequency(
                         tag=tag, log_type=log_type, func=func_name
                     ):

--- a/tests/logger_v2/test_root_logger.py
+++ b/tests/logger_v2/test_root_logger.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import Mock
+
+from deepsparse.loggers_v2.root_logger import RootLogger
+
+
+class TestRootLogger(unittest.TestCase):
+    def test_log_method(self):
+
+        mock_leaf_1 = Mock()
+        mock_leaf_1.log = Mock()
+
+        mock_leaf_2 = Mock()
+        mock_leaf_2.log = Mock()
+
+        mock_leaf_logger = {
+            "logger_id_1": mock_leaf_1,
+            "logger_id_2": mock_leaf_2,
+        }
+
+        mock_config = {
+            "tag1": [{"func": "identity", "freq": 2, "uses": ["logger_id_1"]}],
+            "tag2": [
+                {"func": "identity", "freq": 3, "uses": ["logger_id_2", "logger_id_1"]}
+            ],
+        }
+
+        root_logger = RootLogger(mock_config, mock_leaf_logger)
+
+        root_logger.log("log_value", "log_type", "tag1")
+        assert mock_leaf_1.log.call_count == 0
+
+        root_logger.log("log_value", "log_type", "tag1")
+        assert mock_leaf_1.log.call_count == 1
+
+        mock_leaf_logger["logger_id_1"].log.assert_called_with(
+            value="log_value",
+            tag="tag1",
+            func="identity",
+            log_type="log_type",
+        )
+
+        root_logger.log("log_value", "log_type", "tag2")
+        root_logger.log("log_value", "log_type", "tag2")
+        assert mock_leaf_2.log.call_count == 0
+
+        root_logger.log("log_value", "log_type", "tag2")
+        assert mock_leaf_2.log.call_count == 1
+        assert mock_leaf_1.log.call_count == 2
+
+        mock_leaf_logger["logger_id_1"].log.assert_called_with(
+            value="log_value",
+            tag="tag2",
+            func="identity",
+            log_type="log_type",
+        )
+
+        mock_leaf_logger["logger_id_2"].log.assert_called_with(
+            value="log_value",
+            tag="tag2",
+            func="identity",
+            log_type="log_type",
+        )

--- a/tests/logger_v2/test_root_logger.py
+++ b/tests/logger_v2/test_root_logger.py
@@ -12,66 +12,65 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+
 from unittest.mock import Mock
 
 from deepsparse.loggers_v2.root_logger import RootLogger
 
 
-class TestRootLogger(unittest.TestCase):
-    def test_log_method(self):
+def test_log_method():
 
-        mock_leaf_1 = Mock()
-        mock_leaf_1.log = Mock()
+    mock_leaf_1 = Mock()
+    mock_leaf_1.log = Mock()
 
-        mock_leaf_2 = Mock()
-        mock_leaf_2.log = Mock()
+    mock_leaf_2 = Mock()
+    mock_leaf_2.log = Mock()
 
-        mock_leaf_logger = {
-            "logger_id_1": mock_leaf_1,
-            "logger_id_2": mock_leaf_2,
-        }
+    mock_leaf_logger = {
+        "logger_id_1": mock_leaf_1,
+        "logger_id_2": mock_leaf_2,
+    }
 
-        mock_config = {
-            "tag1": [{"func": "identity", "freq": 2, "uses": ["logger_id_1"]}],
-            "tag2": [
-                {"func": "identity", "freq": 3, "uses": ["logger_id_2", "logger_id_1"]}
-            ],
-        }
+    mock_config = {
+        "tag1": [{"func": "identity", "freq": 2, "uses": ["logger_id_1"]}],
+        "tag2": [
+            {"func": "identity", "freq": 3, "uses": ["logger_id_2", "logger_id_1"]}
+        ],
+    }
 
-        root_logger = RootLogger(mock_config, mock_leaf_logger)
+    root_logger = RootLogger(mock_config, mock_leaf_logger)
 
-        root_logger.log("log_value", "log_type", "tag1")
-        assert mock_leaf_1.log.call_count == 0
+    root_logger.log("log_value", "log_type", "tag1")
+    assert mock_leaf_1.log.call_count == 0
 
-        root_logger.log("log_value", "log_type", "tag1")
-        assert mock_leaf_1.log.call_count == 1
+    root_logger.log("log_value", "log_type", "tag1")
+    assert mock_leaf_1.log.call_count == 1
 
-        mock_leaf_logger["logger_id_1"].log.assert_called_with(
-            value="log_value",
-            tag="tag1",
-            func="identity",
-            log_type="log_type",
-        )
+    mock_leaf_logger["logger_id_1"].log.assert_called_with(
+        value="log_value",
+        tag="tag1",
+        func="identity",
+        log_type="log_type",
+    )
 
-        root_logger.log("log_value", "log_type", "tag2")
-        root_logger.log("log_value", "log_type", "tag2")
-        assert mock_leaf_2.log.call_count == 0
+    root_logger.log("log_value", "log_type", "tag2")
+    root_logger.log("log_value", "log_type", "tag2")
+    assert mock_leaf_2.log.call_count == 0
 
-        root_logger.log("log_value", "log_type", "tag2")
-        assert mock_leaf_2.log.call_count == 1
-        assert mock_leaf_1.log.call_count == 2
+    root_logger.log("log_value", "log_type", "tag2")
+    assert mock_leaf_2.log.call_count == 1
+    assert mock_leaf_1.log.call_count == 2
 
-        mock_leaf_logger["logger_id_1"].log.assert_called_with(
-            value="log_value",
-            tag="tag2",
-            func="identity",
-            log_type="log_type",
-        )
+    mock_leaf_logger["logger_id_1"].log.assert_called_with(
+        value="log_value",
+        tag="tag2",
+        func="identity",
+        log_type="log_type",
+    )
 
-        mock_leaf_logger["logger_id_2"].log.assert_called_with(
-            value="log_value",
-            tag="tag2",
-            func="identity",
-            log_type="log_type",
-        )
+    mock_leaf_logger["logger_id_2"].log.assert_called_with(
+        value="log_value",
+        tag="tag2",
+        func="identity",
+        log_type="log_type",
+    )


### PR DESCRIPTION
<img width="1356" alt="Screenshot 2024-01-18 at 11 31 23 AM" src="https://github.com/neuralmagic/deepsparse/assets/28371594/4a437d93-02ed-488d-bc6b-1d9b204b077b">

Three types of root loggers: system, performance and metric. All root loggers have shared leaf loggers (bc they are singleton). Each root loggers have their own FrequencyFilter. Calling `.log(...)` will call leaf loggers after the filtering rules passes. 