### PR TITLE
[benchmark_pipeline] Update the export dict to remove the middleware key

### DIFF
--- a/src/deepsparse/benchmark/benchmark_pipeline.py
+++ b/src/deepsparse/benchmark/benchmark_pipeline.py
@@ -346,6 +346,11 @@ def benchmark_pipeline(
             "Generated no batch timings, try extending benchmark time with '--time'"
         )
 
+    if SupportedTasks.is_text_generation(task) or SupportedTasks.is_code_generation(
+        task
+    ):
+        kwargs.pop("middleware_manager")
+
     return batch_times, total_run_time, num_streams
 
 


### PR DESCRIPTION
- Middleware is a pipeline_kwarg required in the `benchmark_pipeline` 
- When an optional export_path is provided, all pipeline_kwargs are saved in a json file 
-  This fails for the middleware manager, which cannot be saved as a json
- For this ticket: https://app.asana.com/0/1206109050183159/1206622145453069/f