### PR TITLE
[cherry-pick] make sure benchmark_* imports are the functions, not modules (#1593)

### DIFF
--- a/src/deepsparse/__init__.py
+++ b/src/deepsparse/__init__.py
@@ -40,6 +40,7 @@ from .analytics import deepsparse_analytics as _analytics
 from .subgraph_execute import *
 from .analyze import analyze
 from .evaluation.evaluator import evaluate
-from .benchmark import benchmark_model, benchmark_pipeline
+from .benchmark.benchmark_model import benchmark_model
+from .benchmark.benchmark_pipeline import benchmark_pipeline
 
 _analytics.send_event("python__init")


### PR DESCRIPTION
makes sure that top level benchmark_* imports are the functions, not modules (ie file names)

```python
>>> from deepsparse import benchmark_model, benchmark_pipeline
>>> benchmark_model
<function benchmark_model at 0x7f4b5434faf0>
>>> benchmark_pipeline
<function benchmark_pipeline at 0x7f4b6b368430>
```