### PR TITLE
add top level benchmark imports

### DIFF
--- a/src/deepsparse/__init__.py
+++ b/src/deepsparse/__init__.py
@@ -40,5 +40,6 @@ from .analytics import deepsparse_analytics as _analytics
 from .subgraph_execute import *
 from .analyze import analyze
 from .evaluation.evaluator import evaluate
+from .benchmark import benchmark_model, benchmark_pipeline
 
 _analytics.send_event("python__init")


### PR DESCRIPTION
adds support for:

```python
from deepsparse import benchmark_model, benchmark_pipeline
```