### PR TITLE
Add more detail to yolo bounding boxes documentation

### DIFF
--- a/src/deepsparse/yolo/schemas.py
+++ b/src/deepsparse/yolo/schemas.py
@@ -101,7 +101,7 @@ class YOLOOutput(BaseModel):
     """
 
     boxes: List[List[List[float]]] = Field(
-        description="List of bounding boxes, one for each prediction"
+        description="List of bounding boxes, one for each prediction, in XYXY format (left, top, right, bottom). Units are pixels."
     )
     scores: List[List[float]] = Field(
         description="List of scores, one for each prediction"


### PR DESCRIPTION
Expands the description to include info about the format and units.

Closes #1663 