### PR TITLE
[BugFix] Add analyze callable

### DIFF
--- a/src/deepsparse/__init__.py
+++ b/src/deepsparse/__init__.py
@@ -38,5 +38,6 @@ from .loggers import *
 from .version import __version__, is_release
 from .analytics import deepsparse_analytics as _analytics
 from .subgraph_execute import *
+from .analyze import analyze
 
 _analytics.send_event("python__init")

--- a/src/deepsparse/analyze.py
+++ b/src/deepsparse/analyze.py
@@ -31,7 +31,11 @@ from sparsezoo.analyze import (
     ModelAnalysis,
     NodeInferenceResult,
 )
-from sparsezoo.analyze.cli import analyze_options, analyze_performance_options
+from sparsezoo.analyze.cli import (
+    DEEPSPARSE_ENGINE,
+    analyze_options,
+    analyze_performance_options,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,21 +78,11 @@ def main(
             )
 
     _LOGGER.info("Starting Analysis ...")
-    analysis = ModelAnalysis.create(model_path)
-    _LOGGER.info("Analysis complete, collating results...")
-    scenario = BenchmarkScenario(
-        batch_size=batch_size_throughput,
-        num_cores=None,
-        engine=benchmark_engine,
-    )
-    performance_summary = run_benchmark_and_analysis(
-        onnx_model=model_to_path(model_path),
-        scenario=scenario,
-    )
+    analysis = analyze(model_path, batch_size_throughput, benchmark_engine)
+
     by_types: bool = convert_to_bool(by_types)
     by_layers: bool = convert_to_bool(by_layers)
 
-    analysis.benchmark_results = [performance_summary]
     summary = analysis.summary(
         by_types=by_types,
         by_layers=by_layers,
@@ -103,13 +97,9 @@ def main(
 
         print("Comparison Analysis:")
         for model_to_compare in compare:
-            compare_model_analysis = ModelAnalysis.create(model_to_compare)
-            _LOGGER.info(f"Running Performance Analysis on {model_to_compare}")
-            performance_summary = run_benchmark_and_analysis(
-                onnx_model=model_to_path(model_to_compare),
-                scenario=scenario,
+            compare_model_analysis = analyze(
+                model_to_compare, batch_size_throughput, benchmark_engine
             )
-            compare_model_analysis.benchmark_results = [performance_summary]
             summary_comparison_model = compare_model_analysis.summary(
                 by_types=by_types,
                 by_layers=by_layers,
@@ -122,6 +112,34 @@ def main(
     if save:
         _LOGGER.info(f"Writing results to {save}")
         analysis.yaml(file_path=save)
+
+
+def analyze(
+    model_path,
+    batch_size_throughput: int = 1,
+    benchmark_engine: str = DEEPSPARSE_ENGINE,
+) -> ModelAnalysis:
+    """
+    :param model_path: Local filepath to an ONNX model, or a SparseZoo stub
+    :param batch_size_throughput: Batch size for throughput benchmark
+    :param benchmark_engine: Benchmark engine to use, can be 'deepsparse' or
+        'onnxruntime', defaults to 'deepsparse'
+    :return: A `ModelAnalysis` object encapsulating the results of the analysis
+    """
+    analysis = ModelAnalysis.create(model_path)
+    _LOGGER.info("Analysis complete, collating results...")
+    scenario = BenchmarkScenario(
+        batch_size=batch_size_throughput,
+        num_cores=None,
+        engine=benchmark_engine,
+    )
+    performance_summary = run_benchmark_and_analysis(
+        onnx_model=model_to_path(model_path),
+        scenario=scenario,
+    )
+
+    analysis.benchmark_results = [performance_summary]
+    return analysis
 
 
 def run_benchmark_and_analysis(


### PR DESCRIPTION
Add missing analyze function and top level callable

```python
from deepsparse import analyze

analysis = analyze("zoo:mobilenet_v1-1.0-imagenette-base")
analysis.summary().pretty_print()
```

Output:
```bash
$ python local/descriptions/analyze_bug.py                                                                   (add-analyze-callable|✚2…3⚑1)
2024-02-02 05:08:18 deepsparse.analyze INFO     Analysis complete, collating results...
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20240104 COMMUNITY | (86c38139) (release) (optimized) (system=avx512, binary=avx512)
Node Timings for Benchmark # 1:
 NODE_NAME                      AVG_RUNTIME                    
 Conv_55                        0.02                           
 Conv_60                        0.04                           
 Conv_65                        0.01                           
 Conv_70                        0.08                           
 Conv_75                        0.01                           
 Conv_80                        0.08                           
 Conv_85                        0.01                           
 Conv_90                        0.08                           
 Conv_95                        0.01                           
 Conv_100                       0.08                           
 Conv_105                       0.01                           
 Conv_110                       0.08                           
 Conv_115                       0.01                           
 Conv_120                       0.05                           
 Conv_125                       0.01                           
 Conv_130                       0.10                           
 AveragePool_137                0.00                           
 Gemm_144                       0.01                           
 Softmax_145                    0.00                           

Params:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 zoo:mobilenet_v1-1.0-          0.00                           0.00                           3195338                        102250816                      
 imagenette-base                                                                                                                                            

Ops:
 MODEL                          SPARSITY                       QUANTIZED                      COUNT                          SIZE                           
 zoo:mobilenet_v1-1.0-          0.00                           0.00                           3195402                        102252864                      
 imagenette-base                                                                                                                                            

Overall:
 MODEL                          LATENCY                        THROUGHPUT                     SUPPORTED_GRAPH                SPARSITY                       QUANTIZED                      
 zoo:mobilenet_v1-1.0-          1.28                           781.43                         1.00                           0.00                           0.00                           
 imagenette-base                                                                                                                                                                           
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206486980083091