### PR TITLE
[server] Disable the elastic scheduler when continuous batching is enabled

### DIFF
--- a/src/deepsparse/server/openai_server.py
+++ b/src/deepsparse/server/openai_server.py
@@ -375,7 +375,19 @@ class OpenAIServer(Server):
                 f"{SupportedTasks.code_generation._fields}"
             )
 
-        pipeline = Pipeline.from_config(pipeline_config, context=self.context)
+        if pipeline_config.kwargs.get("continuous_batch_sizes"):
+            _LOGGER.info(
+                "for continuous batching, the single stream scheduler will be enabled."
+            )
+            pipeline_config.num_cores = self.server_config.num_cores
+            pipeline_config.scheduler = "single"
+
+            pipeline = Pipeline.from_config(
+                pipeline_config,
+                num_streams=self.server_config.num_workers,
+            )
+        else:
+            pipeline = Pipeline.from_config(pipeline_config, context=self.context)
 
         if not self.model_to_pipeline.get(endpoint_config.model):
             model_card = ModelCard(

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -75,9 +75,11 @@ class Server:
             self.server_config = server_config
 
         _LOGGER.info(f"Using config: {repr(self.server_config)}")
-
-        self.context = None
         self.server_logger = server_logger_from_config(self.server_config)
+        self.context = Context(
+            num_cores=self.server_config.num_cores,
+            num_streams=self.server_config.num_workers,
+        )
 
     def start_server(
         self,
@@ -106,11 +108,6 @@ class Server:
             _ = start_config_watcher(
                 self.config_path, f"http://{host}:{port}/endpoints", 0.5
             )
-
-        self.context = Context(
-            num_cores=self.server_config.num_cores,
-            num_streams=self.server_config.num_workers,
-        )
 
         app = self._build_app()
 

--- a/src/deepsparse/server/server.py
+++ b/src/deepsparse/server/server.py
@@ -16,7 +16,6 @@ import logging
 import os
 from abc import abstractmethod
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from typing import AsyncGenerator, List, Optional, Union
 
@@ -78,7 +77,6 @@ class Server:
         _LOGGER.info(f"Using config: {repr(self.server_config)}")
 
         self.context = None
-        self.executor = None
         self.server_logger = server_logger_from_config(self.server_config)
 
     def start_server(
@@ -113,7 +111,6 @@ class Server:
             num_cores=self.server_config.num_cores,
             num_streams=self.server_config.num_workers,
         )
-        self.executor = ThreadPoolExecutor(max_workers=self.context.num_streams)
 
         app = self._build_app()
 


### PR DESCRIPTION
# Summary:
- For this ticket: https://app.asana.com/0/1205229323407165/1206269382450968/f
- Previously, the server always initialized a `Context` object as all pipelines used the `MultiModelEngine` which requires a `Context` input. `Context` always uses the `elastic` scheduler
- With this PR, for the case where `continuous_batch_sizes` are provided, a `Context` object is not used during pipeline initialization and a single stream scheduler is selected. 
- This  prevents us from using the `MultiModelEngine` for this case but any other pipeline initialized without `continuous_batch_sizes` will use `Context/MultiModelEngine` 