### PR TITLE
[server] Add `model` argument to server cli

### DIFF
--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -79,7 +79,17 @@ HOT_RELOAD_OPTION = click.option(
     ),
 )
 
-MODEL_OPTION = click.argument("model_path", type=str, default="default")
+MODEL_ARG = click.argument("model", type=str, default=None, required=False)
+MODEL_OPTION = click.option(
+    "--model_path",
+    type=str,
+    default="default",
+    help=(
+        "The path to a model.onnx file, a model folder containing the model.onnx "
+        "and supporting files, or a SparseZoo model stub. "
+        "If not specified, the default model for the task is used."
+    ),
+)
 
 BATCH_OPTION = click.option(
     "--batch_size",
@@ -143,6 +153,7 @@ INTEGRATION_OPTION = click.option(
 @PORT_OPTION
 @LOG_LEVEL_OPTION
 @HOT_RELOAD_OPTION
+@MODEL_ARG
 @MODEL_OPTION
 @BATCH_OPTION
 @CORES_OPTION
@@ -158,6 +169,7 @@ def main(
     log_level: str,
     hot_reload_config: bool,
     model_path: str,
+    model: str,
     batch_size: int,
     num_cores: int,
     num_workers: int,
@@ -207,6 +219,13 @@ def main(
        ...
     ```
     """
+    # the server cli can take a model argument or --model_path option
+    # if the --model_path option is provided, use that
+    # otherwise if the argument is given and --model_path is not used, use the
+    # argument instead
+    if model and model_path == "default":
+        model_path = model
+
     if integration == INTEGRATION_OPENAI:
         if task is None or task != "text_generation":
             task = "text_generation"

--- a/src/deepsparse/server/cli.py
+++ b/src/deepsparse/server/cli.py
@@ -79,16 +79,7 @@ HOT_RELOAD_OPTION = click.option(
     ),
 )
 
-MODEL_OPTION = click.option(
-    "--model_path",
-    type=str,
-    default="default",
-    help=(
-        "The path to a model.onnx file, a model folder containing the model.onnx "
-        "and supporting files, or a SparseZoo model stub. "
-        "If not specified, the default model for the task is used."
-    ),
-)
+MODEL_OPTION = click.argument("model_path", type=str, default="default")
 
 BATCH_OPTION = click.option(
     "--batch_size",
@@ -216,6 +207,10 @@ def main(
        ...
     ```
     """
+    if integration == INTEGRATION_OPENAI:
+        if task is None or task != "text_generation":
+            task = "text_generation"
+
     if ctx.invoked_subcommand is not None:
         return
 
@@ -252,24 +247,6 @@ def main(
     if config_file is not None:
         server = _fetch_server(integration=integration, config=config_file)
         server.start_server(host, port, log_level, hot_reload_config=hot_reload_config)
-
-
-@main.command(
-    context_settings=dict(
-        token_normalize_func=lambda x: x.replace("-", "_"), show_default=True
-    ),
-)
-@click.argument("config-file", type=str)
-@HOST_OPTION
-@PORT_OPTION
-@LOG_LEVEL_OPTION
-@HOT_RELOAD_OPTION
-def openai(
-    config_file: str, host: str, port: int, log_level: str, hot_reload_config: bool
-):
-
-    server = OpenAIServer(server_config=config_file)
-    server.start_server(host, port, log_level, hot_reload_config=hot_reload_config)
 
 
 @main.command(


### PR DESCRIPTION
# Summary:
- With our current `click` set-up, to get the use case described in this ticket (shown below): https://app.asana.com/0/1206109050183159/1206524727025314/f 

```bash
deepsparse.server \
 "zoo:llama2-7b-ultrachat200k_llama2_pretrain-pruned50_quantized" \
 --integration openai
```

# PR Update 
This PR allows us to get the following cli command:

```bash
deepsparse.server --integration openai "hf:mgoin/TinyStories-1M-ds"
```

We can run the following commands with the current set-up:
```bash
deepsparse.server --task text_generation --model_path "hf:mgoin/TinyStories-1M-ds"
deepsparse.server --model_path "hf:mgoin/TinyStories-1M-ds" --integration openai
deepsparse.server --task text_generation "hf:mgoin/TinyStories-1M-ds"
deepsparse.server --intergration openai --task text_generation  "hf:mgoin/TinyStories-1M-ds"
deepsparse.server --config_file ~/debugging/sample_config.yaml
```

Caveats (@bfineran):
- This also does not let us run the cli command by providing the model path first (i.e will not directly follow what is shown in the ticket/UX docs; the integration or task option would have to be first)

Shoutout to @rahul-tuli  for his click knowledge and help 