### PR TITLE
[BugFix] Add evaluate callable

### DIFF
--- a/src/deepsparse/__init__.py
+++ b/src/deepsparse/__init__.py
@@ -38,5 +38,6 @@ from .loggers import *
 from .version import __version__, is_release
 from .analytics import deepsparse_analytics as _analytics
 from .subgraph_execute import *
+from .evaluation.evaluator import evaluate
 
 _analytics.send_event("python__init")


### PR DESCRIPTION
This PR adds evaluate to deepsparse init such that it can be imported directly from deepsparse

```python
from deepsparse import evaluate
```