### PR TITLE
[TextGeneration] Fix llama tokenizer

### DIFF
--- a/src/deepsparse/transformers/pipelines/text_generation/prep_for_generation.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/prep_for_generation.py
@@ -101,6 +101,7 @@ class PrepareGeneration(Operator):
             else [],
             "finished_reason": [],
             "token_generator": token_generator,
+            "past_tokens_queue": copy.copy(tokens),
         }
 
         if kv_cache is None:

--- a/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
@@ -97,7 +97,7 @@ class ProcessOutputs(Operator):
         if isinstance(
             self.tokenizer,
             (transformers.LlamaTokenizer, transformers.LlamaTokenizerFast),
-        ):
+        ) and inference_state.current_state.get("streaming"):
             past_tokens_queue = inference_state.current_state.get("past_tokens_queue")
             sequences = self._generate_streamed_text_from_past_tokens(
                 generated_tokens, past_tokens_queue

--- a/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
@@ -94,6 +94,9 @@ class ProcessOutputs(Operator):
 
         import transformers
 
+        # Fix for LLAMA-specific models when running streaming
+        # TODO: make streaming a conditional input to this operator. using inference
+        # state is a quick fix.
         if isinstance(
             self.tokenizer,
             (transformers.LlamaTokenizer, transformers.LlamaTokenizerFast),

--- a/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
+++ b/src/deepsparse/transformers/pipelines/text_generation/process_outputs.py
@@ -79,7 +79,7 @@ class ProcessOutputs(Operator):
             past_tokens_queue, skip_special_tokens=True
         )
         past_tokens_queue.pop(0)
-        return string_from_n_plus_1_tokens[len(string_from_n_tokens) :]
+        return [string_from_n_plus_1_tokens[len(string_from_n_tokens) :]]
 
     def run(
         self,
@@ -93,7 +93,11 @@ class ProcessOutputs(Operator):
         generated_logits = generated_logits if generation_config.output_scores else None
 
         import transformers
-        if isinstance(self.tokenizer, (transformers.LlamaTokenizer, transformers.LlamaTokenizerFast)):
+
+        if isinstance(
+            self.tokenizer,
+            (transformers.LlamaTokenizer, transformers.LlamaTokenizerFast),
+        ):
             past_tokens_queue = inference_state.current_state.get("past_tokens_queue")
             sequences = self._generate_streamed_text_from_past_tokens(
                 generated_tokens, past_tokens_queue


### PR DESCRIPTION
Tested code:

```python

import deepsparse

MODEL_ID = "hf:nm-testing/llama2-7B-sparse70-retrained-ultrachat200k-pruned70-smoothquant-ds"
#MODEL_ID = "zoo:mistral-7b-ultrachat200k_mistral_pretrain-pruned40_quantized"

pipe = deepsparse.Pipeline.create(
    task="text-generation",
    model_path=MODEL_ID,
    sequence_length=512,
    prompt_sequence_length=16,
)

message = "Once upon a time"

conversation = []
conversation.append({"role": "user", "content": message})
formatted_conversation = pipe.tokenizer.apply_chat_template(
    conversation, tokenize=False, add_generation_prompt=True
)

generation_config = {
    "max_new_tokens": 100,
}

inference = pipe(
    sequences=formatted_conversation,
    generation_config=generation_config,
    streaming=True,
)

for token in inference:
    print(token.generations[0].text, end="")


```

Output:

```

There was a time when the world was a different place. A time when people were more accepting of each other and didn't judge based on race, religion, or gender. A time when kindness and compassion were the norm, and hate and prejudice were unheard of.

But then something changed. The world became more divided, and people started to see each other through a

```