### PR TITLE
[Bug] Fix import bug with numpy_log_softmax

### DIFF
--- a/src/deepsparse/utils/data.py
+++ b/src/deepsparse/utils/data.py
@@ -28,6 +28,7 @@ __all__ = [
     "split_engine_inputs",
     "join_engine_outputs",
     "prep_for_serialization",
+    "numpy_log_softmax",
 ]
 
 from pydantic import BaseModel


### PR DESCRIPTION
This PR fixes a bug with the recently added `numpy_log_softmax` function,
which was causing import errors

Before this PR:
```
In [1]: from deepsparse.utils import numpy_log_softmax                                                                            
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-056db553cbcd> in <module>
----> 1 from deepsparse.utils import numpy_log_softmax

ImportError: cannot import name 'numpy_log_softmax' from 'deepsparse.utils' (/home/rahul/projects/deepsparse/src/deepsparse/utils/__init__.py)
```

After this PR:
```
In [1]: from deepsparse.utils import numpy_log_softmax                                                                               

In [2]:  
```