### PR TITLE
[bug] Use datasets as expected by docs

### DIFF
--- a/src/deepsparse/evaluation/cli.py
+++ b/src/deepsparse/evaluation/cli.py
@@ -23,7 +23,7 @@ OPTIONS:
     MODEL_PATH
                         A path to an ONNX model, local directory containing ONNX model
                         (including all the auxiliary files) or a SparseZoo stub
-    -d DATASET, --dataset DATASET
+    -d DATASETS, --datasets DATASETS
                         The dataset to evaluate on. The user may pass multiple datasets
                         by passing the option multiple times.
     -i INTEGRATION, --integration INTEGRATION
@@ -95,7 +95,7 @@ _LOGGER = logging.getLogger(__name__)
 )
 @click.option(
     "-d",
-    "--dataset",
+    "--datasets",
     type=str,
     multiple=True,
     help="The name of dataset to evaluate on. The user may pass multiple "
@@ -163,7 +163,7 @@ _LOGGER = logging.getLogger(__name__)
 @click.argument("integration_args", nargs=-1, type=click.UNPROCESSED)
 def main(
     model_path,
-    dataset,
+    datasets,
     integration,
     engine_type,
     save_path,
@@ -182,7 +182,7 @@ def main(
 
     """
     # join datasets to a list if multiple datasets are passed
-    datasets = list(dataset) if not isinstance(dataset, str) else dataset
+    datasets = list(datasets) if not isinstance(datasets, str) else datasets
     # format kwargs to a  dict
     integration_args = parse_kwarg_tuples(integration_args)
 


### PR DESCRIPTION
The eval docs pass in `datasets` whereas cli script was expecting `dataset`
Updated cli to accept `datasets` which also conforms with `sparseml.evaluate`
<img width="943" alt="Screenshot 2024-02-23 at 4 43 21 PM" src="https://github.com/neuralmagic/deepsparse/assets/25380596/ae16e7f7-3c14-4b33-907b-d9c43177088d">

