### PR TITLE
[TextGeneration] Add helper function to parse model path from args

### DIFF
--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -702,6 +702,7 @@ def text_generation_pipeline(*args, **kwargs) -> "Pipeline":
     :return: text generation pipeline with the given args and
         kwargs passed to Pipeline.create
     """
+    args, kwargs = _check_model_path_arg(*args, **kwargs)
     return Pipeline.create("text_generation", *args, **kwargs)
 
 
@@ -710,6 +711,7 @@ def code_generation_pipeline(*args, **kwargs) -> "Pipeline":
     :return: text generation pipeline with the given args and
         kwargs passed to Pipeline.create
     """
+    args, kwargs = _check_model_path_arg(*args, **kwargs)
     return Pipeline.create("code_generation", *args, **kwargs)
 
 
@@ -718,6 +720,7 @@ def chat_pipeline(*args, **kwargs) -> "Pipeline":
     :return: text generation pipeline with the given args and
         kwargs passed to Pipeline.create
     """
+    args, kwargs = _check_model_path_arg(*args, **kwargs)
     return Pipeline.create("chat", *args, **kwargs)
 
 
@@ -802,3 +805,14 @@ def zero_shot_text_classification_pipeline(*args, **kwargs) -> "Pipeline":
     is returned depends on the value of the passed model_scheme argument.
     """
     return Pipeline.create("zero_shot_text_classification", *args, **kwargs)
+
+
+def _check_model_path_arg(*args, **kwargs):
+    if args:
+        if len(args) > 1 or "model_path" in kwargs or "model" in kwargs:
+            raise ValueError(
+                "Only the model path can be provided as a non-kwarg argument"
+            )
+        kwargs["model_path"] = args[0]
+        args = args[1:]
+    return args, kwargs

--- a/src/deepsparse/pipeline.py
+++ b/src/deepsparse/pipeline.py
@@ -702,8 +702,8 @@ def text_generation_pipeline(*args, **kwargs) -> "Pipeline":
     :return: text generation pipeline with the given args and
         kwargs passed to Pipeline.create
     """
-    args, kwargs = _check_model_path_arg(*args, **kwargs)
-    return Pipeline.create("text_generation", *args, **kwargs)
+    kwargs = _check_model_path_arg(*args, **kwargs)
+    return Pipeline.create("text_generation", **kwargs)
 
 
 def code_generation_pipeline(*args, **kwargs) -> "Pipeline":
@@ -711,8 +711,8 @@ def code_generation_pipeline(*args, **kwargs) -> "Pipeline":
     :return: text generation pipeline with the given args and
         kwargs passed to Pipeline.create
     """
-    args, kwargs = _check_model_path_arg(*args, **kwargs)
-    return Pipeline.create("code_generation", *args, **kwargs)
+    kwargs = _check_model_path_arg(*args, **kwargs)
+    return Pipeline.create("code_generation", **kwargs)
 
 
 def chat_pipeline(*args, **kwargs) -> "Pipeline":
@@ -720,8 +720,8 @@ def chat_pipeline(*args, **kwargs) -> "Pipeline":
     :return: text generation pipeline with the given args and
         kwargs passed to Pipeline.create
     """
-    args, kwargs = _check_model_path_arg(*args, **kwargs)
-    return Pipeline.create("chat", *args, **kwargs)
+    kwargs = _check_model_path_arg(*args, **kwargs)
+    return Pipeline.create("chat", **kwargs)
 
 
 TextGeneration = text_generation_pipeline
@@ -814,5 +814,4 @@ def _check_model_path_arg(*args, **kwargs):
                 "Only the model path can be provided as a non-kwarg argument"
             )
         kwargs["model_path"] = args[0]
-        args = args[1:]
-    return args, kwargs
+    return kwargs

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -79,15 +79,10 @@ HOT_RELOAD_OPTION = click.option(
     ),
 )
 
-MODEL_OPTION = click.option(
-    "--model_path",
+MODEL_OPTION = click.argument(
+    "model_path",
     type=str,
     default="default",
-    help=(
-        "The path to a model.onnx file, a model folder containing the model.onnx "
-        "and supporting files, or a SparseZoo model stub. "
-        "If not specified, the default model for the task is used."
-    ),
 )
 
 BATCH_OPTION = click.option(
@@ -172,6 +167,9 @@ def main(
     num_workers: int,
     integration: str,
 ):
+    if integration == INTEGRATION_OPENAI:
+        task = "text_generation"
+
     """
     Start a DeepSparse inference server for serving the models and pipelines.
 

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -79,10 +79,15 @@ HOT_RELOAD_OPTION = click.option(
     ),
 )
 
-MODEL_OPTION = click.argument(
-    "model_path",
+MODEL_OPTION = click.option(
+    "--model_path",
     type=str,
     default="default",
+    help=(
+        "The path to a model.onnx file, a model folder containing the model.onnx "
+        "and supporting files, or a SparseZoo model stub. "
+        "If not specified, the default model for the task is used."
+    ),
 )
 
 BATCH_OPTION = click.option(
@@ -167,9 +172,6 @@ def main(
     num_workers: int,
     integration: str,
 ):
-    if integration == INTEGRATION_OPENAI:
-        task = "text_generation"
-
     """
     Start a DeepSparse inference server for serving the models and pipelines.
 


### PR DESCRIPTION
# Summary
- Add a quick helper function which supports non-kwarg for model_path when using the `TextGeneration` pathway
- For this ticket: https://app.asana.com/0/1206109050183159/1206524727025314/f

The following now works:

```python
from deepsparse import TextGeneration
model_path = "hf:mgoin/TinyStories-1M-ds"

pipe = TextGeneration(model_path)

```

This still works:

```python

model_path  = TextGeneration(model_path=model_path)
```
