### PR TITLE
[Fix] ONNX model benchmarking when no sequence_length inferred from the model

### DIFF
--- a/src/deepsparse/benchmark/benchmark_model.py
+++ b/src/deepsparse/benchmark/benchmark_model.py
@@ -411,6 +411,11 @@ def benchmark_model(
         if not disable_kv_cache_overrides:
             if not sequence_length:
                 sequence_length = infer_sequence_length(model_path)
+                if not sequence_length:
+                    raise ValueError(
+                        "Unable to infer sequence length from model. "
+                        "Specify it manually through `sequence_length` argument."
+                    )
             if input_ids_length > sequence_length:
                 raise ValueError(
                     f"input_ids_length: {input_ids_length} "

--- a/src/deepsparse/utils/onnx.py
+++ b/src/deepsparse/utils/onnx.py
@@ -613,7 +613,8 @@ def has_model_kv_cache(model: Union[str, ModelProto]) -> bool:
 def infer_sequence_length(model: Union[str, ModelProto]) -> int:
     """
     :param model: model
-    :return: inferred sequence length of the model
+    :return: inferred sequence length of the model.
+        If unable to infer, return 0
     """
     if not isinstance(model, ModelProto):
         model = onnx.load(model, load_external_data=False)
@@ -623,9 +624,10 @@ def infer_sequence_length(model: Union[str, ModelProto]) -> int:
     for idx, inp in enumerate(model.graph.input):
         if inp.name == "attention_mask":
             target_input_idx = idx
+            break
     try:
         # return shape of second dim if possible
         target_input = model.graph.input[target_input_idx]
         return target_input.type.tensor_type.shape.dim[1].dim_value
     except Exception:
-        return 0  # unable to infer seq len
+        return 0


### PR DESCRIPTION
Fix for: https://app.asana.com/0/1206109050183159/1206490681470513/f

The model `zoo:llama2-7b-open_platypus_orca_llama2_pretrain-pruned40_quantized` does not have the sequence length set internally in the onnx model (@alexm-nm is that something that we expect in the first place)? Because we cannot deduce this parameter, we are crashing with a very obscure message. This PR adds more verbose termination, that guides the user towards the right action (providing the sequence length manually)


