### PR TITLE
Better legacy failure warning

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -140,8 +140,7 @@ class Pipeline(Operator):
                     "provided task should be registered using the OperatorRegistry"
                 )
         except Exception as e:
-            _LOGGER.warning(f"Could not create v2 '{task}' pipeline, with error: {e}")
-            _LOGGER.warning(f"Attempting to create the legacy pipeline")
+            _LOGGER.warning(f"Could not create v2 '{task}' pipeline, attempting to create the legacy pipeline. Reason: {e}")
             from deepsparse.legacy import Pipeline
 
             pipeline = Pipeline.create(task=task, **kwargs)

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -139,8 +139,9 @@ class Pipeline(Operator):
                     "Pipeline was not created for the given task. The "
                     "provided task should be registered using the OperatorRegistry"
                 )
-        except Exception:
-            _LOGGER.warning(f"Could not create v2 '{task}' pipeline, trying legacy")
+        except Exception as e:
+            _LOGGER.warning(f"Could not create v2 '{task}' pipeline, with error: {e}")
+            _LOGGER.warning(f"Attempting to create the legacy pipeline")
             from deepsparse.legacy import Pipeline
 
             pipeline = Pipeline.create(task=task, **kwargs)


### PR DESCRIPTION
In case someone fails to create the V2 pipeline, I think it's helpful to print the error.