### PR TITLE
[DeepSparse Evaluation API] Perplexity eval support for `openai_humaneval`, `c4`, `wikitext2`

### DIFF
--- a/src/deepsparse/evaluation/integrations/perplexity.py
+++ b/src/deepsparse/evaluation/integrations/perplexity.py
@@ -239,6 +239,7 @@ def load_perplexity_dataset(
         are provided, or if the dataset does not require a process_concatenated_datasets
         function to load the dataset.
     :param kwargs: additional keyword arguments to pass to the dataset loading function
+    :return: the dataset and whether to accumulate perplexity over samples
     """
     if isinstance(splits, list):
         raise NotImplementedError("Evaluation on multiple splits not implemented")

--- a/src/deepsparse/evaluation/integrations/perplexity.py
+++ b/src/deepsparse/evaluation/integrations/perplexity.py
@@ -249,13 +249,22 @@ def load_perplexity_dataset(
         dataset = HumanEvalIteratorWrapper(dataset)
         accumulate = False
     elif dataset_name in {"wikitext2", "c4"}:
+        # fetch max_sequence_length from pipeline if not provided
+        max_sequence_length = kwargs.pop("max_sequence_length", None)
+        if max_sequence_length is None and pipeline is not None:
+            max_sequence_length = pipeline.sequence_length
+
+        # fetch model_path from pipeline if not provided
+        model_path = kwargs.pop("model_path", None)
+        if model_path is None and pipeline is not None:
+            model_path = os.path.dirname(pipeline.model_path)
+
         dataset = process_concatenated_datasets(
             dataset_name,
-            model_path=kwargs.pop("model_path", os.path.dirname(pipeline.model_path)),
-            max_sequence_length=kwargs.pop(
-                "max_sequence_length", pipeline.sequence_length
-            ),
-            kwargs=kwargs,
+            model_path=model_path,
+            max_sequence_length=max_sequence_length,
+            split=splits,
+            **kwargs,
         )
         accumulate = True
     else:

--- a/src/deepsparse/evaluation/integrations/perplexity.py
+++ b/src/deepsparse/evaluation/integrations/perplexity.py
@@ -29,6 +29,7 @@ from deepsparse.transformers.pipelines.text_generation import TextGenerationPipe
 from deepsparse.transformers.pipelines.text_generation.pipeline_no_kv_cache import (
     TextGenerationPipelineNoCache,
 )
+from deepsparse.transformers.utils.eval_helpers import process_concatenated_datasets
 
 
 """
@@ -214,9 +215,16 @@ def load_perplexity_dataset(dataset_name: str, splits: Union[List[str], str] = "
     if dataset_name == "openai_humaneval":
         dataset = load_dataset(dataset_name, split=splits)
         accumulate = False
-        return dataset, accumulate
+    elif dataset_name == "wikitext2":
+        dataset = process_concatenated_datasets
+        accumulate = True
+    elif dataset_name == "c4":
+        dataset = process_concatenated_datasets
+        accumulate = True
     else:
         raise NotImplementedError(f"Dataset {dataset_name} not implemented")
+
+    return dataset, accumulate
 
 
 def _enumerate_progress(dataset, max_steps):

--- a/src/deepsparse/transformers/metrics.py
+++ b/src/deepsparse/transformers/metrics.py
@@ -275,6 +275,5 @@ def _cross_entropy(
         neg_log_likelihoods = neg_log_likelihoods.mean(axis=-1)
     elif reduction == "sum":
         neg_log_likelihoods = neg_log_likelihoods.sum(axis=-1)
-    print(neg_log_likelihoods)
 
     return neg_log_likelihoods

--- a/src/deepsparse/transformers/utils/eval_helpers.py
+++ b/src/deepsparse/transformers/utils/eval_helpers.py
@@ -181,3 +181,22 @@ def _split_text_by_tokens(
         )
 
     return split_text
+
+
+class HumanEvalIteratorWrapper:
+    """
+    Wrapper around the `openai_humaneval` dataset,
+    that joins the prompt and the canonical solution
+    into a single string during iteration.
+    """
+
+    def __init__(self, dataset):
+        self.iterator = iter(dataset)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # Get the next sample from the original iterator
+        sample = next(self.iterator)
+        return sample["prompt"] + sample["canonical_solution"]

--- a/src/deepsparse/transformers/utils/eval_helpers.py
+++ b/src/deepsparse/transformers/utils/eval_helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Mapping, Union
+from typing import List, Union
 
 import numpy
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
@@ -27,7 +27,8 @@ def process_concatenated_datasets(
     dataset_name: str,
     model_path: str,
     max_sequence_length: int,
-    kwargs: Mapping,
+    split: str = "test",
+    **kwargs,
 ) -> list:
     """
     Concatenate text datasets and split them into chunks text that, after
@@ -38,6 +39,8 @@ def process_concatenated_datasets(
             Options: "wikitext2" or "c4".
         model_path (str): The path to a pretrained transformer model for tokenization.
         max_sequence_length (int): The maximum number of tokens in each sequence.
+        split (str, optional): The split of the dataset to use.
+            Default is "test".
         kwargs (mapping): Additional keyword arguments.
             - eos (str, optional): The end-of-sentence token.
                 Default is "\n\n" for wikitext2 and "" for c4.
@@ -65,13 +68,13 @@ def process_concatenated_datasets(
         eos = kwargs.get("eos", "\n\n")
         bos = kwargs.get("bos", "")
 
-        raw_dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+        raw_dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split=split)
         raw_text = raw_dataset["text"]
     elif dataset_name == "c4":
         eos = kwargs.get("eos", "<|endoftext|>")
         bos = kwargs.get("bos", "")
         raw_samples = kwargs.get("raw_samples", None)
-        data_file = kwargs.get("data_file", 0)
+        data_file = kwargs.get("data_file", None)
         if data_file is not None:
             raw_dataset = load_dataset(
                 "allenai/c4",
@@ -79,13 +82,13 @@ def process_concatenated_datasets(
                 data_files={
                     "validation": f"en/c4-validation.{data_file:05d}-of-00008.json.gz"
                 },
-                split="validation",
+                split=split,
             )
         else:
             raw_dataset = load_dataset(
                 "allenai/c4",
                 "allenai--c4",
-                split="validation",
+                split=split,
             )
         if raw_samples is not None:
             raw_dataset = raw_dataset[:raw_samples]

--- a/tests/deepsparse/evaluation/integrations/test_perplexity.py
+++ b/tests/deepsparse/evaluation/integrations/test_perplexity.py
@@ -37,9 +37,8 @@ def model_id():
     "datasets",
     [
         "openai_humaneval",
-        # TODO: add more datasets
-        # "c4",
-        # "wikitext2",
+        "c4",
+        "wikitext2",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Example use

```bash
deepsparse.evaluate hf:mgoin/TinyStories-1M-deepsparse --integration perplexity --dataset wikitext2 --limit 2 --batch_size 2 --max_sequence_length 128

2024-02-06 18:14:27 deepsparse.evaluation.cli INFO     Creating deepsparse pipeline to evaluate from model path: hf:mgoin/TinyStories-1M-deepsparse
2024-02-06 18:14:27 deepsparse.evaluation.cli INFO     Datasets to evaluate on: ['wikitext2']
Batch size: 2
Splits to evaluate on: None
Metrics to evaluate on: None
Additional integration arguments supplied: {'limit': 2, 'max_sequence_length': 128}
Fetching 11 files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 149796.57it/s]
DeepSparse, Copyright 2021-present / Neuralmagic, Inc. version: 1.7.0.20240104 COMMUNITY | (86c38139) (release) (optimized) (system=avx2, binary=avx2)
2024-02-06 18:14:30 deepsparse.evaluation.integrations.perplexity INFO     Argument `splits` is None. Defaulting to `test` split.
Token indices sequence length is longer than the specified maximum sequence length for this model (287645 > 2048). Running this sequence through the model will result in indexing errors
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:02<00:00,  1.51it/s]
2024-02-06 18:14:38 deepsparse.evaluation.cli INFO     Evaluation done. Results:
[Evaluation(task='perplexity', dataset=Dataset(type=None, name='wikitext2', config=None, split='test'), metrics=[Metric(name='perplexity', value=24642.261152241255)], samples=None)]
2024-02-06 18:14:38 deepsparse.evaluation.cli INFO     Saving the evaluation results to /nm/drive0/damian/deepsparse/result.json
```